### PR TITLE
Do a partial clone and sparse checkout of linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+/gen/linux

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "gen/linux"]
-	path = gen/linux
-	url = git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git

--- a/gen/modules/general.h
+++ b/gen/modules/general.h
@@ -93,7 +93,7 @@ typedef __UINT32_TYPE__ socklen_t;
 #include <asm/statfs.h>
 
 // Linux only defines this as a macro; make it available as a typedef.
-// And use the libc name. And mips and s930x are special.
+// And use the libc name. And mips and s390x are special.
 #if defined(__mips__) || defined(__s390x__)
 typedef __u32 __fsword_t;
 #elif defined(__mips64__)

--- a/gen/src/main.rs
+++ b/gen/src/main.rs
@@ -232,6 +232,21 @@ fn main() {
 }
 
 fn git_checkout(rev: &str) {
+    // Clone the linux kernel source repo if necessary. Ignore exit code as it will be non-zero in
+    // case it was already cloned.
+    // Use a treeless partial clone to save disk space and clone time.
+    // See https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/ for
+    // more info on partial clones.
+    // Note: this is not using the official repo
+    // git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git but the github fork as the
+    // server of the official repo doesn't recognize filtering.
+    Command::new("git")
+        .arg("clone")
+        .arg("https://github.com/torvalds/linux.git")
+        .arg("--filter=tree:0")
+        .status()
+        .unwrap();
+
     // Delete any generated files from previous versions.
     assert!(Command::new("git")
         .arg("clean")

--- a/gen/src/main.rs
+++ b/gen/src/main.rs
@@ -290,19 +290,11 @@ fn git_checkout(rev: &str) {
         .unwrap()
         .success());
 
-    // Restore any deleted files.
-    assert!(Command::new("git")
-        .arg("restore")
-        .arg(".")
-        .current_dir("linux")
-        .status()
-        .unwrap()
-        .success());
-
     // Check out the given revision.
     assert!(Command::new("git")
         .arg("checkout")
         .arg(rev)
+        .arg("-f")
         .current_dir("linux")
         .status()
         .unwrap()


### PR DESCRIPTION
Combined this reduces the size of the git dir from several GB to less than 800 MB,

Also fixed a typo.

Locally this works fine, but on the CI I setup on my own fork the sparse checkout fails at `git reset .`: https://github.com/bjorn3/linux-raw-sys/runs/3390088361?check_suite_focus=true I think the `git reset .` is never necessary when `git checkout -f` is used immediately afterwards, so can I remove it? Or should I skip the sparse checkout commit for now?