### PR TITLE
#![no_std] support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
         cargo check --features v5_11
         cargo check --features "v3_2 netlink"
         cargo check --no-default-features --features "v5_11 netlink"
+        cargo check --features libc
 
   gen:
     name: Update generated files

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         cargo check --features v5_11
         cargo check --features "v3_2 netlink"
         cargo check --no-default-features --features "v5_11 netlink"
-        cargo check --features libc
+        cargo check --features no_std
 
   gen:
     name: Update generated files

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ exclude = ["gen"]
 all-features = true
 targets = ["x86_64-unknown-linux-gnu", "i686-unknown-linux-gnu"]
 
+[dependencies]
+libc = { version = "0.2.98", optional = true }
+
 # The rest of this file is auto-generated!
 [features]
 v2_6_32 = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ all-features = true
 targets = ["x86_64-unknown-linux-gnu", "i686-unknown-linux-gnu"]
 
 [dependencies]
-libc = { version = "0.2.98", optional = true }
+cty = { version = "0.2.1", optional = true }
 
 # The rest of this file is auto-generated!
 [features]
@@ -32,3 +32,4 @@ v4_20 = []
 v5_4 = []
 v5_11 = []
 default = ["general", "errno"]
+no_std = ['cty']

--- a/gen/src/main.rs
+++ b/gen/src/main.rs
@@ -240,6 +240,7 @@ fn main() {
     }
 
     writeln!(cargo_toml, "default = [{}]", DEFAULT_FEATURES).unwrap();
+    writeln!(cargo_toml, "no_std = ['cty']").unwrap();
 
     // Reset the `linux` directory back to the original branch.
     git_checkout(LINUX_VERSIONS[0]);

--- a/gen/src/main.rs
+++ b/gen/src/main.rs
@@ -392,6 +392,8 @@ fn run_bindgen(
         .blocklist_item("NULL");
 
     let bindings = builder
+        .use_core()
+        .ctypes_prefix("crate::ctypes")
         .header(header_name)
         .generate()
         .expect(&format!("generate bindings for {}", mod_name));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,13 @@
 #![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]
+#![no_std]
+
+#[cfg(not(feature = "libc"))]
+extern crate std;
+#[cfg(not(feature = "libc"))]
+use std::os::raw as ctypes;
+
+#[cfg(feature = "libc")]
+use libc as ctypes;
 
 // The rest of this file is auto-generated!
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "powerpc"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,9 @@
 #![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]
 
 // The rest of this file is auto-generated!
-#[cfg(target_arch = "x86")]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "powerpc"))]
 pub mod v2_6_32;
-#[cfg(target_arch = "x86_64")]
-pub mod v2_6_32;
-#[cfg(target_arch = "powerpc")]
-pub mod v2_6_32;
-#[cfg(target_arch = "x86")]
-pub use v2_6_32::*;
-#[cfg(target_arch = "x86_64")]
-pub use v2_6_32::*;
-#[cfg(target_arch = "powerpc")]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "powerpc"))]
 pub use v2_6_32::*;
 #[cfg(target_arch = "arm")]
 pub mod v3_2;
@@ -25,13 +17,9 @@ pub use v3_10::*;
 pub mod v4_2;
 #[cfg(target_arch = "aarch64")]
 pub use v4_2::*;
-#[cfg(target_arch = "mips")]
+#[cfg(any(target_arch = "mips", target_arch = "mips64"))]
 pub mod v4_4;
-#[cfg(target_arch = "mips64")]
-pub mod v4_4;
-#[cfg(target_arch = "mips")]
-pub use v4_4::*;
-#[cfg(target_arch = "mips64")]
+#[cfg(any(target_arch = "mips", target_arch = "mips64"))]
 pub use v4_4::*;
 #[cfg(target_arch = "riscv64")]
 pub mod v4_20;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,13 @@
 #![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]
 #![no_std]
 
-#[cfg(not(feature = "libc"))]
+#[cfg(not(feature = "no_std"))]
 extern crate std;
-#[cfg(not(feature = "libc"))]
+#[cfg(not(feature = "no_std"))]
 use std::os::raw as ctypes;
 
-#[cfg(feature = "libc")]
-use libc as ctypes;
+#[cfg(feature = "no_std")]
+use cty as ctypes;
 
 // The rest of this file is auto-generated!
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "powerpc"))]

--- a/src/v2_6_32/powerpc/general.rs
+++ b/src/v2_6_32/powerpc/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,61 +18,61 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
 #[repr(C)]
-pub struct __BindgenUnionField<T>(::std::marker::PhantomData<T>);
+pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
 impl<T> __BindgenUnionField<T> {
 #[inline]
 pub const fn new() -> Self {
-__BindgenUnionField(::std::marker::PhantomData)
+__BindgenUnionField(::core::marker::PhantomData)
 }
 #[inline]
 pub unsafe fn as_ref(&self) -> &T {
-::std::mem::transmute(self)
+::core::mem::transmute(self)
 }
 #[inline]
 pub unsafe fn as_mut(&mut self) -> &mut T {
-::std::mem::transmute(self)
+::core::mem::transmute(self)
 }
 }
-impl<T> ::std::default::Default for __BindgenUnionField<T> {
+impl<T> ::core::default::Default for __BindgenUnionField<T> {
 #[inline]
 fn default() -> Self {
 Self::new()
 }
 }
-impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
+impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
 #[inline]
 fn clone(&self) -> Self {
 Self::new()
 }
 }
-impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
+impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__BindgenUnionField")
 }
 }
-impl<T> ::std::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::std::hash::Hasher>(&self, _state: &mut H) {}
+impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
+fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
 }
-impl<T> ::std::cmp::PartialEq for __BindgenUnionField<T> {
+impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
 fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
 true
 }
 }
-impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
+impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 pub const LINUX_VERSION_CODE: u32 = 132640;
 pub const O_DIRECTORY: u32 = 16384;
 pub const O_NOFOLLOW: u32 = 32768;
@@ -1577,17 +1577,17 @@ pub const TFD_NONBLOCK: u32 = 2048;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
-pub type umode_t = ::std::os::raw::c_ushort;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
+pub type umode_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Copy, Clone)]
@@ -1597,41 +1597,41 @@ pub u: [__u32; 4usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_ino_t = ::std::os::raw::c_ulong;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_off_t = ::std::os::raw::c_long;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_long;
-pub type __kernel_time_t = ::std::os::raw::c_long;
-pub type __kernel_clock_t = ::std::os::raw::c_long;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_suseconds_t = ::std::os::raw::c_long;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
-pub type __kernel_old_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_old_gid_t = ::std::os::raw::c_uint;
-pub type __kernel_nlink_t = ::std::os::raw::c_ushort;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_short;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_ino_t = crate::ctypes::c_ulong;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_off_t = crate::ctypes::c_long;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_long;
+pub type __kernel_time_t = crate::ctypes::c_long;
+pub type __kernel_clock_t = crate::ctypes::c_long;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_suseconds_t = crate::ctypes::c_long;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
+pub type __kernel_old_uid_t = crate::ctypes::c_uint;
+pub type __kernel_old_gid_t = crate::ctypes::c_uint;
+pub type __kernel_nlink_t = crate::ctypes::c_ushort;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_short;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __le16 = __u16;
 pub type __be16 = __u16;
@@ -1644,14 +1644,14 @@ pub type __wsum = __u32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -1659,8 +1659,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -1674,16 +1674,16 @@ pub data: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_int,
-pub nr_free_files: ::std::os::raw::c_int,
-pub max_files: ::std::os::raw::c_int,
+pub nr_files: crate::ctypes::c_int,
+pub nr_free_files: crate::ctypes::c_int,
+pub max_files: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_int,
-pub nr_unused: ::std::os::raw::c_int,
-pub dummy: [::std::os::raw::c_int; 5usize],
+pub nr_inodes: crate::ctypes::c_int,
+pub nr_unused: crate::ctypes::c_int,
+pub dummy: [crate::ctypes::c_int; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1694,15 +1694,15 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
 #[repr(C)]
 #[repr(align(4))]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
-pub ss_family: ::std::os::raw::c_ushort,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub ss_family: crate::ctypes::c_ushort,
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -1769,7 +1769,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1812,7 +1812,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -1822,7 +1822,7 @@ pub struct sockaddr_in {
 pub sin_family: u16,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -1839,7 +1839,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -1849,7 +1849,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -1876,22 +1876,22 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1902,8 +1902,8 @@ pub tv_usec: __kernel_suseconds_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1927,53 +1927,53 @@ _unused: [u8; 0],
 pub struct rusage {
 pub ru_utime: timeval,
 pub ru_stime: timeval,
-pub ru_maxrss: ::std::os::raw::c_long,
-pub ru_ixrss: ::std::os::raw::c_long,
-pub ru_idrss: ::std::os::raw::c_long,
-pub ru_isrss: ::std::os::raw::c_long,
-pub ru_minflt: ::std::os::raw::c_long,
-pub ru_majflt: ::std::os::raw::c_long,
-pub ru_nswap: ::std::os::raw::c_long,
-pub ru_inblock: ::std::os::raw::c_long,
-pub ru_oublock: ::std::os::raw::c_long,
-pub ru_msgsnd: ::std::os::raw::c_long,
-pub ru_msgrcv: ::std::os::raw::c_long,
-pub ru_nsignals: ::std::os::raw::c_long,
-pub ru_nvcsw: ::std::os::raw::c_long,
-pub ru_nivcsw: ::std::os::raw::c_long,
+pub ru_maxrss: crate::ctypes::c_long,
+pub ru_ixrss: crate::ctypes::c_long,
+pub ru_idrss: crate::ctypes::c_long,
+pub ru_isrss: crate::ctypes::c_long,
+pub ru_minflt: crate::ctypes::c_long,
+pub ru_majflt: crate::ctypes::c_long,
+pub ru_nswap: crate::ctypes::c_long,
+pub ru_inblock: crate::ctypes::c_long,
+pub ru_oublock: crate::ctypes::c_long,
+pub ru_msgsnd: crate::ctypes::c_long,
+pub ru_msgrcv: crate::ctypes::c_long,
+pub ru_nsignals: crate::ctypes::c_long,
+pub ru_nvcsw: crate::ctypes::c_long,
+pub ru_nivcsw: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rlimit {
-pub rlim_cur: ::std::os::raw::c_ulong,
-pub rlim_max: ::std::os::raw::c_ulong,
+pub rlim_cur: crate::ctypes::c_ulong,
+pub rlim_max: crate::ctypes::c_ulong,
 }
 extern "C" {
-pub fn getrusage(p: *mut task_struct, who: ::std::os::raw::c_int, ru: *mut rusage) -> ::std::os::raw::c_int;
+pub fn getrusage(p: *mut task_struct, who: crate::ctypes::c_int, ru: *mut rusage) -> crate::ctypes::c_int;
 }
-pub type old_sigset_t = ::std::os::raw::c_ulong;
+pub type old_sigset_t = crate::ctypes::c_ulong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigset_t {
-pub sig: [::std::os::raw::c_ulong; 2usize],
+pub sig: [crate::ctypes::c_ulong; 2usize],
 }
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct old_sigaction {
 pub sa_handler: __sighandler_t,
 pub sa_mask: old_sigset_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaction {
 pub sa_handler: __sighandler_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: sigset_t,
 }
@@ -1985,34 +1985,34 @@ pub sa: sigaction,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sig_dbg_op {
-pub dbg_type: ::std::os::raw::c_int,
-pub dbg_value: ::std::os::raw::c_ulong,
+pub dbg_type: crate::ctypes::c_int,
+pub dbg_value: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
 pub struct siginfo {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: siginfo__bindgen_ty_1,
 }
 #[repr(C)]
 pub struct siginfo__bindgen_ty_1 {
-pub _pad: __BindgenUnionField<[::std::os::raw::c_int; 29usize]>,
+pub _pad: __BindgenUnionField<[crate::ctypes::c_int; 29usize]>,
 pub _kill: __BindgenUnionField<siginfo__bindgen_ty_1__bindgen_ty_1>,
 pub _timer: __BindgenUnionField<siginfo__bindgen_ty_1__bindgen_ty_2>,
 pub _rt: __BindgenUnionField<siginfo__bindgen_ty_1__bindgen_ty_3>,
@@ -2030,10 +2030,10 @@ pub _uid: __kernel_uid32_t,
 #[repr(C)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
-pub _pad: __IncompleteArrayField<::std::os::raw::c_char>,
+pub _overrun: crate::ctypes::c_int,
+pub _pad: __IncompleteArrayField<crate::ctypes::c_char>,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2047,48 +2047,48 @@ pub _sigval: sigval_t,
 pub struct siginfo__bindgen_ty_1__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr: *mut crate::ctypes::c_void,
+pub _addr_lsb: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 pub type siginfo_t = siginfo;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 13usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 13usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2116,49 +2116,49 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sgttyb {
-pub sg_ispeed: ::std::os::raw::c_char,
-pub sg_ospeed: ::std::os::raw::c_char,
-pub sg_erase: ::std::os::raw::c_char,
-pub sg_kill: ::std::os::raw::c_char,
-pub sg_flags: ::std::os::raw::c_short,
+pub sg_ispeed: crate::ctypes::c_char,
+pub sg_ospeed: crate::ctypes::c_char,
+pub sg_erase: crate::ctypes::c_char,
+pub sg_kill: crate::ctypes::c_char,
+pub sg_flags: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tchars {
-pub t_intrc: ::std::os::raw::c_char,
-pub t_quitc: ::std::os::raw::c_char,
-pub t_startc: ::std::os::raw::c_char,
-pub t_stopc: ::std::os::raw::c_char,
-pub t_eofc: ::std::os::raw::c_char,
-pub t_brkc: ::std::os::raw::c_char,
+pub t_intrc: crate::ctypes::c_char,
+pub t_quitc: crate::ctypes::c_char,
+pub t_startc: crate::ctypes::c_char,
+pub t_stopc: crate::ctypes::c_char,
+pub t_eofc: crate::ctypes::c_char,
+pub t_brkc: crate::ctypes::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ltchars {
-pub t_suspc: ::std::os::raw::c_char,
-pub t_dsuspc: ::std::os::raw::c_char,
-pub t_rprntc: ::std::os::raw::c_char,
-pub t_flushc: ::std::os::raw::c_char,
-pub t_werasc: ::std::os::raw::c_char,
-pub t_lnextc: ::std::os::raw::c_char,
+pub t_suspc: crate::ctypes::c_char,
+pub t_dsuspc: crate::ctypes::c_char,
+pub t_rprntc: crate::ctypes::c_char,
+pub t_flushc: crate::ctypes::c_char,
+pub t_werasc: crate::ctypes::c_char,
+pub t_lnextc: crate::ctypes::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 10usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 10usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2171,14 +2171,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: u16,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2186,82 +2186,82 @@ pub struct sockaddr {
 pub __storage: __kernel_sockaddr_storage,
 }
 pub type __kernel_sa_family_t = u16;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulonglong,
-pub d_off: ::std::os::raw::c_longlong,
+pub d_ino: crate::ctypes::c_ulonglong,
+pub d_off: crate::ctypes::c_longlong,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __old_kernel_stat {
-pub st_dev: ::std::os::raw::c_ushort,
-pub st_ino: ::std::os::raw::c_ushort,
-pub st_mode: ::std::os::raw::c_ushort,
-pub st_nlink: ::std::os::raw::c_ushort,
-pub st_uid: ::std::os::raw::c_ushort,
-pub st_gid: ::std::os::raw::c_ushort,
-pub st_rdev: ::std::os::raw::c_ushort,
-pub st_size: ::std::os::raw::c_ulong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
+pub st_dev: crate::ctypes::c_ushort,
+pub st_ino: crate::ctypes::c_ushort,
+pub st_mode: crate::ctypes::c_ushort,
+pub st_nlink: crate::ctypes::c_ushort,
+pub st_uid: crate::ctypes::c_ushort,
+pub st_gid: crate::ctypes::c_ushort,
+pub st_rdev: crate::ctypes::c_ushort,
+pub st_size: crate::ctypes::c_ulong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ulong,
+pub st_dev: crate::ctypes::c_ulong,
 pub st_ino: __kernel_ino_t,
 pub st_mode: __kernel_mode_t,
 pub st_nlink: __kernel_nlink_t,
 pub st_uid: __kernel_uid_t,
 pub st_gid: __kernel_gid_t,
-pub st_rdev: ::std::os::raw::c_ulong,
+pub st_rdev: crate::ctypes::c_ulong,
 pub st_size: __kernel_off_t,
-pub st_blksize: ::std::os::raw::c_ulong,
-pub st_blocks: ::std::os::raw::c_ulong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub __unused4: ::std::os::raw::c_ulong,
-pub __unused5: ::std::os::raw::c_ulong,
+pub st_blksize: crate::ctypes::c_ulong,
+pub st_blocks: crate::ctypes::c_ulong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub __unused4: crate::ctypes::c_ulong,
+pub __unused5: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat64 {
-pub st_dev: ::std::os::raw::c_ulonglong,
-pub st_ino: ::std::os::raw::c_ulonglong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_nlink: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub st_rdev: ::std::os::raw::c_ulonglong,
-pub __pad2: ::std::os::raw::c_ushort,
-pub st_size: ::std::os::raw::c_longlong,
-pub st_blksize: ::std::os::raw::c_int,
-pub st_blocks: ::std::os::raw::c_longlong,
-pub st_atime: ::std::os::raw::c_int,
-pub st_atime_nsec: ::std::os::raw::c_uint,
-pub st_mtime: ::std::os::raw::c_int,
-pub st_mtime_nsec: ::std::os::raw::c_uint,
-pub st_ctime: ::std::os::raw::c_int,
-pub st_ctime_nsec: ::std::os::raw::c_uint,
-pub __unused4: ::std::os::raw::c_uint,
-pub __unused5: ::std::os::raw::c_uint,
+pub st_dev: crate::ctypes::c_ulonglong,
+pub st_ino: crate::ctypes::c_ulonglong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_nlink: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub st_rdev: crate::ctypes::c_ulonglong,
+pub __pad2: crate::ctypes::c_ushort,
+pub st_size: crate::ctypes::c_longlong,
+pub st_blksize: crate::ctypes::c_int,
+pub st_blocks: crate::ctypes::c_longlong,
+pub st_atime: crate::ctypes::c_int,
+pub st_atime_nsec: crate::ctypes::c_uint,
+pub st_mtime: crate::ctypes::c_int,
+pub st_mtime_nsec: crate::ctypes::c_uint,
+pub st_ctime: crate::ctypes::c_int,
+pub st_ctime_nsec: crate::ctypes::c_uint,
+pub __unused4: crate::ctypes::c_uint,
+pub __unused5: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v2_6_32/powerpc/netlink.rs
+++ b/src/v2_6_32/powerpc/netlink.rs
@@ -118,24 +118,24 @@ pub const RTMGRP_DECnet_ROUTE: u32 = 16384;
 pub const RTMGRP_IPV6_PREFIX: u32 = 131072;
 pub const TCA_ACT_TAB: u32 = 1;
 pub const TCAA_MAX: u32 = 1;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
 #[repr(C)]
 #[repr(align(4))]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
-pub ss_family: ::std::os::raw::c_ushort,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub ss_family: crate::ctypes::c_ushort,
+pub __data: [crate::ctypes::c_char; 126usize],
 }
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
-pub type umode_t = ::std::os::raw::c_ushort;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
+pub type umode_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Copy, Clone)]
@@ -145,41 +145,41 @@ pub u: [__u32; 4usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_ino_t = ::std::os::raw::c_ulong;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_off_t = ::std::os::raw::c_long;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_long;
-pub type __kernel_time_t = ::std::os::raw::c_long;
-pub type __kernel_clock_t = ::std::os::raw::c_long;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_suseconds_t = ::std::os::raw::c_long;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
-pub type __kernel_old_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_old_gid_t = ::std::os::raw::c_uint;
-pub type __kernel_nlink_t = ::std::os::raw::c_ushort;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_short;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_ino_t = crate::ctypes::c_ulong;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_off_t = crate::ctypes::c_long;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_long;
+pub type __kernel_time_t = crate::ctypes::c_long;
+pub type __kernel_clock_t = crate::ctypes::c_long;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_suseconds_t = crate::ctypes::c_long;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
+pub type __kernel_old_uid_t = crate::ctypes::c_uint;
+pub type __kernel_old_gid_t = crate::ctypes::c_uint;
+pub type __kernel_nlink_t = crate::ctypes::c_ushort;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_short;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __le16 = __u16;
 pub type __be16 = __u16;
@@ -198,7 +198,7 @@ _unused: [u8; 0],
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: u16,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -214,7 +214,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 #[repr(C)]
@@ -672,21 +672,21 @@ __RTM_MAX = 80,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_12 = _bindgen_ty_12::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_12 = _bindgen_ty_12::RTN_UNICAST;
@@ -765,10 +765,10 @@ __RTA_MAX = 16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -848,29 +848,29 @@ pub ident: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_14 = _bindgen_ty_14::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_14 = _bindgen_ty_14::PREFIX_ADDRESS;
@@ -894,10 +894,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -930,14 +930,14 @@ __TCA_MAX = 9,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_16 = _bindgen_ty_16::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_16 = _bindgen_ty_16::NDUSEROPT_SRCADDR;
@@ -982,7 +982,7 @@ __RTNLGRP_MAX = 23,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }

--- a/src/v2_6_32/x86/general.rs
+++ b/src/v2_6_32/x86/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,61 +18,61 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
 #[repr(C)]
-pub struct __BindgenUnionField<T>(::std::marker::PhantomData<T>);
+pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
 impl<T> __BindgenUnionField<T> {
 #[inline]
 pub const fn new() -> Self {
-__BindgenUnionField(::std::marker::PhantomData)
+__BindgenUnionField(::core::marker::PhantomData)
 }
 #[inline]
 pub unsafe fn as_ref(&self) -> &T {
-::std::mem::transmute(self)
+::core::mem::transmute(self)
 }
 #[inline]
 pub unsafe fn as_mut(&mut self) -> &mut T {
-::std::mem::transmute(self)
+::core::mem::transmute(self)
 }
 }
-impl<T> ::std::default::Default for __BindgenUnionField<T> {
+impl<T> ::core::default::Default for __BindgenUnionField<T> {
 #[inline]
 fn default() -> Self {
 Self::new()
 }
 }
-impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
+impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
 #[inline]
 fn clone(&self) -> Self {
 Self::new()
 }
 }
-impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
+impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__BindgenUnionField")
 }
 }
-impl<T> ::std::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::std::hash::Hasher>(&self, _state: &mut H) {}
+impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
+fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
 }
-impl<T> ::std::cmp::PartialEq for __BindgenUnionField<T> {
+impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
 fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
 true
 }
 }
-impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
+impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 pub const LINUX_VERSION_CODE: u32 = 132640;
 pub const __BITS_PER_LONG: u32 = 32;
 pub const __FD_SETSIZE: u32 = 1024;
@@ -1602,55 +1602,55 @@ pub const TFD_NONBLOCK: u32 = 2048;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
-pub type umode_t = ::std::os::raw::c_ushort;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
+pub type umode_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_ino_t = ::std::os::raw::c_ulong;
-pub type __kernel_mode_t = ::std::os::raw::c_ushort;
-pub type __kernel_nlink_t = ::std::os::raw::c_ushort;
-pub type __kernel_off_t = ::std::os::raw::c_long;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_ushort;
-pub type __kernel_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_int;
-pub type __kernel_time_t = ::std::os::raw::c_long;
-pub type __kernel_suseconds_t = ::std::os::raw::c_long;
-pub type __kernel_clock_t = ::std::os::raw::c_long;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
-pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ushort;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_ino_t = crate::ctypes::c_ulong;
+pub type __kernel_mode_t = crate::ctypes::c_ushort;
+pub type __kernel_nlink_t = crate::ctypes::c_ushort;
+pub type __kernel_off_t = crate::ctypes::c_long;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_ushort;
+pub type __kernel_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_int;
+pub type __kernel_time_t = crate::ctypes::c_long;
+pub type __kernel_suseconds_t = crate::ctypes::c_long;
+pub type __kernel_clock_t = crate::ctypes::c_long;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
+pub type __kernel_old_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_dev_t = crate::ctypes::c_ushort;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __le16 = __u16;
 pub type __be16 = __u16;
@@ -1663,14 +1663,14 @@ pub type __wsum = __u32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -1678,8 +1678,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -1693,16 +1693,16 @@ pub data: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_int,
-pub nr_free_files: ::std::os::raw::c_int,
-pub max_files: ::std::os::raw::c_int,
+pub nr_files: crate::ctypes::c_int,
+pub nr_free_files: crate::ctypes::c_int,
+pub max_files: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_int,
-pub nr_unused: ::std::os::raw::c_int,
-pub dummy: [::std::os::raw::c_int; 5usize],
+pub nr_inodes: crate::ctypes::c_int,
+pub nr_unused: crate::ctypes::c_int,
+pub dummy: [crate::ctypes::c_int; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1713,15 +1713,15 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
 #[repr(C)]
 #[repr(align(4))]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
-pub ss_family: ::std::os::raw::c_ushort,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub ss_family: crate::ctypes::c_ushort,
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -1788,7 +1788,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1831,7 +1831,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -1841,7 +1841,7 @@ pub struct sockaddr_in {
 pub sin_family: u16,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -1858,7 +1858,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -1868,7 +1868,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -1895,22 +1895,22 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1921,8 +1921,8 @@ pub tv_usec: __kernel_suseconds_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1946,74 +1946,74 @@ _unused: [u8; 0],
 pub struct rusage {
 pub ru_utime: timeval,
 pub ru_stime: timeval,
-pub ru_maxrss: ::std::os::raw::c_long,
-pub ru_ixrss: ::std::os::raw::c_long,
-pub ru_idrss: ::std::os::raw::c_long,
-pub ru_isrss: ::std::os::raw::c_long,
-pub ru_minflt: ::std::os::raw::c_long,
-pub ru_majflt: ::std::os::raw::c_long,
-pub ru_nswap: ::std::os::raw::c_long,
-pub ru_inblock: ::std::os::raw::c_long,
-pub ru_oublock: ::std::os::raw::c_long,
-pub ru_msgsnd: ::std::os::raw::c_long,
-pub ru_msgrcv: ::std::os::raw::c_long,
-pub ru_nsignals: ::std::os::raw::c_long,
-pub ru_nvcsw: ::std::os::raw::c_long,
-pub ru_nivcsw: ::std::os::raw::c_long,
+pub ru_maxrss: crate::ctypes::c_long,
+pub ru_ixrss: crate::ctypes::c_long,
+pub ru_idrss: crate::ctypes::c_long,
+pub ru_isrss: crate::ctypes::c_long,
+pub ru_minflt: crate::ctypes::c_long,
+pub ru_majflt: crate::ctypes::c_long,
+pub ru_nswap: crate::ctypes::c_long,
+pub ru_inblock: crate::ctypes::c_long,
+pub ru_oublock: crate::ctypes::c_long,
+pub ru_msgsnd: crate::ctypes::c_long,
+pub ru_msgrcv: crate::ctypes::c_long,
+pub ru_nsignals: crate::ctypes::c_long,
+pub ru_nvcsw: crate::ctypes::c_long,
+pub ru_nivcsw: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rlimit {
-pub rlim_cur: ::std::os::raw::c_ulong,
-pub rlim_max: ::std::os::raw::c_ulong,
+pub rlim_cur: crate::ctypes::c_ulong,
+pub rlim_max: crate::ctypes::c_ulong,
 }
 extern "C" {
-pub fn getrusage(p: *mut task_struct, who: ::std::os::raw::c_int, ru: *mut rusage) -> ::std::os::raw::c_int;
+pub fn getrusage(p: *mut task_struct, who: crate::ctypes::c_int, ru: *mut rusage) -> crate::ctypes::c_int;
 }
-pub type sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sigaction {
 pub _u: sigaction__bindgen_ty_1,
 pub sa_mask: sigset_t,
-pub sa_flags: ::std::os::raw::c_ulong,
-pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: ::core::option::Option<unsafe extern "C" fn()>,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigaction__bindgen_ty_1 {
 pub _sa_handler: __sighandler_t,
-pub _sa_sigaction: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int, arg2: *mut siginfo, arg3: *mut ::std::os::raw::c_void)>,
+pub _sa_sigaction: ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int, arg2: *mut siginfo, arg3: *mut crate::ctypes::c_void)>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
 pub struct siginfo {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: siginfo__bindgen_ty_1,
 }
 #[repr(C)]
 pub struct siginfo__bindgen_ty_1 {
-pub _pad: __BindgenUnionField<[::std::os::raw::c_int; 29usize]>,
+pub _pad: __BindgenUnionField<[crate::ctypes::c_int; 29usize]>,
 pub _kill: __BindgenUnionField<siginfo__bindgen_ty_1__bindgen_ty_1>,
 pub _timer: __BindgenUnionField<siginfo__bindgen_ty_1__bindgen_ty_2>,
 pub _rt: __BindgenUnionField<siginfo__bindgen_ty_1__bindgen_ty_3>,
@@ -2031,10 +2031,10 @@ pub _uid: __kernel_uid32_t,
 #[repr(C)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
-pub _pad: __IncompleteArrayField<::std::os::raw::c_char>,
+pub _overrun: crate::ctypes::c_int,
+pub _pad: __IncompleteArrayField<crate::ctypes::c_char>,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2048,48 +2048,48 @@ pub _sigval: sigval_t,
 pub struct siginfo__bindgen_ty_1__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr: *mut crate::ctypes::c_void,
+pub _addr_lsb: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 pub type siginfo_t = siginfo;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 13usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 13usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2127,20 +2127,20 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 8usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2153,14 +2153,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: u16,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2168,82 +2168,82 @@ pub struct sockaddr {
 pub __storage: __kernel_sockaddr_storage,
 }
 pub type __kernel_sa_family_t = u16;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulonglong,
-pub d_off: ::std::os::raw::c_longlong,
+pub d_ino: crate::ctypes::c_ulonglong,
+pub d_off: crate::ctypes::c_longlong,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_ushort,
-pub st_nlink: ::std::os::raw::c_ushort,
-pub st_uid: ::std::os::raw::c_ushort,
-pub st_gid: ::std::os::raw::c_ushort,
-pub st_rdev: ::std::os::raw::c_ulong,
-pub st_size: ::std::os::raw::c_ulong,
-pub st_blksize: ::std::os::raw::c_ulong,
-pub st_blocks: ::std::os::raw::c_ulong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub __unused4: ::std::os::raw::c_ulong,
-pub __unused5: ::std::os::raw::c_ulong,
+pub st_dev: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_ushort,
+pub st_nlink: crate::ctypes::c_ushort,
+pub st_uid: crate::ctypes::c_ushort,
+pub st_gid: crate::ctypes::c_ushort,
+pub st_rdev: crate::ctypes::c_ulong,
+pub st_size: crate::ctypes::c_ulong,
+pub st_blksize: crate::ctypes::c_ulong,
+pub st_blocks: crate::ctypes::c_ulong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub __unused4: crate::ctypes::c_ulong,
+pub __unused5: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat64 {
-pub st_dev: ::std::os::raw::c_ulonglong,
-pub __pad0: [::std::os::raw::c_uchar; 4usize],
-pub __st_ino: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_nlink: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_ulong,
-pub st_gid: ::std::os::raw::c_ulong,
-pub st_rdev: ::std::os::raw::c_ulonglong,
-pub __pad3: [::std::os::raw::c_uchar; 4usize],
-pub st_size: ::std::os::raw::c_longlong,
-pub st_blksize: ::std::os::raw::c_ulong,
-pub st_blocks: ::std::os::raw::c_ulonglong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_mtime_nsec: ::std::os::raw::c_uint,
-pub st_ctime: ::std::os::raw::c_ulong,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulonglong,
+pub st_dev: crate::ctypes::c_ulonglong,
+pub __pad0: [crate::ctypes::c_uchar; 4usize],
+pub __st_ino: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_nlink: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_ulong,
+pub st_gid: crate::ctypes::c_ulong,
+pub st_rdev: crate::ctypes::c_ulonglong,
+pub __pad3: [crate::ctypes::c_uchar; 4usize],
+pub st_size: crate::ctypes::c_longlong,
+pub st_blksize: crate::ctypes::c_ulong,
+pub st_blocks: crate::ctypes::c_ulonglong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_uint,
+pub st_ctime: crate::ctypes::c_ulong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulonglong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __old_kernel_stat {
-pub st_dev: ::std::os::raw::c_ushort,
-pub st_ino: ::std::os::raw::c_ushort,
-pub st_mode: ::std::os::raw::c_ushort,
-pub st_nlink: ::std::os::raw::c_ushort,
-pub st_uid: ::std::os::raw::c_ushort,
-pub st_gid: ::std::os::raw::c_ushort,
-pub st_rdev: ::std::os::raw::c_ushort,
-pub st_size: ::std::os::raw::c_ulong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
+pub st_dev: crate::ctypes::c_ushort,
+pub st_ino: crate::ctypes::c_ushort,
+pub st_mode: crate::ctypes::c_ushort,
+pub st_nlink: crate::ctypes::c_ushort,
+pub st_uid: crate::ctypes::c_ushort,
+pub st_gid: crate::ctypes::c_ushort,
+pub st_rdev: crate::ctypes::c_ushort,
+pub st_size: crate::ctypes::c_ulong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v2_6_32/x86/netlink.rs
+++ b/src/v2_6_32/x86/netlink.rs
@@ -118,62 +118,62 @@ pub const RTMGRP_DECnet_ROUTE: u32 = 16384;
 pub const RTMGRP_IPV6_PREFIX: u32 = 131072;
 pub const TCA_ACT_TAB: u32 = 1;
 pub const TCAA_MAX: u32 = 1;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
 #[repr(C)]
 #[repr(align(4))]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
-pub ss_family: ::std::os::raw::c_ushort,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub ss_family: crate::ctypes::c_ushort,
+pub __data: [crate::ctypes::c_char; 126usize],
 }
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
-pub type umode_t = ::std::os::raw::c_ushort;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
+pub type umode_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_ino_t = ::std::os::raw::c_ulong;
-pub type __kernel_mode_t = ::std::os::raw::c_ushort;
-pub type __kernel_nlink_t = ::std::os::raw::c_ushort;
-pub type __kernel_off_t = ::std::os::raw::c_long;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_ushort;
-pub type __kernel_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_int;
-pub type __kernel_time_t = ::std::os::raw::c_long;
-pub type __kernel_suseconds_t = ::std::os::raw::c_long;
-pub type __kernel_clock_t = ::std::os::raw::c_long;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
-pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ushort;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_ino_t = crate::ctypes::c_ulong;
+pub type __kernel_mode_t = crate::ctypes::c_ushort;
+pub type __kernel_nlink_t = crate::ctypes::c_ushort;
+pub type __kernel_off_t = crate::ctypes::c_long;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_ushort;
+pub type __kernel_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_int;
+pub type __kernel_time_t = crate::ctypes::c_long;
+pub type __kernel_suseconds_t = crate::ctypes::c_long;
+pub type __kernel_clock_t = crate::ctypes::c_long;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
+pub type __kernel_old_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_dev_t = crate::ctypes::c_ushort;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __le16 = __u16;
 pub type __be16 = __u16;
@@ -192,7 +192,7 @@ _unused: [u8; 0],
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: u16,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -208,7 +208,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 #[repr(C)]
@@ -666,21 +666,21 @@ __RTM_MAX = 80,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_12 = _bindgen_ty_12::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_12 = _bindgen_ty_12::RTN_UNICAST;
@@ -759,10 +759,10 @@ __RTA_MAX = 16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -842,29 +842,29 @@ pub ident: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_14 = _bindgen_ty_14::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_14 = _bindgen_ty_14::PREFIX_ADDRESS;
@@ -888,10 +888,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -924,14 +924,14 @@ __TCA_MAX = 9,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_16 = _bindgen_ty_16::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_16 = _bindgen_ty_16::NDUSEROPT_SRCADDR;
@@ -976,7 +976,7 @@ __RTNLGRP_MAX = 23,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }

--- a/src/v2_6_32/x86_64/general.rs
+++ b/src/v2_6_32/x86_64/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,61 +18,61 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
 #[repr(C)]
-pub struct __BindgenUnionField<T>(::std::marker::PhantomData<T>);
+pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
 impl<T> __BindgenUnionField<T> {
 #[inline]
 pub const fn new() -> Self {
-__BindgenUnionField(::std::marker::PhantomData)
+__BindgenUnionField(::core::marker::PhantomData)
 }
 #[inline]
 pub unsafe fn as_ref(&self) -> &T {
-::std::mem::transmute(self)
+::core::mem::transmute(self)
 }
 #[inline]
 pub unsafe fn as_mut(&mut self) -> &mut T {
-::std::mem::transmute(self)
+::core::mem::transmute(self)
 }
 }
-impl<T> ::std::default::Default for __BindgenUnionField<T> {
+impl<T> ::core::default::Default for __BindgenUnionField<T> {
 #[inline]
 fn default() -> Self {
 Self::new()
 }
 }
-impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
+impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
 #[inline]
 fn clone(&self) -> Self {
 Self::new()
 }
 }
-impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
+impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__BindgenUnionField")
 }
 }
-impl<T> ::std::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::std::hash::Hasher>(&self, _state: &mut H) {}
+impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
+fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
 }
-impl<T> ::std::cmp::PartialEq for __BindgenUnionField<T> {
+impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
 fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
 true
 }
 }
-impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
+impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 pub const LINUX_VERSION_CODE: u32 = 132640;
 pub const __BITS_PER_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
@@ -1566,56 +1566,56 @@ pub const TFD_NONBLOCK: u32 = 2048;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
-pub type umode_t = ::std::os::raw::c_ushort;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
+pub type umode_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_ino_t = ::std::os::raw::c_ulong;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_nlink_t = ::std::os::raw::c_ulong;
-pub type __kernel_off_t = ::std::os::raw::c_long;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
-pub type __kernel_size_t = ::std::os::raw::c_ulong;
-pub type __kernel_ssize_t = ::std::os::raw::c_long;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_long;
-pub type __kernel_time_t = ::std::os::raw::c_long;
-pub type __kernel_suseconds_t = ::std::os::raw::c_long;
-pub type __kernel_clock_t = ::std::os::raw::c_long;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_ino_t = crate::ctypes::c_ulong;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_nlink_t = crate::ctypes::c_ulong;
+pub type __kernel_off_t = crate::ctypes::c_long;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
+pub type __kernel_size_t = crate::ctypes::c_ulong;
+pub type __kernel_ssize_t = crate::ctypes::c_long;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_long;
+pub type __kernel_time_t = crate::ctypes::c_long;
+pub type __kernel_suseconds_t = crate::ctypes::c_long;
+pub type __kernel_clock_t = crate::ctypes::c_long;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
-pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
+pub type __kernel_old_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_gid_t = crate::ctypes::c_ushort;
 pub type __kernel_uid32_t = __kernel_uid_t;
 pub type __kernel_gid32_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
+pub type __kernel_old_dev_t = crate::ctypes::c_ulong;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -1627,14 +1627,14 @@ pub type __wsum = __u32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -1642,8 +1642,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -1657,16 +1657,16 @@ pub data: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_int,
-pub nr_free_files: ::std::os::raw::c_int,
-pub max_files: ::std::os::raw::c_int,
+pub nr_files: crate::ctypes::c_int,
+pub nr_free_files: crate::ctypes::c_int,
+pub max_files: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_int,
-pub nr_unused: ::std::os::raw::c_int,
-pub dummy: [::std::os::raw::c_int; 5usize],
+pub nr_inodes: crate::ctypes::c_int,
+pub nr_unused: crate::ctypes::c_int,
+pub dummy: [crate::ctypes::c_int; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1677,15 +1677,15 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
 #[repr(C)]
 #[repr(align(8))]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
-pub ss_family: ::std::os::raw::c_ushort,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub ss_family: crate::ctypes::c_ushort,
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -1752,7 +1752,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1795,7 +1795,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -1805,7 +1805,7 @@ pub struct sockaddr_in {
 pub sin_family: u16,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -1822,7 +1822,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -1832,7 +1832,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -1859,22 +1859,22 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1885,8 +1885,8 @@ pub tv_usec: __kernel_suseconds_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1910,40 +1910,40 @@ _unused: [u8; 0],
 pub struct rusage {
 pub ru_utime: timeval,
 pub ru_stime: timeval,
-pub ru_maxrss: ::std::os::raw::c_long,
-pub ru_ixrss: ::std::os::raw::c_long,
-pub ru_idrss: ::std::os::raw::c_long,
-pub ru_isrss: ::std::os::raw::c_long,
-pub ru_minflt: ::std::os::raw::c_long,
-pub ru_majflt: ::std::os::raw::c_long,
-pub ru_nswap: ::std::os::raw::c_long,
-pub ru_inblock: ::std::os::raw::c_long,
-pub ru_oublock: ::std::os::raw::c_long,
-pub ru_msgsnd: ::std::os::raw::c_long,
-pub ru_msgrcv: ::std::os::raw::c_long,
-pub ru_nsignals: ::std::os::raw::c_long,
-pub ru_nvcsw: ::std::os::raw::c_long,
-pub ru_nivcsw: ::std::os::raw::c_long,
+pub ru_maxrss: crate::ctypes::c_long,
+pub ru_ixrss: crate::ctypes::c_long,
+pub ru_idrss: crate::ctypes::c_long,
+pub ru_isrss: crate::ctypes::c_long,
+pub ru_minflt: crate::ctypes::c_long,
+pub ru_majflt: crate::ctypes::c_long,
+pub ru_nswap: crate::ctypes::c_long,
+pub ru_inblock: crate::ctypes::c_long,
+pub ru_oublock: crate::ctypes::c_long,
+pub ru_msgsnd: crate::ctypes::c_long,
+pub ru_msgrcv: crate::ctypes::c_long,
+pub ru_nsignals: crate::ctypes::c_long,
+pub ru_nvcsw: crate::ctypes::c_long,
+pub ru_nivcsw: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rlimit {
-pub rlim_cur: ::std::os::raw::c_ulong,
-pub rlim_max: ::std::os::raw::c_ulong,
+pub rlim_cur: crate::ctypes::c_ulong,
+pub rlim_max: crate::ctypes::c_ulong,
 }
 extern "C" {
-pub fn getrusage(p: *mut task_struct, who: ::std::os::raw::c_int, ru: *mut rusage) -> ::std::os::raw::c_int;
+pub fn getrusage(p: *mut task_struct, who: crate::ctypes::c_int, ru: *mut rusage) -> crate::ctypes::c_int;
 }
-pub type sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaction {
 pub sa_handler: __sighandler_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: sigset_t,
 }
@@ -1955,28 +1955,28 @@ pub sa: sigaction,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
 pub struct siginfo {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: siginfo__bindgen_ty_1,
 }
 #[repr(C)]
 pub struct siginfo__bindgen_ty_1 {
-pub _pad: __BindgenUnionField<[::std::os::raw::c_int; 28usize]>,
+pub _pad: __BindgenUnionField<[crate::ctypes::c_int; 28usize]>,
 pub _kill: __BindgenUnionField<siginfo__bindgen_ty_1__bindgen_ty_1>,
 pub _timer: __BindgenUnionField<siginfo__bindgen_ty_1__bindgen_ty_2>,
 pub _rt: __BindgenUnionField<siginfo__bindgen_ty_1__bindgen_ty_3>,
@@ -1994,10 +1994,10 @@ pub _uid: __kernel_uid32_t,
 #[repr(C)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
-pub _pad: __IncompleteArrayField<::std::os::raw::c_char>,
+pub _overrun: crate::ctypes::c_int,
+pub _pad: __IncompleteArrayField<crate::ctypes::c_char>,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2011,48 +2011,48 @@ pub _sigval: sigval_t,
 pub struct siginfo__bindgen_ty_1__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr: *mut crate::ctypes::c_void,
+pub _addr_lsb: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 pub type siginfo_t = siginfo;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 12usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 12usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2090,20 +2090,20 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 8usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2116,14 +2116,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: u16,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2131,89 +2131,89 @@ pub struct sockaddr {
 pub __storage: __kernel_sockaddr_storage,
 }
 pub type __kernel_sa_family_t = u16;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulong,
-pub d_off: ::std::os::raw::c_long,
+pub d_ino: crate::ctypes::c_ulong,
+pub d_off: crate::ctypes::c_long,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulong,
-pub st_nlink: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub __pad0: ::std::os::raw::c_uint,
-pub st_rdev: ::std::os::raw::c_ulong,
-pub st_size: ::std::os::raw::c_long,
-pub st_blksize: ::std::os::raw::c_long,
-pub st_blocks: ::std::os::raw::c_long,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub __unused: [::std::os::raw::c_long; 3usize],
+pub st_dev: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulong,
+pub st_nlink: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub __pad0: crate::ctypes::c_uint,
+pub st_rdev: crate::ctypes::c_ulong,
+pub st_size: crate::ctypes::c_long,
+pub st_blksize: crate::ctypes::c_long,
+pub st_blocks: crate::ctypes::c_long,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub __unused: [crate::ctypes::c_long; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __old_kernel_stat {
-pub st_dev: ::std::os::raw::c_ushort,
-pub st_ino: ::std::os::raw::c_ushort,
-pub st_mode: ::std::os::raw::c_ushort,
-pub st_nlink: ::std::os::raw::c_ushort,
-pub st_uid: ::std::os::raw::c_ushort,
-pub st_gid: ::std::os::raw::c_ushort,
-pub st_rdev: ::std::os::raw::c_ushort,
-pub st_size: ::std::os::raw::c_uint,
-pub st_atime: ::std::os::raw::c_uint,
-pub st_mtime: ::std::os::raw::c_uint,
-pub st_ctime: ::std::os::raw::c_uint,
+pub st_dev: crate::ctypes::c_ushort,
+pub st_ino: crate::ctypes::c_ushort,
+pub st_mode: crate::ctypes::c_ushort,
+pub st_nlink: crate::ctypes::c_ushort,
+pub st_uid: crate::ctypes::c_ushort,
+pub st_gid: crate::ctypes::c_ushort,
+pub st_rdev: crate::ctypes::c_ushort,
+pub st_size: crate::ctypes::c_uint,
+pub st_atime: crate::ctypes::c_uint,
+pub st_mtime: crate::ctypes::c_uint,
+pub st_ctime: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct statfs {
-pub f_type: ::std::os::raw::c_long,
-pub f_bsize: ::std::os::raw::c_long,
-pub f_blocks: ::std::os::raw::c_long,
-pub f_bfree: ::std::os::raw::c_long,
-pub f_bavail: ::std::os::raw::c_long,
-pub f_files: ::std::os::raw::c_long,
-pub f_ffree: ::std::os::raw::c_long,
+pub f_type: crate::ctypes::c_long,
+pub f_bsize: crate::ctypes::c_long,
+pub f_blocks: crate::ctypes::c_long,
+pub f_bfree: crate::ctypes::c_long,
+pub f_bavail: crate::ctypes::c_long,
+pub f_files: crate::ctypes::c_long,
+pub f_ffree: crate::ctypes::c_long,
 pub f_fsid: __kernel_fsid_t,
-pub f_namelen: ::std::os::raw::c_long,
-pub f_frsize: ::std::os::raw::c_long,
-pub f_spare: [::std::os::raw::c_long; 5usize],
+pub f_namelen: crate::ctypes::c_long,
+pub f_frsize: crate::ctypes::c_long,
+pub f_spare: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct statfs64 {
-pub f_type: ::std::os::raw::c_long,
-pub f_bsize: ::std::os::raw::c_long,
+pub f_type: crate::ctypes::c_long,
+pub f_bsize: crate::ctypes::c_long,
 pub f_blocks: __u64,
 pub f_bfree: __u64,
 pub f_bavail: __u64,
 pub f_files: __u64,
 pub f_ffree: __u64,
 pub f_fsid: __kernel_fsid_t,
-pub f_namelen: ::std::os::raw::c_long,
-pub f_frsize: ::std::os::raw::c_long,
-pub f_spare: [::std::os::raw::c_long; 5usize],
+pub f_namelen: crate::ctypes::c_long,
+pub f_frsize: crate::ctypes::c_long,
+pub f_spare: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C, packed(4))]
 #[derive(Debug, Copy, Clone)]
@@ -2230,4 +2230,4 @@ pub f_namelen: __u32,
 pub f_frsize: __u32,
 pub f_spare: [__u32; 5usize],
 }
-pub type __fsword_t = ::std::os::raw::c_long;
+pub type __fsword_t = crate::ctypes::c_long;

--- a/src/v2_6_32/x86_64/netlink.rs
+++ b/src/v2_6_32/x86_64/netlink.rs
@@ -118,63 +118,63 @@ pub const RTMGRP_DECnet_ROUTE: u32 = 16384;
 pub const RTMGRP_IPV6_PREFIX: u32 = 131072;
 pub const TCA_ACT_TAB: u32 = 1;
 pub const TCAA_MAX: u32 = 1;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
 #[repr(C)]
 #[repr(align(8))]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
-pub ss_family: ::std::os::raw::c_ushort,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub ss_family: crate::ctypes::c_ushort,
+pub __data: [crate::ctypes::c_char; 126usize],
 }
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
-pub type umode_t = ::std::os::raw::c_ushort;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
+pub type umode_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_ino_t = ::std::os::raw::c_ulong;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_nlink_t = ::std::os::raw::c_ulong;
-pub type __kernel_off_t = ::std::os::raw::c_long;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
-pub type __kernel_size_t = ::std::os::raw::c_ulong;
-pub type __kernel_ssize_t = ::std::os::raw::c_long;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_long;
-pub type __kernel_time_t = ::std::os::raw::c_long;
-pub type __kernel_suseconds_t = ::std::os::raw::c_long;
-pub type __kernel_clock_t = ::std::os::raw::c_long;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_ino_t = crate::ctypes::c_ulong;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_nlink_t = crate::ctypes::c_ulong;
+pub type __kernel_off_t = crate::ctypes::c_long;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
+pub type __kernel_size_t = crate::ctypes::c_ulong;
+pub type __kernel_ssize_t = crate::ctypes::c_long;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_long;
+pub type __kernel_time_t = crate::ctypes::c_long;
+pub type __kernel_suseconds_t = crate::ctypes::c_long;
+pub type __kernel_clock_t = crate::ctypes::c_long;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
-pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
+pub type __kernel_old_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_gid_t = crate::ctypes::c_ushort;
 pub type __kernel_uid32_t = __kernel_uid_t;
 pub type __kernel_gid32_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
+pub type __kernel_old_dev_t = crate::ctypes::c_ulong;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -192,7 +192,7 @@ _unused: [u8; 0],
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: u16,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -208,7 +208,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 #[repr(C)]
@@ -666,21 +666,21 @@ __RTM_MAX = 80,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_12 = _bindgen_ty_12::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_12 = _bindgen_ty_12::RTN_UNICAST;
@@ -759,10 +759,10 @@ __RTA_MAX = 16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -842,29 +842,29 @@ pub ident: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_14 = _bindgen_ty_14::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_14 = _bindgen_ty_14::PREFIX_ADDRESS;
@@ -888,10 +888,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -924,14 +924,14 @@ __TCA_MAX = 9,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_16 = _bindgen_ty_16::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_16 = _bindgen_ty_16::NDUSEROPT_SRCADDR;
@@ -976,7 +976,7 @@ __RTNLGRP_MAX = 23,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }

--- a/src/v3_10/powerpc64/general.rs
+++ b/src/v3_10/powerpc64/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,61 +18,61 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
 #[repr(C)]
-pub struct __BindgenUnionField<T>(::std::marker::PhantomData<T>);
+pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
 impl<T> __BindgenUnionField<T> {
 #[inline]
 pub const fn new() -> Self {
-__BindgenUnionField(::std::marker::PhantomData)
+__BindgenUnionField(::core::marker::PhantomData)
 }
 #[inline]
 pub unsafe fn as_ref(&self) -> &T {
-::std::mem::transmute(self)
+::core::mem::transmute(self)
 }
 #[inline]
 pub unsafe fn as_mut(&mut self) -> &mut T {
-::std::mem::transmute(self)
+::core::mem::transmute(self)
 }
 }
-impl<T> ::std::default::Default for __BindgenUnionField<T> {
+impl<T> ::core::default::Default for __BindgenUnionField<T> {
 #[inline]
 fn default() -> Self {
 Self::new()
 }
 }
-impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
+impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
 #[inline]
 fn clone(&self) -> Self {
 Self::new()
 }
 }
-impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
+impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__BindgenUnionField")
 }
 }
-impl<T> ::std::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::std::hash::Hasher>(&self, _state: &mut H) {}
+impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
+fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
 }
-impl<T> ::std::cmp::PartialEq for __BindgenUnionField<T> {
+impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
 fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
 true
 }
 }
-impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
+impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 pub const LINUX_VERSION_CODE: u32 = 199168;
 pub const O_DIRECTORY: u32 = 16384;
 pub const O_NOFOLLOW: u32 = 32768;
@@ -1656,16 +1656,16 @@ pub const TFD_NONBLOCK: u32 = 2048;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_long;
-pub type __u64 = ::std::os::raw::c_ulong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_long;
+pub type __u64 = crate::ctypes::c_ulong;
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Copy, Clone)]
@@ -1675,24 +1675,24 @@ pub u: [__u32; 4usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_old_dev_t = crate::ctypes::c_ulong;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
 pub type __kernel_size_t = __kernel_ulong_t;
@@ -1701,17 +1701,17 @@ pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -1723,14 +1723,14 @@ pub type __wsum = __u32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -1738,8 +1738,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -1760,16 +1760,16 @@ pub minlen: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_int,
-pub nr_unused: ::std::os::raw::c_int,
-pub dummy: [::std::os::raw::c_int; 5usize],
+pub nr_inodes: crate::ctypes::c_int,
+pub nr_unused: crate::ctypes::c_int,
+pub dummy: [crate::ctypes::c_int; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1780,16 +1780,16 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[repr(align(8))]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -1856,7 +1856,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1899,7 +1899,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -1909,7 +1909,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -1926,7 +1926,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -1936,7 +1936,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -1963,15 +1963,15 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
@@ -1985,7 +1985,7 @@ pub s3: __u32,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1996,8 +1996,8 @@ pub tv_usec: __kernel_suseconds_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2016,26 +2016,26 @@ pub it_value: timeval,
 pub struct rusage {
 pub ru_utime: timeval,
 pub ru_stime: timeval,
-pub ru_maxrss: ::std::os::raw::c_long,
-pub ru_ixrss: ::std::os::raw::c_long,
-pub ru_idrss: ::std::os::raw::c_long,
-pub ru_isrss: ::std::os::raw::c_long,
-pub ru_minflt: ::std::os::raw::c_long,
-pub ru_majflt: ::std::os::raw::c_long,
-pub ru_nswap: ::std::os::raw::c_long,
-pub ru_inblock: ::std::os::raw::c_long,
-pub ru_oublock: ::std::os::raw::c_long,
-pub ru_msgsnd: ::std::os::raw::c_long,
-pub ru_msgrcv: ::std::os::raw::c_long,
-pub ru_nsignals: ::std::os::raw::c_long,
-pub ru_nvcsw: ::std::os::raw::c_long,
-pub ru_nivcsw: ::std::os::raw::c_long,
+pub ru_maxrss: crate::ctypes::c_long,
+pub ru_ixrss: crate::ctypes::c_long,
+pub ru_idrss: crate::ctypes::c_long,
+pub ru_isrss: crate::ctypes::c_long,
+pub ru_minflt: crate::ctypes::c_long,
+pub ru_majflt: crate::ctypes::c_long,
+pub ru_nswap: crate::ctypes::c_long,
+pub ru_inblock: crate::ctypes::c_long,
+pub ru_oublock: crate::ctypes::c_long,
+pub ru_msgsnd: crate::ctypes::c_long,
+pub ru_msgrcv: crate::ctypes::c_long,
+pub ru_nsignals: crate::ctypes::c_long,
+pub ru_nvcsw: crate::ctypes::c_long,
+pub ru_nivcsw: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rlimit {
-pub rlim_cur: ::std::os::raw::c_ulong,
-pub rlim_max: ::std::os::raw::c_ulong,
+pub rlim_cur: crate::ctypes::c_ulong,
+pub rlim_max: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2043,57 +2043,57 @@ pub struct rlimit64 {
 pub rlim_cur: __u64,
 pub rlim_max: __u64,
 }
-pub type old_sigset_t = ::std::os::raw::c_ulong;
+pub type old_sigset_t = crate::ctypes::c_ulong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigset_t {
-pub sig: [::std::os::raw::c_ulong; 1usize],
+pub sig: [crate::ctypes::c_ulong; 1usize],
 }
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct old_sigaction {
 pub sa_handler: __sighandler_t,
 pub sa_mask: old_sigset_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaction {
 pub sa_handler: __sighandler_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
 pub struct siginfo {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: siginfo__bindgen_ty_1,
 }
 #[repr(C)]
 pub struct siginfo__bindgen_ty_1 {
-pub _pad: __BindgenUnionField<[::std::os::raw::c_int; 28usize]>,
+pub _pad: __BindgenUnionField<[crate::ctypes::c_int; 28usize]>,
 pub _kill: __BindgenUnionField<siginfo__bindgen_ty_1__bindgen_ty_1>,
 pub _timer: __BindgenUnionField<siginfo__bindgen_ty_1__bindgen_ty_2>,
 pub _rt: __BindgenUnionField<siginfo__bindgen_ty_1__bindgen_ty_3>,
@@ -2112,10 +2112,10 @@ pub _uid: __kernel_uid32_t,
 #[repr(C)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
-pub _pad: __IncompleteArrayField<::std::os::raw::c_char>,
+pub _overrun: crate::ctypes::c_int,
+pub _pad: __IncompleteArrayField<crate::ctypes::c_char>,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2129,55 +2129,55 @@ pub _sigval: sigval_t,
 pub struct siginfo__bindgen_ty_1__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr: *mut crate::ctypes::c_void,
+pub _addr_lsb: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 pub type siginfo_t = siginfo;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 12usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 12usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2205,49 +2205,49 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sgttyb {
-pub sg_ispeed: ::std::os::raw::c_char,
-pub sg_ospeed: ::std::os::raw::c_char,
-pub sg_erase: ::std::os::raw::c_char,
-pub sg_kill: ::std::os::raw::c_char,
-pub sg_flags: ::std::os::raw::c_short,
+pub sg_ispeed: crate::ctypes::c_char,
+pub sg_ospeed: crate::ctypes::c_char,
+pub sg_erase: crate::ctypes::c_char,
+pub sg_kill: crate::ctypes::c_char,
+pub sg_flags: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tchars {
-pub t_intrc: ::std::os::raw::c_char,
-pub t_quitc: ::std::os::raw::c_char,
-pub t_startc: ::std::os::raw::c_char,
-pub t_stopc: ::std::os::raw::c_char,
-pub t_eofc: ::std::os::raw::c_char,
-pub t_brkc: ::std::os::raw::c_char,
+pub t_intrc: crate::ctypes::c_char,
+pub t_quitc: crate::ctypes::c_char,
+pub t_startc: crate::ctypes::c_char,
+pub t_stopc: crate::ctypes::c_char,
+pub t_eofc: crate::ctypes::c_char,
+pub t_brkc: crate::ctypes::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ltchars {
-pub t_suspc: ::std::os::raw::c_char,
-pub t_dsuspc: ::std::os::raw::c_char,
-pub t_rprntc: ::std::os::raw::c_char,
-pub t_flushc: ::std::os::raw::c_char,
-pub t_werasc: ::std::os::raw::c_char,
-pub t_lnextc: ::std::os::raw::c_char,
+pub t_suspc: crate::ctypes::c_char,
+pub t_dsuspc: crate::ctypes::c_char,
+pub t_rprntc: crate::ctypes::c_char,
+pub t_flushc: crate::ctypes::c_char,
+pub t_werasc: crate::ctypes::c_char,
+pub t_lnextc: crate::ctypes::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 10usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 10usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2260,114 +2260,114 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr {
 pub __storage: __kernel_sockaddr_storage,
 }
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulong,
-pub d_off: ::std::os::raw::c_long,
+pub d_ino: crate::ctypes::c_ulong,
+pub d_off: crate::ctypes::c_long,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ulong,
+pub st_dev: crate::ctypes::c_ulong,
 pub st_ino: __kernel_ino_t,
-pub st_nlink: ::std::os::raw::c_ulong,
+pub st_nlink: crate::ctypes::c_ulong,
 pub st_mode: __kernel_mode_t,
 pub st_uid: __kernel_uid_t,
 pub st_gid: __kernel_gid_t,
-pub st_rdev: ::std::os::raw::c_ulong,
+pub st_rdev: crate::ctypes::c_ulong,
 pub st_size: __kernel_off_t,
-pub st_blksize: ::std::os::raw::c_ulong,
-pub st_blocks: ::std::os::raw::c_ulong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub __unused4: ::std::os::raw::c_ulong,
-pub __unused5: ::std::os::raw::c_ulong,
-pub __unused6: ::std::os::raw::c_ulong,
+pub st_blksize: crate::ctypes::c_ulong,
+pub st_blocks: crate::ctypes::c_ulong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub __unused4: crate::ctypes::c_ulong,
+pub __unused5: crate::ctypes::c_ulong,
+pub __unused6: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat64 {
-pub st_dev: ::std::os::raw::c_ulonglong,
-pub st_ino: ::std::os::raw::c_ulonglong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_nlink: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub st_rdev: ::std::os::raw::c_ulonglong,
-pub __pad2: ::std::os::raw::c_ushort,
-pub st_size: ::std::os::raw::c_longlong,
-pub st_blksize: ::std::os::raw::c_int,
-pub st_blocks: ::std::os::raw::c_longlong,
-pub st_atime: ::std::os::raw::c_int,
-pub st_atime_nsec: ::std::os::raw::c_uint,
-pub st_mtime: ::std::os::raw::c_int,
-pub st_mtime_nsec: ::std::os::raw::c_uint,
-pub st_ctime: ::std::os::raw::c_int,
-pub st_ctime_nsec: ::std::os::raw::c_uint,
-pub __unused4: ::std::os::raw::c_uint,
-pub __unused5: ::std::os::raw::c_uint,
+pub st_dev: crate::ctypes::c_ulonglong,
+pub st_ino: crate::ctypes::c_ulonglong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_nlink: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub st_rdev: crate::ctypes::c_ulonglong,
+pub __pad2: crate::ctypes::c_ushort,
+pub st_size: crate::ctypes::c_longlong,
+pub st_blksize: crate::ctypes::c_int,
+pub st_blocks: crate::ctypes::c_longlong,
+pub st_atime: crate::ctypes::c_int,
+pub st_atime_nsec: crate::ctypes::c_uint,
+pub st_mtime: crate::ctypes::c_int,
+pub st_mtime_nsec: crate::ctypes::c_uint,
+pub st_ctime: crate::ctypes::c_int,
+pub st_ctime_nsec: crate::ctypes::c_uint,
+pub __unused4: crate::ctypes::c_uint,
+pub __unused5: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct statfs {
-pub f_type: ::std::os::raw::c_long,
-pub f_bsize: ::std::os::raw::c_long,
-pub f_blocks: ::std::os::raw::c_long,
-pub f_bfree: ::std::os::raw::c_long,
-pub f_bavail: ::std::os::raw::c_long,
-pub f_files: ::std::os::raw::c_long,
-pub f_ffree: ::std::os::raw::c_long,
+pub f_type: crate::ctypes::c_long,
+pub f_bsize: crate::ctypes::c_long,
+pub f_blocks: crate::ctypes::c_long,
+pub f_bfree: crate::ctypes::c_long,
+pub f_bavail: crate::ctypes::c_long,
+pub f_files: crate::ctypes::c_long,
+pub f_ffree: crate::ctypes::c_long,
 pub f_fsid: __kernel_fsid_t,
-pub f_namelen: ::std::os::raw::c_long,
-pub f_frsize: ::std::os::raw::c_long,
-pub f_flags: ::std::os::raw::c_long,
-pub f_spare: [::std::os::raw::c_long; 4usize],
+pub f_namelen: crate::ctypes::c_long,
+pub f_frsize: crate::ctypes::c_long,
+pub f_flags: crate::ctypes::c_long,
+pub f_spare: [crate::ctypes::c_long; 4usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct statfs64 {
-pub f_type: ::std::os::raw::c_long,
-pub f_bsize: ::std::os::raw::c_long,
+pub f_type: crate::ctypes::c_long,
+pub f_bsize: crate::ctypes::c_long,
 pub f_blocks: __u64,
 pub f_bfree: __u64,
 pub f_bavail: __u64,
 pub f_files: __u64,
 pub f_ffree: __u64,
 pub f_fsid: __kernel_fsid_t,
-pub f_namelen: ::std::os::raw::c_long,
-pub f_frsize: ::std::os::raw::c_long,
-pub f_flags: ::std::os::raw::c_long,
-pub f_spare: [::std::os::raw::c_long; 4usize],
+pub f_namelen: crate::ctypes::c_long,
+pub f_frsize: crate::ctypes::c_long,
+pub f_flags: crate::ctypes::c_long,
+pub f_spare: [crate::ctypes::c_long; 4usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2385,4 +2385,4 @@ pub f_frsize: __u32,
 pub f_flags: __u32,
 pub f_spare: [__u32; 4usize],
 }
-pub type __fsword_t = ::std::os::raw::c_long;
+pub type __fsword_t = crate::ctypes::c_long;

--- a/src/v3_10/powerpc64/netlink.rs
+++ b/src/v3_10/powerpc64/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -168,16 +168,16 @@ pub const TCA_ACT_TAB: u32 = 1;
 pub const TCAA_MAX: u32 = 1;
 pub const RTEXT_FILTER_VF: u32 = 1;
 pub const RTEXT_FILTER_BRVLAN: u32 = 2;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_long;
-pub type __u64 = ::std::os::raw::c_ulong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_long;
+pub type __u64 = crate::ctypes::c_ulong;
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Copy, Clone)]
@@ -187,24 +187,24 @@ pub u: [__u32; 4usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_old_dev_t = crate::ctypes::c_ulong;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
 pub type __kernel_size_t = __kernel_ulong_t;
@@ -213,17 +213,17 @@ pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -248,21 +248,21 @@ pub pad: __u16,
 pub totalhigh: __kernel_ulong_t,
 pub freehigh: __kernel_ulong_t,
 pub mem_unit: __u32,
-pub _f: __IncompleteArrayField<::std::os::raw::c_char>,
+pub _f: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[repr(align(8))]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -278,7 +278,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 #[repr(C)]
@@ -289,16 +289,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -1114,21 +1114,21 @@ __RTM_MAX = 87,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_25 = _bindgen_ty_25::RTN_UNICAST;
@@ -1209,10 +1209,10 @@ __RTA_MAX = 18,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1301,29 +1301,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_27 = _bindgen_ty_27::PREFIX_ADDRESS;
@@ -1347,10 +1347,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -1383,14 +1383,14 @@ __TCA_MAX = 9,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_29 = _bindgen_ty_29::NDUSEROPT_SRCADDR;
@@ -1439,7 +1439,7 @@ __RTNLGRP_MAX = 27,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }

--- a/src/v3_2/arm/general.rs
+++ b/src/v3_2/arm/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,61 +18,61 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
 #[repr(C)]
-pub struct __BindgenUnionField<T>(::std::marker::PhantomData<T>);
+pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
 impl<T> __BindgenUnionField<T> {
 #[inline]
 pub const fn new() -> Self {
-__BindgenUnionField(::std::marker::PhantomData)
+__BindgenUnionField(::core::marker::PhantomData)
 }
 #[inline]
 pub unsafe fn as_ref(&self) -> &T {
-::std::mem::transmute(self)
+::core::mem::transmute(self)
 }
 #[inline]
 pub unsafe fn as_mut(&mut self) -> &mut T {
-::std::mem::transmute(self)
+::core::mem::transmute(self)
 }
 }
-impl<T> ::std::default::Default for __BindgenUnionField<T> {
+impl<T> ::core::default::Default for __BindgenUnionField<T> {
 #[inline]
 fn default() -> Self {
 Self::new()
 }
 }
-impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
+impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
 #[inline]
 fn clone(&self) -> Self {
 Self::new()
 }
 }
-impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
+impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__BindgenUnionField")
 }
 }
-impl<T> ::std::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::std::hash::Hasher>(&self, _state: &mut H) {}
+impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
+fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
 }
-impl<T> ::std::cmp::PartialEq for __BindgenUnionField<T> {
+impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
 fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
 true
 }
 }
-impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
+impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 pub const LINUX_VERSION_CODE: u32 = 197120;
 pub const O_DIRECTORY: u32 = 16384;
 pub const O_NOFOLLOW: u32 = 32768;
@@ -1659,55 +1659,55 @@ pub const TFD_NONBLOCK: u32 = 2048;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
-pub type umode_t = ::std::os::raw::c_ushort;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
+pub type umode_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_ino_t = ::std::os::raw::c_ulong;
-pub type __kernel_mode_t = ::std::os::raw::c_ushort;
-pub type __kernel_nlink_t = ::std::os::raw::c_ushort;
-pub type __kernel_off_t = ::std::os::raw::c_long;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_ushort;
-pub type __kernel_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_int;
-pub type __kernel_time_t = ::std::os::raw::c_long;
-pub type __kernel_suseconds_t = ::std::os::raw::c_long;
-pub type __kernel_clock_t = ::std::os::raw::c_long;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
-pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ushort;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_ino_t = crate::ctypes::c_ulong;
+pub type __kernel_mode_t = crate::ctypes::c_ushort;
+pub type __kernel_nlink_t = crate::ctypes::c_ushort;
+pub type __kernel_off_t = crate::ctypes::c_long;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_ushort;
+pub type __kernel_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_int;
+pub type __kernel_time_t = crate::ctypes::c_long;
+pub type __kernel_suseconds_t = crate::ctypes::c_long;
+pub type __kernel_clock_t = crate::ctypes::c_long;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
+pub type __kernel_old_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_dev_t = crate::ctypes::c_ushort;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __le16 = __u16;
 pub type __be16 = __u16;
@@ -1720,14 +1720,14 @@ pub type __wsum = __u32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -1735,8 +1735,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -1792,16 +1792,16 @@ pub minlen: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_int,
-pub nr_unused: ::std::os::raw::c_int,
-pub dummy: [::std::os::raw::c_int; 5usize],
+pub nr_inodes: crate::ctypes::c_int,
+pub nr_unused: crate::ctypes::c_int,
+pub dummy: [crate::ctypes::c_int; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1812,16 +1812,16 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[repr(align(4))]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -1888,7 +1888,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1931,7 +1931,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -1941,7 +1941,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -1958,7 +1958,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -1968,7 +1968,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -1995,15 +1995,15 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
@@ -2017,7 +2017,7 @@ pub s3: __u32,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2028,8 +2028,8 @@ pub tv_usec: __kernel_suseconds_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2048,26 +2048,26 @@ pub it_value: timeval,
 pub struct rusage {
 pub ru_utime: timeval,
 pub ru_stime: timeval,
-pub ru_maxrss: ::std::os::raw::c_long,
-pub ru_ixrss: ::std::os::raw::c_long,
-pub ru_idrss: ::std::os::raw::c_long,
-pub ru_isrss: ::std::os::raw::c_long,
-pub ru_minflt: ::std::os::raw::c_long,
-pub ru_majflt: ::std::os::raw::c_long,
-pub ru_nswap: ::std::os::raw::c_long,
-pub ru_inblock: ::std::os::raw::c_long,
-pub ru_oublock: ::std::os::raw::c_long,
-pub ru_msgsnd: ::std::os::raw::c_long,
-pub ru_msgrcv: ::std::os::raw::c_long,
-pub ru_nsignals: ::std::os::raw::c_long,
-pub ru_nvcsw: ::std::os::raw::c_long,
-pub ru_nivcsw: ::std::os::raw::c_long,
+pub ru_maxrss: crate::ctypes::c_long,
+pub ru_ixrss: crate::ctypes::c_long,
+pub ru_idrss: crate::ctypes::c_long,
+pub ru_isrss: crate::ctypes::c_long,
+pub ru_minflt: crate::ctypes::c_long,
+pub ru_majflt: crate::ctypes::c_long,
+pub ru_nswap: crate::ctypes::c_long,
+pub ru_inblock: crate::ctypes::c_long,
+pub ru_oublock: crate::ctypes::c_long,
+pub ru_msgsnd: crate::ctypes::c_long,
+pub ru_msgrcv: crate::ctypes::c_long,
+pub ru_nsignals: crate::ctypes::c_long,
+pub ru_nvcsw: crate::ctypes::c_long,
+pub ru_nivcsw: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rlimit {
-pub rlim_cur: ::std::os::raw::c_ulong,
-pub rlim_max: ::std::os::raw::c_ulong,
+pub rlim_cur: crate::ctypes::c_ulong,
+pub rlim_max: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2075,50 +2075,50 @@ pub struct rlimit64 {
 pub rlim_cur: __u64,
 pub rlim_max: __u64,
 }
-pub type sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sigaction {
 pub _u: sigaction__bindgen_ty_1,
 pub sa_mask: sigset_t,
-pub sa_flags: ::std::os::raw::c_ulong,
-pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: ::core::option::Option<unsafe extern "C" fn()>,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigaction__bindgen_ty_1 {
 pub _sa_handler: __sighandler_t,
-pub _sa_sigaction: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int, arg2: *mut siginfo, arg3: *mut ::std::os::raw::c_void)>,
+pub _sa_sigaction: ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int, arg2: *mut siginfo, arg3: *mut crate::ctypes::c_void)>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
 pub struct siginfo {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: siginfo__bindgen_ty_1,
 }
 #[repr(C)]
 pub struct siginfo__bindgen_ty_1 {
-pub _pad: __BindgenUnionField<[::std::os::raw::c_int; 29usize]>,
+pub _pad: __BindgenUnionField<[crate::ctypes::c_int; 29usize]>,
 pub _kill: __BindgenUnionField<siginfo__bindgen_ty_1__bindgen_ty_1>,
 pub _timer: __BindgenUnionField<siginfo__bindgen_ty_1__bindgen_ty_2>,
 pub _rt: __BindgenUnionField<siginfo__bindgen_ty_1__bindgen_ty_3>,
@@ -2136,10 +2136,10 @@ pub _uid: __kernel_uid32_t,
 #[repr(C)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
-pub _pad: __IncompleteArrayField<::std::os::raw::c_char>,
+pub _overrun: crate::ctypes::c_int,
+pub _pad: __IncompleteArrayField<crate::ctypes::c_char>,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2153,48 +2153,48 @@ pub _sigval: sigval_t,
 pub struct siginfo__bindgen_ty_1__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr: *mut crate::ctypes::c_void,
+pub _addr_lsb: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 pub type siginfo_t = siginfo;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 13usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 13usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2232,20 +2232,20 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 8usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2258,96 +2258,96 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr {
 pub __storage: __kernel_sockaddr_storage,
 }
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulonglong,
-pub d_off: ::std::os::raw::c_longlong,
+pub d_ino: crate::ctypes::c_ulonglong,
+pub d_off: crate::ctypes::c_longlong,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __old_kernel_stat {
-pub st_dev: ::std::os::raw::c_ushort,
-pub st_ino: ::std::os::raw::c_ushort,
-pub st_mode: ::std::os::raw::c_ushort,
-pub st_nlink: ::std::os::raw::c_ushort,
-pub st_uid: ::std::os::raw::c_ushort,
-pub st_gid: ::std::os::raw::c_ushort,
-pub st_rdev: ::std::os::raw::c_ushort,
-pub st_size: ::std::os::raw::c_ulong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
+pub st_dev: crate::ctypes::c_ushort,
+pub st_ino: crate::ctypes::c_ushort,
+pub st_mode: crate::ctypes::c_ushort,
+pub st_nlink: crate::ctypes::c_ushort,
+pub st_uid: crate::ctypes::c_ushort,
+pub st_gid: crate::ctypes::c_ushort,
+pub st_rdev: crate::ctypes::c_ushort,
+pub st_size: crate::ctypes::c_ulong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_ushort,
-pub st_nlink: ::std::os::raw::c_ushort,
-pub st_uid: ::std::os::raw::c_ushort,
-pub st_gid: ::std::os::raw::c_ushort,
-pub st_rdev: ::std::os::raw::c_ulong,
-pub st_size: ::std::os::raw::c_ulong,
-pub st_blksize: ::std::os::raw::c_ulong,
-pub st_blocks: ::std::os::raw::c_ulong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub __unused4: ::std::os::raw::c_ulong,
-pub __unused5: ::std::os::raw::c_ulong,
+pub st_dev: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_ushort,
+pub st_nlink: crate::ctypes::c_ushort,
+pub st_uid: crate::ctypes::c_ushort,
+pub st_gid: crate::ctypes::c_ushort,
+pub st_rdev: crate::ctypes::c_ulong,
+pub st_size: crate::ctypes::c_ulong,
+pub st_blksize: crate::ctypes::c_ulong,
+pub st_blocks: crate::ctypes::c_ulong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub __unused4: crate::ctypes::c_ulong,
+pub __unused5: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat64 {
-pub st_dev: ::std::os::raw::c_ulonglong,
-pub __pad0: [::std::os::raw::c_uchar; 4usize],
-pub __st_ino: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_nlink: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_ulong,
-pub st_gid: ::std::os::raw::c_ulong,
-pub st_rdev: ::std::os::raw::c_ulonglong,
-pub __pad3: [::std::os::raw::c_uchar; 4usize],
-pub st_size: ::std::os::raw::c_longlong,
-pub st_blksize: ::std::os::raw::c_ulong,
-pub st_blocks: ::std::os::raw::c_ulonglong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulonglong,
+pub st_dev: crate::ctypes::c_ulonglong,
+pub __pad0: [crate::ctypes::c_uchar; 4usize],
+pub __st_ino: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_nlink: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_ulong,
+pub st_gid: crate::ctypes::c_ulong,
+pub st_rdev: crate::ctypes::c_ulonglong,
+pub __pad3: [crate::ctypes::c_uchar; 4usize],
+pub st_size: crate::ctypes::c_longlong,
+pub st_blksize: crate::ctypes::c_ulong,
+pub st_blocks: crate::ctypes::c_ulonglong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulonglong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v3_2/arm/netlink.rs
+++ b/src/v3_2/arm/netlink.rs
@@ -127,63 +127,63 @@ pub const RTMGRP_DECnet_ROUTE: u32 = 16384;
 pub const RTMGRP_IPV6_PREFIX: u32 = 131072;
 pub const TCA_ACT_TAB: u32 = 1;
 pub const TCAA_MAX: u32 = 1;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[repr(align(4))]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
-pub type umode_t = ::std::os::raw::c_ushort;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
+pub type umode_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_ino_t = ::std::os::raw::c_ulong;
-pub type __kernel_mode_t = ::std::os::raw::c_ushort;
-pub type __kernel_nlink_t = ::std::os::raw::c_ushort;
-pub type __kernel_off_t = ::std::os::raw::c_long;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_ushort;
-pub type __kernel_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_int;
-pub type __kernel_time_t = ::std::os::raw::c_long;
-pub type __kernel_suseconds_t = ::std::os::raw::c_long;
-pub type __kernel_clock_t = ::std::os::raw::c_long;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
-pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ushort;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_ino_t = crate::ctypes::c_ulong;
+pub type __kernel_mode_t = crate::ctypes::c_ushort;
+pub type __kernel_nlink_t = crate::ctypes::c_ushort;
+pub type __kernel_off_t = crate::ctypes::c_long;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_ushort;
+pub type __kernel_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_int;
+pub type __kernel_time_t = crate::ctypes::c_long;
+pub type __kernel_suseconds_t = crate::ctypes::c_long;
+pub type __kernel_clock_t = crate::ctypes::c_long;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
+pub type __kernel_old_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_dev_t = crate::ctypes::c_ushort;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __le16 = __u16;
 pub type __be16 = __u16;
@@ -197,7 +197,7 @@ pub type __wsum = __u32;
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -213,7 +213,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 #[repr(C)]
@@ -884,21 +884,21 @@ __RTM_MAX = 80,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_20 = _bindgen_ty_20::RTN_UNICAST;
@@ -978,10 +978,10 @@ __RTA_MAX = 17,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1063,29 +1063,29 @@ pub ident: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_22 = _bindgen_ty_22::PREFIX_ADDRESS;
@@ -1109,10 +1109,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -1145,14 +1145,14 @@ __TCA_MAX = 9,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_24 = _bindgen_ty_24::NDUSEROPT_SRCADDR;
@@ -1198,7 +1198,7 @@ __RTNLGRP_MAX = 24,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }

--- a/src/v4_2/aarch64/general.rs
+++ b/src/v4_2/aarch64/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,61 +18,61 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
 #[repr(C)]
-pub struct __BindgenUnionField<T>(::std::marker::PhantomData<T>);
+pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
 impl<T> __BindgenUnionField<T> {
 #[inline]
 pub const fn new() -> Self {
-__BindgenUnionField(::std::marker::PhantomData)
+__BindgenUnionField(::core::marker::PhantomData)
 }
 #[inline]
 pub unsafe fn as_ref(&self) -> &T {
-::std::mem::transmute(self)
+::core::mem::transmute(self)
 }
 #[inline]
 pub unsafe fn as_mut(&mut self) -> &mut T {
-::std::mem::transmute(self)
+::core::mem::transmute(self)
 }
 }
-impl<T> ::std::default::Default for __BindgenUnionField<T> {
+impl<T> ::core::default::Default for __BindgenUnionField<T> {
 #[inline]
 fn default() -> Self {
 Self::new()
 }
 }
-impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
+impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
 #[inline]
 fn clone(&self) -> Self {
 Self::new()
 }
 }
-impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
+impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__BindgenUnionField")
 }
 }
-impl<T> ::std::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::std::hash::Hasher>(&self, _state: &mut H) {}
+impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
+fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
 }
-impl<T> ::std::cmp::PartialEq for __BindgenUnionField<T> {
+impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
 fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
 true
 }
 }
-impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
+impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 pub const LINUX_VERSION_CODE: u32 = 262656;
 pub const O_DIRECTORY: u32 = 16384;
 pub const O_NOFOLLOW: u32 = 32768;
@@ -1671,56 +1671,56 @@ pub const TFD_NONBLOCK: u32 = 2048;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_old_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -1732,14 +1732,14 @@ pub type __wsum = __u32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -1747,8 +1747,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -1769,16 +1769,16 @@ pub minlen: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1789,16 +1789,16 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[repr(align(8))]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -1873,7 +1873,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1916,7 +1916,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -1926,7 +1926,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -1943,7 +1943,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -1953,7 +1953,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -1980,9 +1980,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2005,15 +2005,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2024,8 +2024,8 @@ pub tv_usec: __kernel_suseconds_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2074,46 +2074,46 @@ pub rlim_max: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigset_t {
-pub sig: [::std::os::raw::c_ulong; 1usize],
+pub sig: [crate::ctypes::c_ulong; 1usize],
 }
-pub type old_sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type old_sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaction {
 pub sa_handler: __sighandler_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
 pub struct siginfo {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: siginfo__bindgen_ty_1,
 }
 #[repr(C)]
 pub struct siginfo__bindgen_ty_1 {
-pub _pad: __BindgenUnionField<[::std::os::raw::c_int; 28usize]>,
+pub _pad: __BindgenUnionField<[crate::ctypes::c_int; 28usize]>,
 pub _kill: __BindgenUnionField<siginfo__bindgen_ty_1__bindgen_ty_1>,
 pub _timer: __BindgenUnionField<siginfo__bindgen_ty_1__bindgen_ty_2>,
 pub _rt: __BindgenUnionField<siginfo__bindgen_ty_1__bindgen_ty_3>,
@@ -2132,10 +2132,10 @@ pub _uid: __kernel_uid32_t,
 #[repr(C)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
-pub _pad: __IncompleteArrayField<::std::os::raw::c_char>,
+pub _overrun: crate::ctypes::c_int,
+pub _pad: __IncompleteArrayField<crate::ctypes::c_char>,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2149,62 +2149,62 @@ pub _sigval: sigval_t,
 pub struct siginfo__bindgen_ty_1__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr: *mut crate::ctypes::c_void,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: siginfo__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_5__bindgen_ty_1 {
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 pub type siginfo_t = siginfo;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 12usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 12usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2242,20 +2242,20 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 8usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2268,60 +2268,60 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr {
 pub __storage: __kernel_sockaddr_storage,
 }
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulong,
-pub d_off: ::std::os::raw::c_long,
+pub d_ino: crate::ctypes::c_ulong,
+pub d_off: crate::ctypes::c_long,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_nlink: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub st_rdev: ::std::os::raw::c_ulong,
-pub __pad1: ::std::os::raw::c_ulong,
-pub st_size: ::std::os::raw::c_long,
-pub st_blksize: ::std::os::raw::c_int,
-pub __pad2: ::std::os::raw::c_int,
-pub st_blocks: ::std::os::raw::c_long,
-pub st_atime: ::std::os::raw::c_long,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_long,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_long,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub __unused4: ::std::os::raw::c_uint,
-pub __unused5: ::std::os::raw::c_uint,
+pub st_dev: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_nlink: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub st_rdev: crate::ctypes::c_ulong,
+pub __pad1: crate::ctypes::c_ulong,
+pub st_size: crate::ctypes::c_long,
+pub st_blksize: crate::ctypes::c_int,
+pub __pad2: crate::ctypes::c_int,
+pub st_blocks: crate::ctypes::c_long,
+pub st_atime: crate::ctypes::c_long,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_long,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_long,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub __unused4: crate::ctypes::c_uint,
+pub __unused5: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v4_2/aarch64/netlink.rs
+++ b/src/v4_2/aarch64/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -180,56 +180,56 @@ pub const TCAA_MAX: u32 = 1;
 pub const RTEXT_FILTER_VF: u32 = 1;
 pub const RTEXT_FILTER_BRVLAN: u32 = 2;
 pub const RTEXT_FILTER_BRVLAN_COMPRESSED: u32 = 4;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_old_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -254,21 +254,21 @@ pub pad: __u16,
 pub totalhigh: __kernel_ulong_t,
 pub freehigh: __kernel_ulong_t,
 pub mem_unit: __u32,
-pub _f: __IncompleteArrayField<::std::os::raw::c_char>,
+pub _f: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[repr(align(8))]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -284,7 +284,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 #[repr(C)]
@@ -295,16 +295,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -1444,21 +1444,21 @@ __RTM_MAX = 91,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_34 = _bindgen_ty_34::RTN_UNICAST;
@@ -1542,10 +1542,10 @@ __RTA_MAX = 21,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -1644,29 +1644,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_36 = _bindgen_ty_36::PREFIX_ADDRESS;
@@ -1690,10 +1690,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -1726,14 +1726,14 @@ __TCA_MAX = 9,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_38 = _bindgen_ty_38::NDUSEROPT_SRCADDR;
@@ -1784,7 +1784,7 @@ __RTNLGRP_MAX = 29,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }

--- a/src/v4_20/riscv64/general.rs
+++ b/src/v4_20/riscv64/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -1844,57 +1844,57 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -1903,18 +1903,18 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -1922,8 +1922,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -1971,16 +1971,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1990,7 +1990,7 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2008,7 +2008,7 @@ pub mode: __u32,
 pub raw: [__u8; 64usize],
 pub size: __u32,
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2018,16 +2018,16 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[repr(align(8))]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2102,7 +2102,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2145,7 +2145,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2155,7 +2155,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2172,7 +2172,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2182,7 +2182,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2209,9 +2209,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2234,15 +2234,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2253,8 +2253,8 @@ pub tv_usec: __kernel_suseconds_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2272,7 +2272,7 @@ pub it_value: timeval,
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2321,33 +2321,33 @@ pub rlim_max: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigset_t {
-pub sig: [::std::os::raw::c_ulong; 1usize],
+pub sig: [crate::ctypes::c_ulong; 1usize],
 }
-pub type old_sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type old_sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaction {
 pub sa_handler: __sighandler_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2371,9 +2371,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2387,48 +2387,48 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
+pub _addr: *mut crate::ctypes::c_void,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 8usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 8usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 8usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 8usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2439,14 +2439,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2454,22 +2454,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 12usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 12usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -2504,9 +2504,9 @@ pub stx_dev_major: __u32,
 pub stx_dev_minor: __u32,
 pub __spare2: [__u64; 14usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2544,20 +2544,20 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 8usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2570,14 +2570,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2587,36 +2587,36 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulong,
-pub d_off: ::std::os::raw::c_long,
+pub d_ino: crate::ctypes::c_ulong,
+pub d_off: crate::ctypes::c_long,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_nlink: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub st_rdev: ::std::os::raw::c_ulong,
-pub __pad1: ::std::os::raw::c_ulong,
-pub st_size: ::std::os::raw::c_long,
-pub st_blksize: ::std::os::raw::c_int,
-pub __pad2: ::std::os::raw::c_int,
-pub st_blocks: ::std::os::raw::c_long,
-pub st_atime: ::std::os::raw::c_long,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_long,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_long,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub __unused4: ::std::os::raw::c_uint,
-pub __unused5: ::std::os::raw::c_uint,
+pub st_dev: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_nlink: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub st_rdev: crate::ctypes::c_ulong,
+pub __pad1: crate::ctypes::c_ulong,
+pub st_size: crate::ctypes::c_long,
+pub st_blksize: crate::ctypes::c_int,
+pub __pad2: crate::ctypes::c_int,
+pub st_blocks: crate::ctypes::c_long,
+pub st_atime: crate::ctypes::c_long,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_long,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_long,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub __unused4: crate::ctypes::c_uint,
+pub __unused5: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v4_20/riscv64/netlink.rs
+++ b/src/v4_20/riscv64/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -212,57 +212,57 @@ pub const RTEXT_FILTER_VF: u32 = 1;
 pub const RTEXT_FILTER_BRVLAN: u32 = 2;
 pub const RTEXT_FILTER_BRVLAN_COMPRESSED: u32 = 4;
 pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -271,7 +271,7 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug)]
 pub struct sysinfo {
@@ -288,21 +288,21 @@ pub pad: __u16,
 pub totalhigh: __kernel_ulong_t,
 pub freehigh: __kernel_ulong_t,
 pub mem_unit: __u32,
-pub _f: __IncompleteArrayField<::std::os::raw::c_char>,
+pub _f: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[repr(align(8))]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -318,7 +318,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -342,16 +342,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2028,21 +2028,21 @@ __RTM_MAX = 103,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNICAST;
@@ -2135,10 +2135,10 @@ __RTA_MAX = 30,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2239,29 +2239,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_ADDRESS;
@@ -2285,10 +2285,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2333,14 +2333,14 @@ __TCA_MAX = 15,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_SRCADDR;
@@ -2394,9 +2394,9 @@ __RTNLGRP_MAX = 32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_TAB;

--- a/src/v4_4/mips/general.rs
+++ b/src/v4_4/mips/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,61 +18,61 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
 #[repr(C)]
-pub struct __BindgenUnionField<T>(::std::marker::PhantomData<T>);
+pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
 impl<T> __BindgenUnionField<T> {
 #[inline]
 pub const fn new() -> Self {
-__BindgenUnionField(::std::marker::PhantomData)
+__BindgenUnionField(::core::marker::PhantomData)
 }
 #[inline]
 pub unsafe fn as_ref(&self) -> &T {
-::std::mem::transmute(self)
+::core::mem::transmute(self)
 }
 #[inline]
 pub unsafe fn as_mut(&mut self) -> &mut T {
-::std::mem::transmute(self)
+::core::mem::transmute(self)
 }
 }
-impl<T> ::std::default::Default for __BindgenUnionField<T> {
+impl<T> ::core::default::Default for __BindgenUnionField<T> {
 #[inline]
 fn default() -> Self {
 Self::new()
 }
 }
-impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
+impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
 #[inline]
 fn clone(&self) -> Self {
 Self::new()
 }
 }
-impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
+impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__BindgenUnionField")
 }
 }
-impl<T> ::std::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::std::hash::Hasher>(&self, _state: &mut H) {}
+impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
+fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
 }
-impl<T> ::std::cmp::PartialEq for __BindgenUnionField<T> {
+impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
 fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
 true
 }
 }
-impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
+impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 pub const LINUX_VERSION_CODE: u32 = 263168;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
@@ -1899,56 +1899,56 @@ pub const TFD_NONBLOCK: u32 = 128;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 524416;
 pub const TFD_CREATE_FLAGS: u32 = 524416;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_daddr_t = ::std::os::raw::c_long;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_daddr_t = crate::ctypes::c_long;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_long; 2usize],
+pub val: [crate::ctypes::c_long; 2usize],
 }
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_int;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_int;
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -1960,25 +1960,25 @@ pub type __wsum = __u32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
-pub l_sysid: ::std::os::raw::c_long,
+pub l_sysid: crate::ctypes::c_long,
 pub l_pid: __kernel_pid_t,
-pub pad: [::std::os::raw::c_long; 4usize],
+pub pad: [crate::ctypes::c_long; 4usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -1999,16 +1999,16 @@ pub minlen: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2019,16 +2019,16 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[repr(align(4))]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2103,7 +2103,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2146,7 +2146,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2156,7 +2156,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2173,7 +2173,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2183,7 +2183,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2210,9 +2210,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2235,15 +2235,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2254,8 +2254,8 @@ pub tv_usec: __kernel_suseconds_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2304,68 +2304,68 @@ pub rlim_max: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigset_t {
-pub sig: [::std::os::raw::c_ulong; 4usize],
+pub sig: [crate::ctypes::c_ulong; 4usize],
 }
-pub type old_sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type old_sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaction {
-pub sa_flags: ::std::os::raw::c_uint,
+pub sa_flags: crate::ctypes::c_uint,
 pub sa_handler: __sighandler_t,
 pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
+pub ss_sp: *mut crate::ctypes::c_void,
 pub ss_size: size_t,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_flags: crate::ctypes::c_int,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 13usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 13usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
 pub struct siginfo {
-pub si_signo: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub __pad0: __IncompleteArrayField<::std::os::raw::c_int>,
+pub si_signo: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub __pad0: __IncompleteArrayField<crate::ctypes::c_int>,
 pub _sifields: siginfo__bindgen_ty_1,
 }
 #[repr(C)]
 pub struct siginfo__bindgen_ty_1 {
-pub _pad: __BindgenUnionField<[::std::os::raw::c_int; 29usize]>,
+pub _pad: __BindgenUnionField<[crate::ctypes::c_int; 29usize]>,
 pub _kill: __BindgenUnionField<siginfo__bindgen_ty_1__bindgen_ty_1>,
 pub _timer: __BindgenUnionField<siginfo__bindgen_ty_1__bindgen_ty_2>,
 pub _rt: __BindgenUnionField<siginfo__bindgen_ty_1__bindgen_ty_3>,
@@ -2385,10 +2385,10 @@ pub _uid: __kernel_uid32_t,
 #[repr(C)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
-pub _pad: __IncompleteArrayField<::std::os::raw::c_char>,
+pub _overrun: crate::ctypes::c_int,
+pub _pad: __IncompleteArrayField<crate::ctypes::c_char>,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2402,7 +2402,7 @@ pub _sigval: sigval_t,
 pub struct siginfo__bindgen_ty_1__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
@@ -2411,39 +2411,39 @@ pub _stime: __kernel_clock_t,
 pub struct siginfo__bindgen_ty_1__bindgen_ty_5 {
 pub _pid: __kernel_pid_t,
 pub _utime: __kernel_clock_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_6 {
-pub _addr: *mut ::std::os::raw::c_void,
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr: *mut crate::ctypes::c_void,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: siginfo__bindgen_ty_1__bindgen_ty_6__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_6__bindgen_ty_1 {
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_7 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_8 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 pub type siginfo_t = siginfo;
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2481,49 +2481,49 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sgttyb {
-pub sg_ispeed: ::std::os::raw::c_char,
-pub sg_ospeed: ::std::os::raw::c_char,
-pub sg_erase: ::std::os::raw::c_char,
-pub sg_kill: ::std::os::raw::c_char,
-pub sg_flags: ::std::os::raw::c_int,
+pub sg_ispeed: crate::ctypes::c_char,
+pub sg_ospeed: crate::ctypes::c_char,
+pub sg_erase: crate::ctypes::c_char,
+pub sg_kill: crate::ctypes::c_char,
+pub sg_flags: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tchars {
-pub t_intrc: ::std::os::raw::c_char,
-pub t_quitc: ::std::os::raw::c_char,
-pub t_startc: ::std::os::raw::c_char,
-pub t_stopc: ::std::os::raw::c_char,
-pub t_eofc: ::std::os::raw::c_char,
-pub t_brkc: ::std::os::raw::c_char,
+pub t_intrc: crate::ctypes::c_char,
+pub t_quitc: crate::ctypes::c_char,
+pub t_startc: crate::ctypes::c_char,
+pub t_stopc: crate::ctypes::c_char,
+pub t_eofc: crate::ctypes::c_char,
+pub t_brkc: crate::ctypes::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ltchars {
-pub t_suspc: ::std::os::raw::c_char,
-pub t_dsuspc: ::std::os::raw::c_char,
-pub t_rprntc: ::std::os::raw::c_char,
-pub t_flushc: ::std::os::raw::c_char,
-pub t_werasc: ::std::os::raw::c_char,
-pub t_lnextc: ::std::os::raw::c_char,
+pub t_suspc: crate::ctypes::c_char,
+pub t_dsuspc: crate::ctypes::c_char,
+pub t_rprntc: crate::ctypes::c_char,
+pub t_flushc: crate::ctypes::c_char,
+pub t_werasc: crate::ctypes::c_char,
+pub t_lnextc: crate::ctypes::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_char,
-pub c_cc: [::std::os::raw::c_uchar; 23usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_char,
+pub c_cc: [crate::ctypes::c_uchar; 23usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2536,100 +2536,100 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr {
 pub __storage: __kernel_sockaddr_storage,
 }
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulonglong,
-pub d_off: ::std::os::raw::c_longlong,
+pub d_ino: crate::ctypes::c_ulonglong,
+pub d_off: crate::ctypes::c_longlong,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_uint,
-pub st_pad1: [::std::os::raw::c_long; 3usize],
+pub st_dev: crate::ctypes::c_uint,
+pub st_pad1: [crate::ctypes::c_long; 3usize],
 pub st_ino: __kernel_ino_t,
 pub st_mode: __kernel_mode_t,
 pub st_nlink: __u32,
 pub st_uid: __kernel_uid_t,
 pub st_gid: __kernel_gid_t,
-pub st_rdev: ::std::os::raw::c_uint,
-pub st_pad2: [::std::os::raw::c_long; 2usize],
+pub st_rdev: crate::ctypes::c_uint,
+pub st_pad2: [crate::ctypes::c_long; 2usize],
 pub st_size: __kernel_off_t,
-pub st_pad3: ::std::os::raw::c_long,
+pub st_pad3: crate::ctypes::c_long,
 pub st_atime: __kernel_time_t,
-pub st_atime_nsec: ::std::os::raw::c_long,
+pub st_atime_nsec: crate::ctypes::c_long,
 pub st_mtime: __kernel_time_t,
-pub st_mtime_nsec: ::std::os::raw::c_long,
+pub st_mtime_nsec: crate::ctypes::c_long,
 pub st_ctime: __kernel_time_t,
-pub st_ctime_nsec: ::std::os::raw::c_long,
-pub st_blksize: ::std::os::raw::c_long,
-pub st_blocks: ::std::os::raw::c_long,
-pub st_pad4: [::std::os::raw::c_long; 14usize],
+pub st_ctime_nsec: crate::ctypes::c_long,
+pub st_blksize: crate::ctypes::c_long,
+pub st_blocks: crate::ctypes::c_long,
+pub st_pad4: [crate::ctypes::c_long; 14usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat64 {
-pub st_dev: ::std::os::raw::c_ulong,
-pub st_pad0: [::std::os::raw::c_ulong; 3usize],
-pub st_ino: ::std::os::raw::c_ulonglong,
+pub st_dev: crate::ctypes::c_ulong,
+pub st_pad0: [crate::ctypes::c_ulong; 3usize],
+pub st_ino: crate::ctypes::c_ulonglong,
 pub st_mode: __kernel_mode_t,
 pub st_nlink: __u32,
 pub st_uid: __kernel_uid_t,
 pub st_gid: __kernel_gid_t,
-pub st_rdev: ::std::os::raw::c_ulong,
-pub st_pad1: [::std::os::raw::c_ulong; 3usize],
-pub st_size: ::std::os::raw::c_longlong,
+pub st_rdev: crate::ctypes::c_ulong,
+pub st_pad1: [crate::ctypes::c_ulong; 3usize],
+pub st_size: crate::ctypes::c_longlong,
 pub st_atime: __kernel_time_t,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
 pub st_mtime: __kernel_time_t,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
 pub st_ctime: __kernel_time_t,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub st_blksize: ::std::os::raw::c_ulong,
-pub st_pad2: ::std::os::raw::c_ulong,
-pub st_blocks: ::std::os::raw::c_longlong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub st_blksize: crate::ctypes::c_ulong,
+pub st_pad2: crate::ctypes::c_ulong,
+pub st_blocks: crate::ctypes::c_longlong,
 }
 pub type fsid_t = __kernel_fsid_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct statfs {
-pub f_type: ::std::os::raw::c_long,
-pub f_bsize: ::std::os::raw::c_long,
-pub f_frsize: ::std::os::raw::c_long,
-pub f_blocks: ::std::os::raw::c_long,
-pub f_bfree: ::std::os::raw::c_long,
-pub f_files: ::std::os::raw::c_long,
-pub f_ffree: ::std::os::raw::c_long,
-pub f_bavail: ::std::os::raw::c_long,
+pub f_type: crate::ctypes::c_long,
+pub f_bsize: crate::ctypes::c_long,
+pub f_frsize: crate::ctypes::c_long,
+pub f_blocks: crate::ctypes::c_long,
+pub f_bfree: crate::ctypes::c_long,
+pub f_files: crate::ctypes::c_long,
+pub f_ffree: crate::ctypes::c_long,
+pub f_bavail: crate::ctypes::c_long,
 pub f_fsid: __kernel_fsid_t,
-pub f_namelen: ::std::os::raw::c_long,
-pub f_flags: ::std::os::raw::c_long,
-pub f_spare: [::std::os::raw::c_long; 5usize],
+pub f_namelen: crate::ctypes::c_long,
+pub f_flags: crate::ctypes::c_long,
+pub f_spare: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v4_4/mips/netlink.rs
+++ b/src/v4_4/mips/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -194,56 +194,56 @@ pub const RTEXT_FILTER_VF: u32 = 1;
 pub const RTEXT_FILTER_BRVLAN: u32 = 2;
 pub const RTEXT_FILTER_BRVLAN_COMPRESSED: u32 = 4;
 pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_daddr_t = ::std::os::raw::c_long;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_daddr_t = crate::ctypes::c_long;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_long; 2usize],
+pub val: [crate::ctypes::c_long; 2usize],
 }
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_int;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_int;
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -268,21 +268,21 @@ pub pad: __u16,
 pub totalhigh: __kernel_ulong_t,
 pub freehigh: __kernel_ulong_t,
 pub mem_unit: __u32,
-pub _f: [::std::os::raw::c_char; 8usize],
+pub _f: [crate::ctypes::c_char; 8usize],
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[repr(align(4))]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -298,7 +298,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 #[repr(C)]
@@ -309,16 +309,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -1588,21 +1588,21 @@ __RTM_MAX = 91,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_35 = _bindgen_ty_35::RTN_UNICAST;
@@ -1688,10 +1688,10 @@ __RTA_MAX = 23,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -1790,29 +1790,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_37 = _bindgen_ty_37::PREFIX_ADDRESS;
@@ -1836,10 +1836,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -1872,14 +1872,14 @@ __TCA_MAX = 9,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_39 = _bindgen_ty_39::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_39 = _bindgen_ty_39::NDUSEROPT_SRCADDR;
@@ -1930,7 +1930,7 @@ __RTNLGRP_MAX = 29,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }

--- a/src/v4_4/mips64/general.rs
+++ b/src/v4_4/mips64/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,61 +18,61 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
 #[repr(C)]
-pub struct __BindgenUnionField<T>(::std::marker::PhantomData<T>);
+pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
 impl<T> __BindgenUnionField<T> {
 #[inline]
 pub const fn new() -> Self {
-__BindgenUnionField(::std::marker::PhantomData)
+__BindgenUnionField(::core::marker::PhantomData)
 }
 #[inline]
 pub unsafe fn as_ref(&self) -> &T {
-::std::mem::transmute(self)
+::core::mem::transmute(self)
 }
 #[inline]
 pub unsafe fn as_mut(&mut self) -> &mut T {
-::std::mem::transmute(self)
+::core::mem::transmute(self)
 }
 }
-impl<T> ::std::default::Default for __BindgenUnionField<T> {
+impl<T> ::core::default::Default for __BindgenUnionField<T> {
 #[inline]
 fn default() -> Self {
 Self::new()
 }
 }
-impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
+impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
 #[inline]
 fn clone(&self) -> Self {
 Self::new()
 }
 }
-impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
+impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__BindgenUnionField")
 }
 }
-impl<T> ::std::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::std::hash::Hasher>(&self, _state: &mut H) {}
+impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
+fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
 }
-impl<T> ::std::cmp::PartialEq for __BindgenUnionField<T> {
+impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
 fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
 true
 }
 }
-impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
+impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 pub const LINUX_VERSION_CODE: u32 = 263168;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
@@ -1859,56 +1859,56 @@ pub const TFD_NONBLOCK: u32 = 128;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 524416;
 pub const TFD_CREATE_FLAGS: u32 = 524416;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_long;
-pub type __u64 = ::std::os::raw::c_ulong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_long;
+pub type __u64 = crate::ctypes::c_ulong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_daddr_t = ::std::os::raw::c_long;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_daddr_t = crate::ctypes::c_long;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -1920,14 +1920,14 @@ pub type __wsum = __u32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -1935,8 +1935,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -1957,16 +1957,16 @@ pub minlen: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1977,16 +1977,16 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[repr(align(8))]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2061,7 +2061,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2104,7 +2104,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2114,7 +2114,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2131,7 +2131,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2141,7 +2141,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2168,9 +2168,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2193,15 +2193,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2212,8 +2212,8 @@ pub tv_usec: __kernel_suseconds_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2262,68 +2262,68 @@ pub rlim_max: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigset_t {
-pub sig: [::std::os::raw::c_ulong; 2usize],
+pub sig: [crate::ctypes::c_ulong; 2usize],
 }
-pub type old_sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type old_sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaction {
-pub sa_flags: ::std::os::raw::c_uint,
+pub sa_flags: crate::ctypes::c_uint,
 pub sa_handler: __sighandler_t,
 pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
+pub ss_sp: *mut crate::ctypes::c_void,
 pub ss_size: size_t,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_flags: crate::ctypes::c_int,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 12usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 12usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
 pub struct siginfo {
-pub si_signo: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub __pad0: [::std::os::raw::c_int; 1usize],
+pub si_signo: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub __pad0: [crate::ctypes::c_int; 1usize],
 pub _sifields: siginfo__bindgen_ty_1,
 }
 #[repr(C)]
 pub struct siginfo__bindgen_ty_1 {
-pub _pad: __BindgenUnionField<[::std::os::raw::c_int; 28usize]>,
+pub _pad: __BindgenUnionField<[crate::ctypes::c_int; 28usize]>,
 pub _kill: __BindgenUnionField<siginfo__bindgen_ty_1__bindgen_ty_1>,
 pub _timer: __BindgenUnionField<siginfo__bindgen_ty_1__bindgen_ty_2>,
 pub _rt: __BindgenUnionField<siginfo__bindgen_ty_1__bindgen_ty_3>,
@@ -2343,10 +2343,10 @@ pub _uid: __kernel_uid32_t,
 #[repr(C)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
-pub _pad: __IncompleteArrayField<::std::os::raw::c_char>,
+pub _overrun: crate::ctypes::c_int,
+pub _pad: __IncompleteArrayField<crate::ctypes::c_char>,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2360,7 +2360,7 @@ pub _sigval: sigval_t,
 pub struct siginfo__bindgen_ty_1__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
@@ -2369,39 +2369,39 @@ pub _stime: __kernel_clock_t,
 pub struct siginfo__bindgen_ty_1__bindgen_ty_5 {
 pub _pid: __kernel_pid_t,
 pub _utime: __kernel_clock_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_6 {
-pub _addr: *mut ::std::os::raw::c_void,
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr: *mut crate::ctypes::c_void,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: siginfo__bindgen_ty_1__bindgen_ty_6__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_6__bindgen_ty_1 {
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_7 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_8 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 pub type siginfo_t = siginfo;
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2439,49 +2439,49 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sgttyb {
-pub sg_ispeed: ::std::os::raw::c_char,
-pub sg_ospeed: ::std::os::raw::c_char,
-pub sg_erase: ::std::os::raw::c_char,
-pub sg_kill: ::std::os::raw::c_char,
-pub sg_flags: ::std::os::raw::c_int,
+pub sg_ispeed: crate::ctypes::c_char,
+pub sg_ospeed: crate::ctypes::c_char,
+pub sg_erase: crate::ctypes::c_char,
+pub sg_kill: crate::ctypes::c_char,
+pub sg_flags: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tchars {
-pub t_intrc: ::std::os::raw::c_char,
-pub t_quitc: ::std::os::raw::c_char,
-pub t_startc: ::std::os::raw::c_char,
-pub t_stopc: ::std::os::raw::c_char,
-pub t_eofc: ::std::os::raw::c_char,
-pub t_brkc: ::std::os::raw::c_char,
+pub t_intrc: crate::ctypes::c_char,
+pub t_quitc: crate::ctypes::c_char,
+pub t_startc: crate::ctypes::c_char,
+pub t_stopc: crate::ctypes::c_char,
+pub t_eofc: crate::ctypes::c_char,
+pub t_brkc: crate::ctypes::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ltchars {
-pub t_suspc: ::std::os::raw::c_char,
-pub t_dsuspc: ::std::os::raw::c_char,
-pub t_rprntc: ::std::os::raw::c_char,
-pub t_flushc: ::std::os::raw::c_char,
-pub t_werasc: ::std::os::raw::c_char,
-pub t_lnextc: ::std::os::raw::c_char,
+pub t_suspc: crate::ctypes::c_char,
+pub t_dsuspc: crate::ctypes::c_char,
+pub t_rprntc: crate::ctypes::c_char,
+pub t_flushc: crate::ctypes::c_char,
+pub t_werasc: crate::ctypes::c_char,
+pub t_lnextc: crate::ctypes::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_char,
-pub c_cc: [::std::os::raw::c_uchar; 23usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_char,
+pub c_cc: [crate::ctypes::c_uchar; 23usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2494,92 +2494,92 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr {
 pub __storage: __kernel_sockaddr_storage,
 }
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulong,
-pub d_off: ::std::os::raw::c_long,
+pub d_ino: crate::ctypes::c_ulong,
+pub d_off: crate::ctypes::c_long,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_uint,
-pub st_pad0: [::std::os::raw::c_uint; 3usize],
-pub st_ino: ::std::os::raw::c_ulong,
+pub st_dev: crate::ctypes::c_uint,
+pub st_pad0: [crate::ctypes::c_uint; 3usize],
+pub st_ino: crate::ctypes::c_ulong,
 pub st_mode: __kernel_mode_t,
 pub st_nlink: __u32,
 pub st_uid: __kernel_uid_t,
 pub st_gid: __kernel_gid_t,
-pub st_rdev: ::std::os::raw::c_uint,
-pub st_pad1: [::std::os::raw::c_uint; 3usize],
+pub st_rdev: crate::ctypes::c_uint,
+pub st_pad1: [crate::ctypes::c_uint; 3usize],
 pub st_size: __kernel_off_t,
-pub st_atime: ::std::os::raw::c_uint,
-pub st_atime_nsec: ::std::os::raw::c_uint,
-pub st_mtime: ::std::os::raw::c_uint,
-pub st_mtime_nsec: ::std::os::raw::c_uint,
-pub st_ctime: ::std::os::raw::c_uint,
-pub st_ctime_nsec: ::std::os::raw::c_uint,
-pub st_blksize: ::std::os::raw::c_uint,
-pub st_pad2: ::std::os::raw::c_uint,
-pub st_blocks: ::std::os::raw::c_ulong,
+pub st_atime: crate::ctypes::c_uint,
+pub st_atime_nsec: crate::ctypes::c_uint,
+pub st_mtime: crate::ctypes::c_uint,
+pub st_mtime_nsec: crate::ctypes::c_uint,
+pub st_ctime: crate::ctypes::c_uint,
+pub st_ctime_nsec: crate::ctypes::c_uint,
+pub st_blksize: crate::ctypes::c_uint,
+pub st_pad2: crate::ctypes::c_uint,
+pub st_blocks: crate::ctypes::c_ulong,
 }
 pub type fsid_t = __kernel_fsid_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct statfs {
-pub f_type: ::std::os::raw::c_long,
-pub f_bsize: ::std::os::raw::c_long,
-pub f_frsize: ::std::os::raw::c_long,
-pub f_blocks: ::std::os::raw::c_long,
-pub f_bfree: ::std::os::raw::c_long,
-pub f_files: ::std::os::raw::c_long,
-pub f_ffree: ::std::os::raw::c_long,
-pub f_bavail: ::std::os::raw::c_long,
+pub f_type: crate::ctypes::c_long,
+pub f_bsize: crate::ctypes::c_long,
+pub f_frsize: crate::ctypes::c_long,
+pub f_blocks: crate::ctypes::c_long,
+pub f_bfree: crate::ctypes::c_long,
+pub f_files: crate::ctypes::c_long,
+pub f_ffree: crate::ctypes::c_long,
+pub f_bavail: crate::ctypes::c_long,
 pub f_fsid: __kernel_fsid_t,
-pub f_namelen: ::std::os::raw::c_long,
-pub f_flags: ::std::os::raw::c_long,
-pub f_spare: [::std::os::raw::c_long; 5usize],
+pub f_namelen: crate::ctypes::c_long,
+pub f_flags: crate::ctypes::c_long,
+pub f_spare: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct statfs64 {
-pub f_type: ::std::os::raw::c_long,
-pub f_bsize: ::std::os::raw::c_long,
-pub f_frsize: ::std::os::raw::c_long,
-pub f_blocks: ::std::os::raw::c_long,
-pub f_bfree: ::std::os::raw::c_long,
-pub f_files: ::std::os::raw::c_long,
-pub f_ffree: ::std::os::raw::c_long,
-pub f_bavail: ::std::os::raw::c_long,
+pub f_type: crate::ctypes::c_long,
+pub f_bsize: crate::ctypes::c_long,
+pub f_frsize: crate::ctypes::c_long,
+pub f_blocks: crate::ctypes::c_long,
+pub f_bfree: crate::ctypes::c_long,
+pub f_files: crate::ctypes::c_long,
+pub f_ffree: crate::ctypes::c_long,
+pub f_bavail: crate::ctypes::c_long,
 pub f_fsid: __kernel_fsid_t,
-pub f_namelen: ::std::os::raw::c_long,
-pub f_flags: ::std::os::raw::c_long,
-pub f_spare: [::std::os::raw::c_long; 5usize],
+pub f_namelen: crate::ctypes::c_long,
+pub f_flags: crate::ctypes::c_long,
+pub f_spare: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v4_4/mips64/netlink.rs
+++ b/src/v4_4/mips64/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -194,56 +194,56 @@ pub const RTEXT_FILTER_VF: u32 = 1;
 pub const RTEXT_FILTER_BRVLAN: u32 = 2;
 pub const RTEXT_FILTER_BRVLAN_COMPRESSED: u32 = 4;
 pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_long;
-pub type __u64 = ::std::os::raw::c_ulong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_long;
+pub type __u64 = crate::ctypes::c_ulong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_daddr_t = ::std::os::raw::c_long;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_daddr_t = crate::ctypes::c_long;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -268,21 +268,21 @@ pub pad: __u16,
 pub totalhigh: __kernel_ulong_t,
 pub freehigh: __kernel_ulong_t,
 pub mem_unit: __u32,
-pub _f: __IncompleteArrayField<::std::os::raw::c_char>,
+pub _f: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[repr(align(8))]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -298,7 +298,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 #[repr(C)]
@@ -309,16 +309,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -1588,21 +1588,21 @@ __RTM_MAX = 91,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_35 = _bindgen_ty_35::RTN_UNICAST;
@@ -1688,10 +1688,10 @@ __RTA_MAX = 23,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -1790,29 +1790,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_37 = _bindgen_ty_37::PREFIX_ADDRESS;
@@ -1836,10 +1836,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -1872,14 +1872,14 @@ __TCA_MAX = 9,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_39 = _bindgen_ty_39::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_39 = _bindgen_ty_39::NDUSEROPT_SRCADDR;
@@ -1930,7 +1930,7 @@ __RTNLGRP_MAX = 29,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }

--- a/src/v5_11/aarch64/general.rs
+++ b/src/v5_11/aarch64/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -2002,58 +2002,58 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_old_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2062,18 +2062,18 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -2081,8 +2081,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -2235,16 +2235,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2254,9 +2254,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2266,10 +2266,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2279,13 +2279,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2364,7 +2364,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2407,7 +2407,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2417,7 +2417,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2434,7 +2434,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2444,7 +2444,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2471,9 +2471,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2496,15 +2496,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2522,7 +2522,7 @@ pub tv_usec: __kernel_long_t,
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_old_timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2540,7 +2540,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2563,8 +2563,8 @@ pub it_value: timeval,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2601,34 +2601,34 @@ pub rlim_max: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigset_t {
-pub sig: [::std::os::raw::c_ulong; 1usize],
+pub sig: [crate::ctypes::c_ulong; 1usize],
 }
-pub type old_sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type old_sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaction {
 pub sa_handler: __sighandler_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2652,9 +2652,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2668,48 +2668,48 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
+pub _addr: *mut crate::ctypes::c_void,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 8usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 8usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 8usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 8usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2720,14 +2720,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2735,22 +2735,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 12usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 12usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -2787,9 +2787,9 @@ pub stx_mnt_id: __u64,
 pub __spare2: __u64,
 pub __spare3: [__u64; 12usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2827,20 +2827,20 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 8usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2853,14 +2853,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2870,36 +2870,36 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulong,
-pub d_off: ::std::os::raw::c_long,
+pub d_ino: crate::ctypes::c_ulong,
+pub d_off: crate::ctypes::c_long,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_nlink: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub st_rdev: ::std::os::raw::c_ulong,
-pub __pad1: ::std::os::raw::c_ulong,
-pub st_size: ::std::os::raw::c_long,
-pub st_blksize: ::std::os::raw::c_int,
-pub __pad2: ::std::os::raw::c_int,
-pub st_blocks: ::std::os::raw::c_long,
-pub st_atime: ::std::os::raw::c_long,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_long,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_long,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub __unused4: ::std::os::raw::c_uint,
-pub __unused5: ::std::os::raw::c_uint,
+pub st_dev: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_nlink: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub st_rdev: crate::ctypes::c_ulong,
+pub __pad1: crate::ctypes::c_ulong,
+pub st_size: crate::ctypes::c_long,
+pub st_blksize: crate::ctypes::c_int,
+pub __pad2: crate::ctypes::c_int,
+pub st_blocks: crate::ctypes::c_long,
+pub st_atime: crate::ctypes::c_long,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_long,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_long,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub __unused4: crate::ctypes::c_uint,
+pub __unused5: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v5_11/aarch64/netlink.rs
+++ b/src/v5_11/aarch64/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -223,9 +223,9 @@ pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
 pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -235,64 +235,64 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_old_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -301,12 +301,12 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -322,7 +322,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -347,16 +347,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2239,21 +2239,21 @@ __RTM_MAX = 115,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNICAST;
@@ -2347,10 +2347,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2451,29 +2451,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_ADDRESS;
@@ -2497,10 +2497,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2547,14 +2547,14 @@ __TCA_MAX = 16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_SRCADDR;
@@ -2610,9 +2610,9 @@ __RTNLGRP_MAX = 34,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_TAB;

--- a/src/v5_11/arm/general.rs
+++ b/src/v5_11/arm/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -2088,58 +2088,58 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_mode_t = ::std::os::raw::c_ushort;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_ushort;
-pub type __kernel_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ushort;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_mode_t = crate::ctypes::c_ushort;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_ushort;
+pub type __kernel_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_dev_t = crate::ctypes::c_ushort;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_pid_t = crate::ctypes::c_int;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_int;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2148,18 +2148,18 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -2167,8 +2167,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -2321,16 +2321,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2340,9 +2340,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2352,10 +2352,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2365,13 +2365,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2450,7 +2450,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2493,7 +2493,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2503,7 +2503,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2520,7 +2520,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2530,7 +2530,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2557,9 +2557,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2582,15 +2582,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2608,7 +2608,7 @@ pub tv_usec: __kernel_long_t,
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_old_timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2626,7 +2626,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2649,8 +2649,8 @@ pub it_value: timeval,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2684,38 +2684,38 @@ pub struct rlimit64 {
 pub rlim_cur: __u64,
 pub rlim_max: __u64,
 }
-pub type sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sigaction {
 pub _u: sigaction__bindgen_ty_1,
 pub sa_mask: sigset_t,
-pub sa_flags: ::std::os::raw::c_ulong,
-pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: ::core::option::Option<unsafe extern "C" fn()>,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigaction__bindgen_ty_1 {
 pub _sa_handler: __sighandler_t,
-pub _sa_sigaction: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int, arg2: *mut siginfo, arg3: *mut ::std::os::raw::c_void)>,
+pub _sa_sigaction: ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int, arg2: *mut siginfo, arg3: *mut crate::ctypes::c_void)>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2739,9 +2739,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2755,48 +2755,48 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
+pub _addr: *mut crate::ctypes::c_void,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 4usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 4usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 4usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 4usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2807,14 +2807,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2822,22 +2822,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 13usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 13usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -2874,9 +2874,9 @@ pub stx_mnt_id: __u64,
 pub __spare2: __u64,
 pub __spare3: [__u64; 12usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2914,20 +2914,20 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 8usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2940,14 +2940,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2957,72 +2957,72 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulonglong,
-pub d_off: ::std::os::raw::c_longlong,
+pub d_ino: crate::ctypes::c_ulonglong,
+pub d_off: crate::ctypes::c_longlong,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __old_kernel_stat {
-pub st_dev: ::std::os::raw::c_ushort,
-pub st_ino: ::std::os::raw::c_ushort,
-pub st_mode: ::std::os::raw::c_ushort,
-pub st_nlink: ::std::os::raw::c_ushort,
-pub st_uid: ::std::os::raw::c_ushort,
-pub st_gid: ::std::os::raw::c_ushort,
-pub st_rdev: ::std::os::raw::c_ushort,
-pub st_size: ::std::os::raw::c_ulong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
+pub st_dev: crate::ctypes::c_ushort,
+pub st_ino: crate::ctypes::c_ushort,
+pub st_mode: crate::ctypes::c_ushort,
+pub st_nlink: crate::ctypes::c_ushort,
+pub st_uid: crate::ctypes::c_ushort,
+pub st_gid: crate::ctypes::c_ushort,
+pub st_rdev: crate::ctypes::c_ushort,
+pub st_size: crate::ctypes::c_ulong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_ushort,
-pub st_nlink: ::std::os::raw::c_ushort,
-pub st_uid: ::std::os::raw::c_ushort,
-pub st_gid: ::std::os::raw::c_ushort,
-pub st_rdev: ::std::os::raw::c_ulong,
-pub st_size: ::std::os::raw::c_ulong,
-pub st_blksize: ::std::os::raw::c_ulong,
-pub st_blocks: ::std::os::raw::c_ulong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub __unused4: ::std::os::raw::c_ulong,
-pub __unused5: ::std::os::raw::c_ulong,
+pub st_dev: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_ushort,
+pub st_nlink: crate::ctypes::c_ushort,
+pub st_uid: crate::ctypes::c_ushort,
+pub st_gid: crate::ctypes::c_ushort,
+pub st_rdev: crate::ctypes::c_ulong,
+pub st_size: crate::ctypes::c_ulong,
+pub st_blksize: crate::ctypes::c_ulong,
+pub st_blocks: crate::ctypes::c_ulong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub __unused4: crate::ctypes::c_ulong,
+pub __unused5: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat64 {
-pub st_dev: ::std::os::raw::c_ulonglong,
-pub __pad0: [::std::os::raw::c_uchar; 4usize],
-pub __st_ino: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_nlink: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_ulong,
-pub st_gid: ::std::os::raw::c_ulong,
-pub st_rdev: ::std::os::raw::c_ulonglong,
-pub __pad3: [::std::os::raw::c_uchar; 4usize],
-pub st_size: ::std::os::raw::c_longlong,
-pub st_blksize: ::std::os::raw::c_ulong,
-pub st_blocks: ::std::os::raw::c_ulonglong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulonglong,
+pub st_dev: crate::ctypes::c_ulonglong,
+pub __pad0: [crate::ctypes::c_uchar; 4usize],
+pub __st_ino: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_nlink: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_ulong,
+pub st_gid: crate::ctypes::c_ulong,
+pub st_rdev: crate::ctypes::c_ulonglong,
+pub __pad3: [crate::ctypes::c_uchar; 4usize],
+pub st_size: crate::ctypes::c_longlong,
+pub st_blksize: crate::ctypes::c_ulong,
+pub st_blocks: crate::ctypes::c_ulonglong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulonglong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v5_11/arm/netlink.rs
+++ b/src/v5_11/arm/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -223,9 +223,9 @@ pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
 pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -235,64 +235,64 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_mode_t = ::std::os::raw::c_ushort;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_ushort;
-pub type __kernel_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ushort;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_mode_t = crate::ctypes::c_ushort;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_ushort;
+pub type __kernel_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_dev_t = crate::ctypes::c_ushort;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_pid_t = crate::ctypes::c_int;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_int;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -301,12 +301,12 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -322,7 +322,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -347,16 +347,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2239,21 +2239,21 @@ __RTM_MAX = 115,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNICAST;
@@ -2347,10 +2347,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2451,29 +2451,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_ADDRESS;
@@ -2497,10 +2497,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2547,14 +2547,14 @@ __TCA_MAX = 16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_SRCADDR;
@@ -2610,9 +2610,9 @@ __RTNLGRP_MAX = 34,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_TAB;

--- a/src/v5_11/mips/general.rs
+++ b/src/v5_11/mips/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -2229,58 +2229,58 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 524416;
 pub const TFD_CREATE_FLAGS: u32 = 524416;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_daddr_t = ::std::os::raw::c_long;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_daddr_t = crate::ctypes::c_long;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_int;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2289,29 +2289,29 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
-pub l_sysid: ::std::os::raw::c_long,
+pub l_sysid: crate::ctypes::c_long,
 pub l_pid: __kernel_pid_t,
-pub pad: [::std::os::raw::c_long; 4usize],
+pub pad: [crate::ctypes::c_long; 4usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -2464,16 +2464,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2483,9 +2483,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2495,10 +2495,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2508,13 +2508,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2593,7 +2593,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2636,7 +2636,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2646,7 +2646,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2663,7 +2663,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2673,7 +2673,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2700,9 +2700,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2725,15 +2725,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2751,7 +2751,7 @@ pub tv_usec: __kernel_long_t,
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_old_timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2769,7 +2769,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2792,8 +2792,8 @@ pub it_value: timeval,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2830,33 +2830,33 @@ pub rlim_max: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigset_t {
-pub sig: [::std::os::raw::c_ulong; 4usize],
+pub sig: [crate::ctypes::c_ulong; 4usize],
 }
-pub type old_sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type old_sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaction {
-pub sa_flags: ::std::os::raw::c_uint,
+pub sa_flags: crate::ctypes::c_uint,
 pub sa_handler: __sighandler_t,
 pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
+pub ss_sp: *mut crate::ctypes::c_void,
 pub ss_size: size_t,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_flags: crate::ctypes::c_int,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2880,9 +2880,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2896,48 +2896,48 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
+pub _addr: *mut crate::ctypes::c_void,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 4usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 4usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 4usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 4usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2948,14 +2948,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2963,22 +2963,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 13usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 13usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -3015,9 +3015,9 @@ pub stx_mnt_id: __u64,
 pub __spare2: __u64,
 pub __spare3: [__u64; 12usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -3055,49 +3055,49 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sgttyb {
-pub sg_ispeed: ::std::os::raw::c_char,
-pub sg_ospeed: ::std::os::raw::c_char,
-pub sg_erase: ::std::os::raw::c_char,
-pub sg_kill: ::std::os::raw::c_char,
-pub sg_flags: ::std::os::raw::c_int,
+pub sg_ispeed: crate::ctypes::c_char,
+pub sg_ospeed: crate::ctypes::c_char,
+pub sg_erase: crate::ctypes::c_char,
+pub sg_kill: crate::ctypes::c_char,
+pub sg_flags: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tchars {
-pub t_intrc: ::std::os::raw::c_char,
-pub t_quitc: ::std::os::raw::c_char,
-pub t_startc: ::std::os::raw::c_char,
-pub t_stopc: ::std::os::raw::c_char,
-pub t_eofc: ::std::os::raw::c_char,
-pub t_brkc: ::std::os::raw::c_char,
+pub t_intrc: crate::ctypes::c_char,
+pub t_quitc: crate::ctypes::c_char,
+pub t_startc: crate::ctypes::c_char,
+pub t_stopc: crate::ctypes::c_char,
+pub t_eofc: crate::ctypes::c_char,
+pub t_brkc: crate::ctypes::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ltchars {
-pub t_suspc: ::std::os::raw::c_char,
-pub t_dsuspc: ::std::os::raw::c_char,
-pub t_rprntc: ::std::os::raw::c_char,
-pub t_flushc: ::std::os::raw::c_char,
-pub t_werasc: ::std::os::raw::c_char,
-pub t_lnextc: ::std::os::raw::c_char,
+pub t_suspc: crate::ctypes::c_char,
+pub t_dsuspc: crate::ctypes::c_char,
+pub t_rprntc: crate::ctypes::c_char,
+pub t_flushc: crate::ctypes::c_char,
+pub t_werasc: crate::ctypes::c_char,
+pub t_lnextc: crate::ctypes::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_char,
-pub c_cc: [::std::os::raw::c_uchar; 23usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_char,
+pub c_cc: [crate::ctypes::c_uchar; 23usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3110,14 +3110,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3127,76 +3127,76 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulonglong,
-pub d_off: ::std::os::raw::c_longlong,
+pub d_ino: crate::ctypes::c_ulonglong,
+pub d_off: crate::ctypes::c_longlong,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_uint,
-pub st_pad1: [::std::os::raw::c_long; 3usize],
+pub st_dev: crate::ctypes::c_uint,
+pub st_pad1: [crate::ctypes::c_long; 3usize],
 pub st_ino: __kernel_ino_t,
 pub st_mode: __kernel_mode_t,
 pub st_nlink: __u32,
 pub st_uid: __kernel_uid_t,
 pub st_gid: __kernel_gid_t,
-pub st_rdev: ::std::os::raw::c_uint,
-pub st_pad2: [::std::os::raw::c_long; 2usize],
-pub st_size: ::std::os::raw::c_long,
-pub st_pad3: ::std::os::raw::c_long,
-pub st_atime: ::std::os::raw::c_long,
-pub st_atime_nsec: ::std::os::raw::c_long,
-pub st_mtime: ::std::os::raw::c_long,
-pub st_mtime_nsec: ::std::os::raw::c_long,
-pub st_ctime: ::std::os::raw::c_long,
-pub st_ctime_nsec: ::std::os::raw::c_long,
-pub st_blksize: ::std::os::raw::c_long,
-pub st_blocks: ::std::os::raw::c_long,
-pub st_pad4: [::std::os::raw::c_long; 14usize],
+pub st_rdev: crate::ctypes::c_uint,
+pub st_pad2: [crate::ctypes::c_long; 2usize],
+pub st_size: crate::ctypes::c_long,
+pub st_pad3: crate::ctypes::c_long,
+pub st_atime: crate::ctypes::c_long,
+pub st_atime_nsec: crate::ctypes::c_long,
+pub st_mtime: crate::ctypes::c_long,
+pub st_mtime_nsec: crate::ctypes::c_long,
+pub st_ctime: crate::ctypes::c_long,
+pub st_ctime_nsec: crate::ctypes::c_long,
+pub st_blksize: crate::ctypes::c_long,
+pub st_blocks: crate::ctypes::c_long,
+pub st_pad4: [crate::ctypes::c_long; 14usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat64 {
-pub st_dev: ::std::os::raw::c_ulong,
-pub st_pad0: [::std::os::raw::c_ulong; 3usize],
-pub st_ino: ::std::os::raw::c_ulonglong,
+pub st_dev: crate::ctypes::c_ulong,
+pub st_pad0: [crate::ctypes::c_ulong; 3usize],
+pub st_ino: crate::ctypes::c_ulonglong,
 pub st_mode: __kernel_mode_t,
 pub st_nlink: __u32,
 pub st_uid: __kernel_uid_t,
 pub st_gid: __kernel_gid_t,
-pub st_rdev: ::std::os::raw::c_ulong,
-pub st_pad1: [::std::os::raw::c_ulong; 3usize],
-pub st_size: ::std::os::raw::c_longlong,
-pub st_atime: ::std::os::raw::c_long,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_long,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_long,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub st_blksize: ::std::os::raw::c_ulong,
-pub st_pad2: ::std::os::raw::c_ulong,
-pub st_blocks: ::std::os::raw::c_longlong,
+pub st_rdev: crate::ctypes::c_ulong,
+pub st_pad1: [crate::ctypes::c_ulong; 3usize],
+pub st_size: crate::ctypes::c_longlong,
+pub st_atime: crate::ctypes::c_long,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_long,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_long,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub st_blksize: crate::ctypes::c_ulong,
+pub st_pad2: crate::ctypes::c_ulong,
+pub st_blocks: crate::ctypes::c_longlong,
 }
 pub type fsid_t = __kernel_fsid_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct statfs {
-pub f_type: ::std::os::raw::c_long,
-pub f_bsize: ::std::os::raw::c_long,
-pub f_frsize: ::std::os::raw::c_long,
-pub f_blocks: ::std::os::raw::c_long,
-pub f_bfree: ::std::os::raw::c_long,
-pub f_files: ::std::os::raw::c_long,
-pub f_ffree: ::std::os::raw::c_long,
-pub f_bavail: ::std::os::raw::c_long,
+pub f_type: crate::ctypes::c_long,
+pub f_bsize: crate::ctypes::c_long,
+pub f_frsize: crate::ctypes::c_long,
+pub f_blocks: crate::ctypes::c_long,
+pub f_bfree: crate::ctypes::c_long,
+pub f_files: crate::ctypes::c_long,
+pub f_ffree: crate::ctypes::c_long,
+pub f_bavail: crate::ctypes::c_long,
 pub f_fsid: __kernel_fsid_t,
-pub f_namelen: ::std::os::raw::c_long,
-pub f_flags: ::std::os::raw::c_long,
-pub f_spare: [::std::os::raw::c_long; 5usize],
+pub f_namelen: crate::ctypes::c_long,
+pub f_flags: crate::ctypes::c_long,
+pub f_spare: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v5_11/mips/netlink.rs
+++ b/src/v5_11/mips/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -232,9 +232,9 @@ pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
 pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -244,64 +244,64 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_daddr_t = ::std::os::raw::c_long;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_daddr_t = crate::ctypes::c_long;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_int;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -310,12 +310,12 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -331,7 +331,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -356,16 +356,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2248,21 +2248,21 @@ __RTM_MAX = 115,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNICAST;
@@ -2356,10 +2356,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2460,29 +2460,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_ADDRESS;
@@ -2506,10 +2506,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2556,14 +2556,14 @@ __TCA_MAX = 16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_SRCADDR;
@@ -2619,9 +2619,9 @@ __RTNLGRP_MAX = 34,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_TAB;

--- a/src/v5_11/mips64/general.rs
+++ b/src/v5_11/mips64/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -2167,58 +2167,58 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 524416;
 pub const TFD_CREATE_FLAGS: u32 = 524416;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_long;
-pub type __u64 = ::std::os::raw::c_ulong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_long;
+pub type __u64 = crate::ctypes::c_ulong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_daddr_t = ::std::os::raw::c_long;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_daddr_t = crate::ctypes::c_long;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2227,18 +2227,18 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -2246,8 +2246,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -2400,16 +2400,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2419,9 +2419,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2431,10 +2431,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2444,13 +2444,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2529,7 +2529,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2572,7 +2572,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2582,7 +2582,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2599,7 +2599,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2609,7 +2609,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2636,9 +2636,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2661,15 +2661,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2687,7 +2687,7 @@ pub tv_usec: __kernel_long_t,
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_old_timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2705,7 +2705,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2728,8 +2728,8 @@ pub it_value: timeval,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2766,33 +2766,33 @@ pub rlim_max: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigset_t {
-pub sig: [::std::os::raw::c_ulong; 2usize],
+pub sig: [crate::ctypes::c_ulong; 2usize],
 }
-pub type old_sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type old_sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaction {
-pub sa_flags: ::std::os::raw::c_uint,
+pub sa_flags: crate::ctypes::c_uint,
 pub sa_handler: __sighandler_t,
 pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
+pub ss_sp: *mut crate::ctypes::c_void,
 pub ss_size: size_t,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_flags: crate::ctypes::c_int,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2816,9 +2816,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2832,48 +2832,48 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
+pub _addr: *mut crate::ctypes::c_void,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 8usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 8usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 8usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 8usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2884,14 +2884,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2899,22 +2899,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 12usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 12usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -2951,9 +2951,9 @@ pub stx_mnt_id: __u64,
 pub __spare2: __u64,
 pub __spare3: [__u64; 12usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2991,49 +2991,49 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sgttyb {
-pub sg_ispeed: ::std::os::raw::c_char,
-pub sg_ospeed: ::std::os::raw::c_char,
-pub sg_erase: ::std::os::raw::c_char,
-pub sg_kill: ::std::os::raw::c_char,
-pub sg_flags: ::std::os::raw::c_int,
+pub sg_ispeed: crate::ctypes::c_char,
+pub sg_ospeed: crate::ctypes::c_char,
+pub sg_erase: crate::ctypes::c_char,
+pub sg_kill: crate::ctypes::c_char,
+pub sg_flags: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tchars {
-pub t_intrc: ::std::os::raw::c_char,
-pub t_quitc: ::std::os::raw::c_char,
-pub t_startc: ::std::os::raw::c_char,
-pub t_stopc: ::std::os::raw::c_char,
-pub t_eofc: ::std::os::raw::c_char,
-pub t_brkc: ::std::os::raw::c_char,
+pub t_intrc: crate::ctypes::c_char,
+pub t_quitc: crate::ctypes::c_char,
+pub t_startc: crate::ctypes::c_char,
+pub t_stopc: crate::ctypes::c_char,
+pub t_eofc: crate::ctypes::c_char,
+pub t_brkc: crate::ctypes::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ltchars {
-pub t_suspc: ::std::os::raw::c_char,
-pub t_dsuspc: ::std::os::raw::c_char,
-pub t_rprntc: ::std::os::raw::c_char,
-pub t_flushc: ::std::os::raw::c_char,
-pub t_werasc: ::std::os::raw::c_char,
-pub t_lnextc: ::std::os::raw::c_char,
+pub t_suspc: crate::ctypes::c_char,
+pub t_dsuspc: crate::ctypes::c_char,
+pub t_rprntc: crate::ctypes::c_char,
+pub t_flushc: crate::ctypes::c_char,
+pub t_werasc: crate::ctypes::c_char,
+pub t_lnextc: crate::ctypes::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_char,
-pub c_cc: [::std::os::raw::c_uchar; 23usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_char,
+pub c_cc: [crate::ctypes::c_uchar; 23usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3046,14 +3046,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3063,68 +3063,68 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulong,
-pub d_off: ::std::os::raw::c_long,
+pub d_ino: crate::ctypes::c_ulong,
+pub d_off: crate::ctypes::c_long,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_uint,
-pub st_pad0: [::std::os::raw::c_uint; 3usize],
-pub st_ino: ::std::os::raw::c_ulong,
+pub st_dev: crate::ctypes::c_uint,
+pub st_pad0: [crate::ctypes::c_uint; 3usize],
+pub st_ino: crate::ctypes::c_ulong,
 pub st_mode: __kernel_mode_t,
 pub st_nlink: __u32,
 pub st_uid: __kernel_uid_t,
 pub st_gid: __kernel_gid_t,
-pub st_rdev: ::std::os::raw::c_uint,
-pub st_pad1: [::std::os::raw::c_uint; 3usize],
-pub st_size: ::std::os::raw::c_long,
-pub st_atime: ::std::os::raw::c_uint,
-pub st_atime_nsec: ::std::os::raw::c_uint,
-pub st_mtime: ::std::os::raw::c_uint,
-pub st_mtime_nsec: ::std::os::raw::c_uint,
-pub st_ctime: ::std::os::raw::c_uint,
-pub st_ctime_nsec: ::std::os::raw::c_uint,
-pub st_blksize: ::std::os::raw::c_uint,
-pub st_pad2: ::std::os::raw::c_uint,
-pub st_blocks: ::std::os::raw::c_ulong,
+pub st_rdev: crate::ctypes::c_uint,
+pub st_pad1: [crate::ctypes::c_uint; 3usize],
+pub st_size: crate::ctypes::c_long,
+pub st_atime: crate::ctypes::c_uint,
+pub st_atime_nsec: crate::ctypes::c_uint,
+pub st_mtime: crate::ctypes::c_uint,
+pub st_mtime_nsec: crate::ctypes::c_uint,
+pub st_ctime: crate::ctypes::c_uint,
+pub st_ctime_nsec: crate::ctypes::c_uint,
+pub st_blksize: crate::ctypes::c_uint,
+pub st_pad2: crate::ctypes::c_uint,
+pub st_blocks: crate::ctypes::c_ulong,
 }
 pub type fsid_t = __kernel_fsid_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct statfs {
-pub f_type: ::std::os::raw::c_long,
-pub f_bsize: ::std::os::raw::c_long,
-pub f_frsize: ::std::os::raw::c_long,
-pub f_blocks: ::std::os::raw::c_long,
-pub f_bfree: ::std::os::raw::c_long,
-pub f_files: ::std::os::raw::c_long,
-pub f_ffree: ::std::os::raw::c_long,
-pub f_bavail: ::std::os::raw::c_long,
+pub f_type: crate::ctypes::c_long,
+pub f_bsize: crate::ctypes::c_long,
+pub f_frsize: crate::ctypes::c_long,
+pub f_blocks: crate::ctypes::c_long,
+pub f_bfree: crate::ctypes::c_long,
+pub f_files: crate::ctypes::c_long,
+pub f_ffree: crate::ctypes::c_long,
+pub f_bavail: crate::ctypes::c_long,
 pub f_fsid: __kernel_fsid_t,
-pub f_namelen: ::std::os::raw::c_long,
-pub f_flags: ::std::os::raw::c_long,
-pub f_spare: [::std::os::raw::c_long; 5usize],
+pub f_namelen: crate::ctypes::c_long,
+pub f_flags: crate::ctypes::c_long,
+pub f_spare: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct statfs64 {
-pub f_type: ::std::os::raw::c_long,
-pub f_bsize: ::std::os::raw::c_long,
-pub f_frsize: ::std::os::raw::c_long,
-pub f_blocks: ::std::os::raw::c_long,
-pub f_bfree: ::std::os::raw::c_long,
-pub f_files: ::std::os::raw::c_long,
-pub f_ffree: ::std::os::raw::c_long,
-pub f_bavail: ::std::os::raw::c_long,
+pub f_type: crate::ctypes::c_long,
+pub f_bsize: crate::ctypes::c_long,
+pub f_frsize: crate::ctypes::c_long,
+pub f_blocks: crate::ctypes::c_long,
+pub f_bfree: crate::ctypes::c_long,
+pub f_files: crate::ctypes::c_long,
+pub f_ffree: crate::ctypes::c_long,
+pub f_bavail: crate::ctypes::c_long,
 pub f_fsid: __kernel_fsid_t,
-pub f_namelen: ::std::os::raw::c_long,
-pub f_flags: ::std::os::raw::c_long,
-pub f_spare: [::std::os::raw::c_long; 5usize],
+pub f_namelen: crate::ctypes::c_long,
+pub f_flags: crate::ctypes::c_long,
+pub f_spare: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v5_11/mips64/netlink.rs
+++ b/src/v5_11/mips64/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -232,9 +232,9 @@ pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
 pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -244,64 +244,64 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_long;
-pub type __u64 = ::std::os::raw::c_ulong;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_long;
+pub type __u64 = crate::ctypes::c_ulong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_daddr_t = ::std::os::raw::c_long;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_daddr_t = crate::ctypes::c_long;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -310,12 +310,12 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -331,7 +331,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -356,16 +356,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2248,21 +2248,21 @@ __RTM_MAX = 115,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNICAST;
@@ -2356,10 +2356,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2460,29 +2460,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_ADDRESS;
@@ -2506,10 +2506,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2556,14 +2556,14 @@ __TCA_MAX = 16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_SRCADDR;
@@ -2619,9 +2619,9 @@ __RTNLGRP_MAX = 34,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_TAB;

--- a/src/v5_11/powerpc/general.rs
+++ b/src/v5_11/powerpc/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -2095,16 +2095,16 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Copy, Clone)]
@@ -2114,45 +2114,45 @@ pub u: [__u32; 4usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_long;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_short;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_long;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_short;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2161,18 +2161,18 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -2180,8 +2180,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -2334,16 +2334,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2353,9 +2353,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2365,10 +2365,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2378,13 +2378,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2463,7 +2463,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2506,7 +2506,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2516,7 +2516,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2533,7 +2533,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2543,7 +2543,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2570,9 +2570,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2595,15 +2595,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2621,7 +2621,7 @@ pub tv_usec: __kernel_long_t,
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_old_timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2639,7 +2639,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2662,8 +2662,8 @@ pub it_value: timeval,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2697,51 +2697,51 @@ pub struct rlimit64 {
 pub rlim_cur: __u64,
 pub rlim_max: __u64,
 }
-pub type old_sigset_t = ::std::os::raw::c_ulong;
+pub type old_sigset_t = crate::ctypes::c_ulong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigset_t {
-pub sig: [::std::os::raw::c_ulong; 2usize],
+pub sig: [crate::ctypes::c_ulong; 2usize],
 }
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct old_sigaction {
 pub sa_handler: __sighandler_t,
 pub sa_mask: old_sigset_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaction {
 pub sa_handler: __sighandler_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sig_dbg_op {
-pub dbg_type: ::std::os::raw::c_int,
-pub dbg_value: ::std::os::raw::c_ulong,
+pub dbg_type: crate::ctypes::c_int,
+pub dbg_value: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2765,9 +2765,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2781,48 +2781,48 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
+pub _addr: *mut crate::ctypes::c_void,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 4usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 4usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 4usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 4usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2833,14 +2833,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2848,22 +2848,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 13usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 13usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -2900,9 +2900,9 @@ pub stx_mnt_id: __u64,
 pub __spare2: __u64,
 pub __spare3: [__u64; 12usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2930,49 +2930,49 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sgttyb {
-pub sg_ispeed: ::std::os::raw::c_char,
-pub sg_ospeed: ::std::os::raw::c_char,
-pub sg_erase: ::std::os::raw::c_char,
-pub sg_kill: ::std::os::raw::c_char,
-pub sg_flags: ::std::os::raw::c_short,
+pub sg_ispeed: crate::ctypes::c_char,
+pub sg_ospeed: crate::ctypes::c_char,
+pub sg_erase: crate::ctypes::c_char,
+pub sg_kill: crate::ctypes::c_char,
+pub sg_flags: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tchars {
-pub t_intrc: ::std::os::raw::c_char,
-pub t_quitc: ::std::os::raw::c_char,
-pub t_startc: ::std::os::raw::c_char,
-pub t_stopc: ::std::os::raw::c_char,
-pub t_eofc: ::std::os::raw::c_char,
-pub t_brkc: ::std::os::raw::c_char,
+pub t_intrc: crate::ctypes::c_char,
+pub t_quitc: crate::ctypes::c_char,
+pub t_startc: crate::ctypes::c_char,
+pub t_stopc: crate::ctypes::c_char,
+pub t_eofc: crate::ctypes::c_char,
+pub t_brkc: crate::ctypes::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ltchars {
-pub t_suspc: ::std::os::raw::c_char,
-pub t_dsuspc: ::std::os::raw::c_char,
-pub t_rprntc: ::std::os::raw::c_char,
-pub t_flushc: ::std::os::raw::c_char,
-pub t_werasc: ::std::os::raw::c_char,
-pub t_lnextc: ::std::os::raw::c_char,
+pub t_suspc: crate::ctypes::c_char,
+pub t_dsuspc: crate::ctypes::c_char,
+pub t_rprntc: crate::ctypes::c_char,
+pub t_flushc: crate::ctypes::c_char,
+pub t_werasc: crate::ctypes::c_char,
+pub t_lnextc: crate::ctypes::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 10usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 10usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2985,14 +2985,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3002,72 +3002,72 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulonglong,
-pub d_off: ::std::os::raw::c_longlong,
+pub d_ino: crate::ctypes::c_ulonglong,
+pub d_off: crate::ctypes::c_longlong,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __old_kernel_stat {
-pub st_dev: ::std::os::raw::c_ushort,
-pub st_ino: ::std::os::raw::c_ushort,
-pub st_mode: ::std::os::raw::c_ushort,
-pub st_nlink: ::std::os::raw::c_ushort,
-pub st_uid: ::std::os::raw::c_ushort,
-pub st_gid: ::std::os::raw::c_ushort,
-pub st_rdev: ::std::os::raw::c_ushort,
-pub st_size: ::std::os::raw::c_ulong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
+pub st_dev: crate::ctypes::c_ushort,
+pub st_ino: crate::ctypes::c_ushort,
+pub st_mode: crate::ctypes::c_ushort,
+pub st_nlink: crate::ctypes::c_ushort,
+pub st_uid: crate::ctypes::c_ushort,
+pub st_gid: crate::ctypes::c_ushort,
+pub st_rdev: crate::ctypes::c_ushort,
+pub st_size: crate::ctypes::c_ulong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ulong,
+pub st_dev: crate::ctypes::c_ulong,
 pub st_ino: __kernel_ino_t,
 pub st_mode: __kernel_mode_t,
-pub st_nlink: ::std::os::raw::c_ushort,
+pub st_nlink: crate::ctypes::c_ushort,
 pub st_uid: __kernel_uid_t,
 pub st_gid: __kernel_gid_t,
-pub st_rdev: ::std::os::raw::c_ulong,
-pub st_size: ::std::os::raw::c_long,
-pub st_blksize: ::std::os::raw::c_ulong,
-pub st_blocks: ::std::os::raw::c_ulong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub __unused4: ::std::os::raw::c_ulong,
-pub __unused5: ::std::os::raw::c_ulong,
+pub st_rdev: crate::ctypes::c_ulong,
+pub st_size: crate::ctypes::c_long,
+pub st_blksize: crate::ctypes::c_ulong,
+pub st_blocks: crate::ctypes::c_ulong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub __unused4: crate::ctypes::c_ulong,
+pub __unused5: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat64 {
-pub st_dev: ::std::os::raw::c_ulonglong,
-pub st_ino: ::std::os::raw::c_ulonglong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_nlink: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub st_rdev: ::std::os::raw::c_ulonglong,
-pub __pad2: ::std::os::raw::c_ushort,
-pub st_size: ::std::os::raw::c_longlong,
-pub st_blksize: ::std::os::raw::c_int,
-pub st_blocks: ::std::os::raw::c_longlong,
-pub st_atime: ::std::os::raw::c_int,
-pub st_atime_nsec: ::std::os::raw::c_uint,
-pub st_mtime: ::std::os::raw::c_int,
-pub st_mtime_nsec: ::std::os::raw::c_uint,
-pub st_ctime: ::std::os::raw::c_int,
-pub st_ctime_nsec: ::std::os::raw::c_uint,
-pub __unused4: ::std::os::raw::c_uint,
-pub __unused5: ::std::os::raw::c_uint,
+pub st_dev: crate::ctypes::c_ulonglong,
+pub st_ino: crate::ctypes::c_ulonglong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_nlink: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub st_rdev: crate::ctypes::c_ulonglong,
+pub __pad2: crate::ctypes::c_ushort,
+pub st_size: crate::ctypes::c_longlong,
+pub st_blksize: crate::ctypes::c_int,
+pub st_blocks: crate::ctypes::c_longlong,
+pub st_atime: crate::ctypes::c_int,
+pub st_atime_nsec: crate::ctypes::c_uint,
+pub st_mtime: crate::ctypes::c_int,
+pub st_mtime_nsec: crate::ctypes::c_uint,
+pub st_ctime: crate::ctypes::c_int,
+pub st_ctime_nsec: crate::ctypes::c_uint,
+pub __unused4: crate::ctypes::c_uint,
+pub __unused5: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v5_11/powerpc/netlink.rs
+++ b/src/v5_11/powerpc/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -223,9 +223,9 @@ pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
 pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -235,22 +235,22 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Copy, Clone)]
@@ -260,45 +260,45 @@ pub u: [__u32; 4usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_long;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_short;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_long;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_short;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -307,12 +307,12 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -328,7 +328,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -353,16 +353,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2245,21 +2245,21 @@ __RTM_MAX = 115,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNICAST;
@@ -2353,10 +2353,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2457,29 +2457,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_ADDRESS;
@@ -2503,10 +2503,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2553,14 +2553,14 @@ __TCA_MAX = 16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_SRCADDR;
@@ -2616,9 +2616,9 @@ __RTNLGRP_MAX = 34,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_TAB;

--- a/src/v5_11/powerpc64/general.rs
+++ b/src/v5_11/powerpc64/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -2073,16 +2073,16 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_long;
-pub type __u64 = ::std::os::raw::c_ulong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_long;
+pub type __u64 = crate::ctypes::c_ulong;
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Copy, Clone)]
@@ -2092,24 +2092,24 @@ pub u: [__u32; 4usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_old_dev_t = crate::ctypes::c_ulong;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
 pub type __kernel_size_t = __kernel_ulong_t;
@@ -2118,19 +2118,19 @@ pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2139,18 +2139,18 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -2158,8 +2158,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -2312,16 +2312,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2331,9 +2331,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2343,10 +2343,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2356,13 +2356,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2441,7 +2441,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2484,7 +2484,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2494,7 +2494,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2511,7 +2511,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2521,7 +2521,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2548,9 +2548,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2573,15 +2573,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2599,7 +2599,7 @@ pub tv_usec: __kernel_long_t,
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_old_timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2617,7 +2617,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2640,8 +2640,8 @@ pub it_value: timeval,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2675,45 +2675,45 @@ pub struct rlimit64 {
 pub rlim_cur: __u64,
 pub rlim_max: __u64,
 }
-pub type old_sigset_t = ::std::os::raw::c_ulong;
+pub type old_sigset_t = crate::ctypes::c_ulong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigset_t {
-pub sig: [::std::os::raw::c_ulong; 1usize],
+pub sig: [crate::ctypes::c_ulong; 1usize],
 }
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct old_sigaction {
 pub sa_handler: __sighandler_t,
 pub sa_mask: old_sigset_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaction {
 pub sa_handler: __sighandler_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2737,9 +2737,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2753,48 +2753,48 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
+pub _addr: *mut crate::ctypes::c_void,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 8usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 8usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 8usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 8usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2805,14 +2805,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2820,22 +2820,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 12usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 12usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -2872,9 +2872,9 @@ pub stx_mnt_id: __u64,
 pub __spare2: __u64,
 pub __spare3: [__u64; 12usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2902,49 +2902,49 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sgttyb {
-pub sg_ispeed: ::std::os::raw::c_char,
-pub sg_ospeed: ::std::os::raw::c_char,
-pub sg_erase: ::std::os::raw::c_char,
-pub sg_kill: ::std::os::raw::c_char,
-pub sg_flags: ::std::os::raw::c_short,
+pub sg_ispeed: crate::ctypes::c_char,
+pub sg_ospeed: crate::ctypes::c_char,
+pub sg_erase: crate::ctypes::c_char,
+pub sg_kill: crate::ctypes::c_char,
+pub sg_flags: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tchars {
-pub t_intrc: ::std::os::raw::c_char,
-pub t_quitc: ::std::os::raw::c_char,
-pub t_startc: ::std::os::raw::c_char,
-pub t_stopc: ::std::os::raw::c_char,
-pub t_eofc: ::std::os::raw::c_char,
-pub t_brkc: ::std::os::raw::c_char,
+pub t_intrc: crate::ctypes::c_char,
+pub t_quitc: crate::ctypes::c_char,
+pub t_startc: crate::ctypes::c_char,
+pub t_stopc: crate::ctypes::c_char,
+pub t_eofc: crate::ctypes::c_char,
+pub t_brkc: crate::ctypes::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ltchars {
-pub t_suspc: ::std::os::raw::c_char,
-pub t_dsuspc: ::std::os::raw::c_char,
-pub t_rprntc: ::std::os::raw::c_char,
-pub t_flushc: ::std::os::raw::c_char,
-pub t_werasc: ::std::os::raw::c_char,
-pub t_lnextc: ::std::os::raw::c_char,
+pub t_suspc: crate::ctypes::c_char,
+pub t_dsuspc: crate::ctypes::c_char,
+pub t_rprntc: crate::ctypes::c_char,
+pub t_flushc: crate::ctypes::c_char,
+pub t_werasc: crate::ctypes::c_char,
+pub t_lnextc: crate::ctypes::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 10usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 10usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2957,14 +2957,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2974,58 +2974,58 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulong,
-pub d_off: ::std::os::raw::c_long,
+pub d_ino: crate::ctypes::c_ulong,
+pub d_off: crate::ctypes::c_long,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ulong,
+pub st_dev: crate::ctypes::c_ulong,
 pub st_ino: __kernel_ino_t,
-pub st_nlink: ::std::os::raw::c_ulong,
+pub st_nlink: crate::ctypes::c_ulong,
 pub st_mode: __kernel_mode_t,
 pub st_uid: __kernel_uid_t,
 pub st_gid: __kernel_gid_t,
-pub st_rdev: ::std::os::raw::c_ulong,
-pub st_size: ::std::os::raw::c_long,
-pub st_blksize: ::std::os::raw::c_ulong,
-pub st_blocks: ::std::os::raw::c_ulong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub __unused4: ::std::os::raw::c_ulong,
-pub __unused5: ::std::os::raw::c_ulong,
-pub __unused6: ::std::os::raw::c_ulong,
+pub st_rdev: crate::ctypes::c_ulong,
+pub st_size: crate::ctypes::c_long,
+pub st_blksize: crate::ctypes::c_ulong,
+pub st_blocks: crate::ctypes::c_ulong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub __unused4: crate::ctypes::c_ulong,
+pub __unused5: crate::ctypes::c_ulong,
+pub __unused6: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat64 {
-pub st_dev: ::std::os::raw::c_ulonglong,
-pub st_ino: ::std::os::raw::c_ulonglong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_nlink: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub st_rdev: ::std::os::raw::c_ulonglong,
-pub __pad2: ::std::os::raw::c_ushort,
-pub st_size: ::std::os::raw::c_longlong,
-pub st_blksize: ::std::os::raw::c_int,
-pub st_blocks: ::std::os::raw::c_longlong,
-pub st_atime: ::std::os::raw::c_int,
-pub st_atime_nsec: ::std::os::raw::c_uint,
-pub st_mtime: ::std::os::raw::c_int,
-pub st_mtime_nsec: ::std::os::raw::c_uint,
-pub st_ctime: ::std::os::raw::c_int,
-pub st_ctime_nsec: ::std::os::raw::c_uint,
-pub __unused4: ::std::os::raw::c_uint,
-pub __unused5: ::std::os::raw::c_uint,
+pub st_dev: crate::ctypes::c_ulonglong,
+pub st_ino: crate::ctypes::c_ulonglong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_nlink: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub st_rdev: crate::ctypes::c_ulonglong,
+pub __pad2: crate::ctypes::c_ushort,
+pub st_size: crate::ctypes::c_longlong,
+pub st_blksize: crate::ctypes::c_int,
+pub st_blocks: crate::ctypes::c_longlong,
+pub st_atime: crate::ctypes::c_int,
+pub st_atime_nsec: crate::ctypes::c_uint,
+pub st_mtime: crate::ctypes::c_int,
+pub st_mtime_nsec: crate::ctypes::c_uint,
+pub st_ctime: crate::ctypes::c_int,
+pub st_ctime_nsec: crate::ctypes::c_uint,
+pub __unused4: crate::ctypes::c_uint,
+pub __unused5: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v5_11/powerpc64/netlink.rs
+++ b/src/v5_11/powerpc64/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -223,9 +223,9 @@ pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
 pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -235,22 +235,22 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_long;
-pub type __u64 = ::std::os::raw::c_ulong;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_long;
+pub type __u64 = crate::ctypes::c_ulong;
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Copy, Clone)]
@@ -260,24 +260,24 @@ pub u: [__u32; 4usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_old_dev_t = crate::ctypes::c_ulong;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
 pub type __kernel_size_t = __kernel_ulong_t;
@@ -286,19 +286,19 @@ pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -307,12 +307,12 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -328,7 +328,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -353,16 +353,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2245,21 +2245,21 @@ __RTM_MAX = 115,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNICAST;
@@ -2353,10 +2353,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2457,29 +2457,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_ADDRESS;
@@ -2503,10 +2503,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2553,14 +2553,14 @@ __TCA_MAX = 16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_SRCADDR;
@@ -2616,9 +2616,9 @@ __RTNLGRP_MAX = 34,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_TAB;

--- a/src/v5_11/riscv32/general.rs
+++ b/src/v5_11/riscv32/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -1975,58 +1975,58 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_int;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2035,18 +2035,18 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -2054,8 +2054,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -2208,16 +2208,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2227,9 +2227,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2239,10 +2239,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2252,13 +2252,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2337,7 +2337,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2380,7 +2380,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2390,7 +2390,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2407,7 +2407,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2417,7 +2417,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2444,9 +2444,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2469,15 +2469,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2495,7 +2495,7 @@ pub tv_usec: __kernel_long_t,
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_old_timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2513,7 +2513,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2536,8 +2536,8 @@ pub it_value: timeval,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2574,33 +2574,33 @@ pub rlim_max: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigset_t {
-pub sig: [::std::os::raw::c_ulong; 2usize],
+pub sig: [crate::ctypes::c_ulong; 2usize],
 }
-pub type old_sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type old_sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaction {
 pub sa_handler: __sighandler_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2624,9 +2624,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2640,48 +2640,48 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
+pub _addr: *mut crate::ctypes::c_void,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 4usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 4usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 4usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 4usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2692,14 +2692,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2707,22 +2707,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 13usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 13usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -2759,9 +2759,9 @@ pub stx_mnt_id: __u64,
 pub __spare2: __u64,
 pub __spare3: [__u64; 12usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2799,20 +2799,20 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 8usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2825,14 +2825,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2842,60 +2842,60 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulonglong,
-pub d_off: ::std::os::raw::c_longlong,
+pub d_ino: crate::ctypes::c_ulonglong,
+pub d_off: crate::ctypes::c_longlong,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_nlink: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub st_rdev: ::std::os::raw::c_ulong,
-pub __pad1: ::std::os::raw::c_ulong,
-pub st_size: ::std::os::raw::c_long,
-pub st_blksize: ::std::os::raw::c_int,
-pub __pad2: ::std::os::raw::c_int,
-pub st_blocks: ::std::os::raw::c_long,
-pub st_atime: ::std::os::raw::c_long,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_long,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_long,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub __unused4: ::std::os::raw::c_uint,
-pub __unused5: ::std::os::raw::c_uint,
+pub st_dev: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_nlink: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub st_rdev: crate::ctypes::c_ulong,
+pub __pad1: crate::ctypes::c_ulong,
+pub st_size: crate::ctypes::c_long,
+pub st_blksize: crate::ctypes::c_int,
+pub __pad2: crate::ctypes::c_int,
+pub st_blocks: crate::ctypes::c_long,
+pub st_atime: crate::ctypes::c_long,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_long,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_long,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub __unused4: crate::ctypes::c_uint,
+pub __unused5: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat64 {
-pub st_dev: ::std::os::raw::c_ulonglong,
-pub st_ino: ::std::os::raw::c_ulonglong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_nlink: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub st_rdev: ::std::os::raw::c_ulonglong,
-pub __pad1: ::std::os::raw::c_ulonglong,
-pub st_size: ::std::os::raw::c_longlong,
-pub st_blksize: ::std::os::raw::c_int,
-pub __pad2: ::std::os::raw::c_int,
-pub st_blocks: ::std::os::raw::c_longlong,
-pub st_atime: ::std::os::raw::c_int,
-pub st_atime_nsec: ::std::os::raw::c_uint,
-pub st_mtime: ::std::os::raw::c_int,
-pub st_mtime_nsec: ::std::os::raw::c_uint,
-pub st_ctime: ::std::os::raw::c_int,
-pub st_ctime_nsec: ::std::os::raw::c_uint,
-pub __unused4: ::std::os::raw::c_uint,
-pub __unused5: ::std::os::raw::c_uint,
+pub st_dev: crate::ctypes::c_ulonglong,
+pub st_ino: crate::ctypes::c_ulonglong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_nlink: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub st_rdev: crate::ctypes::c_ulonglong,
+pub __pad1: crate::ctypes::c_ulonglong,
+pub st_size: crate::ctypes::c_longlong,
+pub st_blksize: crate::ctypes::c_int,
+pub __pad2: crate::ctypes::c_int,
+pub st_blocks: crate::ctypes::c_longlong,
+pub st_atime: crate::ctypes::c_int,
+pub st_atime_nsec: crate::ctypes::c_uint,
+pub st_mtime: crate::ctypes::c_int,
+pub st_mtime_nsec: crate::ctypes::c_uint,
+pub st_ctime: crate::ctypes::c_int,
+pub st_ctime_nsec: crate::ctypes::c_uint,
+pub __unused4: crate::ctypes::c_uint,
+pub __unused5: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v5_11/riscv32/netlink.rs
+++ b/src/v5_11/riscv32/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -222,9 +222,9 @@ pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
 pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -234,64 +234,64 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_int;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -300,12 +300,12 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -321,7 +321,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -346,16 +346,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2238,21 +2238,21 @@ __RTM_MAX = 115,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNICAST;
@@ -2346,10 +2346,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2450,29 +2450,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_ADDRESS;
@@ -2496,10 +2496,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2546,14 +2546,14 @@ __TCA_MAX = 16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_SRCADDR;
@@ -2609,9 +2609,9 @@ __RTNLGRP_MAX = 34,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_TAB;

--- a/src/v5_11/riscv64/general.rs
+++ b/src/v5_11/riscv64/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -1996,58 +1996,58 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2056,18 +2056,18 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -2075,8 +2075,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -2229,16 +2229,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2248,9 +2248,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2260,10 +2260,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2273,13 +2273,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2358,7 +2358,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2401,7 +2401,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2411,7 +2411,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2428,7 +2428,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2438,7 +2438,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2465,9 +2465,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2490,15 +2490,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2516,7 +2516,7 @@ pub tv_usec: __kernel_long_t,
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_old_timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2534,7 +2534,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2557,8 +2557,8 @@ pub it_value: timeval,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2595,33 +2595,33 @@ pub rlim_max: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigset_t {
-pub sig: [::std::os::raw::c_ulong; 1usize],
+pub sig: [crate::ctypes::c_ulong; 1usize],
 }
-pub type old_sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type old_sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaction {
 pub sa_handler: __sighandler_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2645,9 +2645,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2661,48 +2661,48 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
+pub _addr: *mut crate::ctypes::c_void,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 8usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 8usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 8usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 8usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2713,14 +2713,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2728,22 +2728,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 12usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 12usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -2780,9 +2780,9 @@ pub stx_mnt_id: __u64,
 pub __spare2: __u64,
 pub __spare3: [__u64; 12usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2820,20 +2820,20 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 8usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2846,14 +2846,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2863,36 +2863,36 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulong,
-pub d_off: ::std::os::raw::c_long,
+pub d_ino: crate::ctypes::c_ulong,
+pub d_off: crate::ctypes::c_long,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_nlink: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub st_rdev: ::std::os::raw::c_ulong,
-pub __pad1: ::std::os::raw::c_ulong,
-pub st_size: ::std::os::raw::c_long,
-pub st_blksize: ::std::os::raw::c_int,
-pub __pad2: ::std::os::raw::c_int,
-pub st_blocks: ::std::os::raw::c_long,
-pub st_atime: ::std::os::raw::c_long,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_long,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_long,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub __unused4: ::std::os::raw::c_uint,
-pub __unused5: ::std::os::raw::c_uint,
+pub st_dev: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_nlink: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub st_rdev: crate::ctypes::c_ulong,
+pub __pad1: crate::ctypes::c_ulong,
+pub st_size: crate::ctypes::c_long,
+pub st_blksize: crate::ctypes::c_int,
+pub __pad2: crate::ctypes::c_int,
+pub st_blocks: crate::ctypes::c_long,
+pub st_atime: crate::ctypes::c_long,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_long,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_long,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub __unused4: crate::ctypes::c_uint,
+pub __unused5: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v5_11/riscv64/netlink.rs
+++ b/src/v5_11/riscv64/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -222,9 +222,9 @@ pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
 pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -234,64 +234,64 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -300,12 +300,12 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -321,7 +321,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -346,16 +346,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2238,21 +2238,21 @@ __RTM_MAX = 115,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNICAST;
@@ -2346,10 +2346,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2450,29 +2450,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_ADDRESS;
@@ -2496,10 +2496,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2546,14 +2546,14 @@ __TCA_MAX = 16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_SRCADDR;
@@ -2609,9 +2609,9 @@ __RTNLGRP_MAX = 34,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_TAB;

--- a/src/v5_11/s390x/general.rs
+++ b/src/v5_11/s390x/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -2047,18 +2047,18 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
-pub type addr_t = ::std::os::raw::c_ulong;
-pub type saddr_t = ::std::os::raw::c_long;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
+pub type addr_t = crate::ctypes::c_ulong;
+pub type saddr_t = crate::ctypes::c_long;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __vector128 {
@@ -2067,46 +2067,46 @@ pub u: [__u32; 4usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_size_t = ::std::os::raw::c_ulong;
-pub type __kernel_ssize_t = ::std::os::raw::c_long;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ushort;
-pub type __kernel_ino_t = ::std::os::raw::c_uint;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_long;
-pub type __kernel_sigset_t = ::std::os::raw::c_ulong;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_size_t = crate::ctypes::c_ulong;
+pub type __kernel_ssize_t = crate::ctypes::c_long;
+pub type __kernel_old_dev_t = crate::ctypes::c_ushort;
+pub type __kernel_ino_t = crate::ctypes::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_long;
+pub type __kernel_sigset_t = crate::ctypes::c_ulong;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
+pub type __kernel_pid_t = crate::ctypes::c_int;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2115,18 +2115,18 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -2134,8 +2134,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -2288,16 +2288,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2307,9 +2307,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2319,10 +2319,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2332,13 +2332,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2417,7 +2417,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2460,7 +2460,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2470,7 +2470,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2487,7 +2487,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2497,7 +2497,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2524,9 +2524,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2549,15 +2549,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2575,7 +2575,7 @@ pub tv_usec: __kernel_long_t,
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_old_timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2593,7 +2593,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2616,8 +2616,8 @@ pub it_value: timeval,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2656,38 +2656,38 @@ pub rlim_max: __u64,
 pub struct pt_regs {
 _unused: [u8; 0],
 }
-pub type sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sigaction {
 pub _u: sigaction__bindgen_ty_1,
-pub sa_flags: ::std::os::raw::c_ulong,
-pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: ::core::option::Option<unsafe extern "C" fn()>,
 pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigaction__bindgen_ty_1 {
 pub _sa_handler: __sighandler_t,
-pub _sa_sigaction: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int, arg2: *mut siginfo, arg3: *mut ::std::os::raw::c_void)>,
+pub _sa_sigaction: ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int, arg2: *mut siginfo, arg3: *mut crate::ctypes::c_void)>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2711,9 +2711,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2727,48 +2727,48 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
+pub _addr: *mut crate::ctypes::c_void,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 8usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 8usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 8usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 8usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2779,14 +2779,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2794,22 +2794,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 12usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 12usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -2846,9 +2846,9 @@ pub stx_mnt_id: __u64,
 pub __spare2: __u64,
 pub __spare3: [__u64; 12usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2886,20 +2886,20 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 8usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2912,14 +2912,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2929,66 +2929,66 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulong,
-pub d_off: ::std::os::raw::c_long,
+pub d_ino: crate::ctypes::c_ulong,
+pub d_off: crate::ctypes::c_long,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulong,
-pub st_nlink: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub __pad1: ::std::os::raw::c_uint,
-pub st_rdev: ::std::os::raw::c_ulong,
-pub st_size: ::std::os::raw::c_ulong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub st_blksize: ::std::os::raw::c_ulong,
-pub st_blocks: ::std::os::raw::c_long,
-pub __unused: [::std::os::raw::c_ulong; 3usize],
+pub st_dev: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulong,
+pub st_nlink: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub __pad1: crate::ctypes::c_uint,
+pub st_rdev: crate::ctypes::c_ulong,
+pub st_size: crate::ctypes::c_ulong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub st_blksize: crate::ctypes::c_ulong,
+pub st_blocks: crate::ctypes::c_long,
+pub __unused: [crate::ctypes::c_ulong; 3usize],
 }
 pub type fsid_t = __kernel_fsid_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct statfs {
-pub f_type: ::std::os::raw::c_uint,
-pub f_bsize: ::std::os::raw::c_uint,
-pub f_blocks: ::std::os::raw::c_ulong,
-pub f_bfree: ::std::os::raw::c_ulong,
-pub f_bavail: ::std::os::raw::c_ulong,
-pub f_files: ::std::os::raw::c_ulong,
-pub f_ffree: ::std::os::raw::c_ulong,
+pub f_type: crate::ctypes::c_uint,
+pub f_bsize: crate::ctypes::c_uint,
+pub f_blocks: crate::ctypes::c_ulong,
+pub f_bfree: crate::ctypes::c_ulong,
+pub f_bavail: crate::ctypes::c_ulong,
+pub f_files: crate::ctypes::c_ulong,
+pub f_ffree: crate::ctypes::c_ulong,
 pub f_fsid: __kernel_fsid_t,
-pub f_namelen: ::std::os::raw::c_uint,
-pub f_frsize: ::std::os::raw::c_uint,
-pub f_flags: ::std::os::raw::c_uint,
-pub f_spare: [::std::os::raw::c_uint; 4usize],
+pub f_namelen: crate::ctypes::c_uint,
+pub f_frsize: crate::ctypes::c_uint,
+pub f_flags: crate::ctypes::c_uint,
+pub f_spare: [crate::ctypes::c_uint; 4usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct statfs64 {
-pub f_type: ::std::os::raw::c_uint,
-pub f_bsize: ::std::os::raw::c_uint,
-pub f_blocks: ::std::os::raw::c_ulonglong,
-pub f_bfree: ::std::os::raw::c_ulonglong,
-pub f_bavail: ::std::os::raw::c_ulonglong,
-pub f_files: ::std::os::raw::c_ulonglong,
-pub f_ffree: ::std::os::raw::c_ulonglong,
+pub f_type: crate::ctypes::c_uint,
+pub f_bsize: crate::ctypes::c_uint,
+pub f_blocks: crate::ctypes::c_ulonglong,
+pub f_bfree: crate::ctypes::c_ulonglong,
+pub f_bavail: crate::ctypes::c_ulonglong,
+pub f_files: crate::ctypes::c_ulonglong,
+pub f_ffree: crate::ctypes::c_ulonglong,
 pub f_fsid: __kernel_fsid_t,
-pub f_namelen: ::std::os::raw::c_uint,
-pub f_frsize: ::std::os::raw::c_uint,
-pub f_flags: ::std::os::raw::c_uint,
-pub f_spare: [::std::os::raw::c_uint; 4usize],
+pub f_namelen: crate::ctypes::c_uint,
+pub f_frsize: crate::ctypes::c_uint,
+pub f_flags: crate::ctypes::c_uint,
+pub f_spare: [crate::ctypes::c_uint; 4usize],
 }
 pub type __fsword_t = __u32;

--- a/src/v5_11/s390x/netlink.rs
+++ b/src/v5_11/s390x/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -223,9 +223,9 @@ pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
 pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -235,24 +235,24 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
-pub type addr_t = ::std::os::raw::c_ulong;
-pub type saddr_t = ::std::os::raw::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
+pub type addr_t = crate::ctypes::c_ulong;
+pub type saddr_t = crate::ctypes::c_long;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __vector128 {
@@ -261,46 +261,46 @@ pub u: [__u32; 4usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_size_t = ::std::os::raw::c_ulong;
-pub type __kernel_ssize_t = ::std::os::raw::c_long;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ushort;
-pub type __kernel_ino_t = ::std::os::raw::c_uint;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_long;
-pub type __kernel_sigset_t = ::std::os::raw::c_ulong;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_size_t = crate::ctypes::c_ulong;
+pub type __kernel_ssize_t = crate::ctypes::c_long;
+pub type __kernel_old_dev_t = crate::ctypes::c_ushort;
+pub type __kernel_ino_t = crate::ctypes::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_long;
+pub type __kernel_sigset_t = crate::ctypes::c_ulong;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
+pub type __kernel_pid_t = crate::ctypes::c_int;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -309,12 +309,12 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -330,7 +330,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -355,16 +355,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2247,21 +2247,21 @@ __RTM_MAX = 115,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNICAST;
@@ -2355,10 +2355,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2459,29 +2459,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_ADDRESS;
@@ -2505,10 +2505,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2555,14 +2555,14 @@ __TCA_MAX = 16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_SRCADDR;
@@ -2618,9 +2618,9 @@ __RTNLGRP_MAX = 34,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_TAB;

--- a/src/v5_11/sparc/general.rs
+++ b/src/v5_11/sparc/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -2298,58 +2298,58 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 4210688;
 pub const TFD_CREATE_FLAGS: u32 = 4210688;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_long;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_ushort;
-pub type __kernel_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_mode_t = ::std::os::raw::c_ushort;
-pub type __kernel_daddr_t = ::std::os::raw::c_long;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ushort;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_long;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_ushort;
+pub type __kernel_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_mode_t = crate::ctypes::c_ushort;
+pub type __kernel_daddr_t = crate::ctypes::c_long;
+pub type __kernel_old_dev_t = crate::ctypes::c_ushort;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_pid_t = crate::ctypes::c_int;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2358,32 +2358,32 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
-pub __unused: ::std::os::raw::c_short,
+pub __unused: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
-pub __unused: ::std::os::raw::c_short,
+pub __unused: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2533,16 +2533,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2552,9 +2552,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2564,10 +2564,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2577,13 +2577,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2662,7 +2662,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2705,7 +2705,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2715,7 +2715,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2732,7 +2732,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2742,7 +2742,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2769,9 +2769,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2794,15 +2794,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2820,7 +2820,7 @@ pub tv_usec: __kernel_long_t,
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_old_timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2838,7 +2838,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2861,8 +2861,8 @@ pub it_value: timeval,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2896,27 +2896,27 @@ pub struct rlimit64 {
 pub rlim_cur: __u64,
 pub rlim_max: __u64,
 }
-pub type sigset_t = ::std::os::raw::c_ulong;
+pub type sigset_t = crate::ctypes::c_ulong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __new_sigset_t {
-pub sig: [::std::os::raw::c_ulong; 2usize],
+pub sig: [crate::ctypes::c_ulong; 2usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigstack {
-pub the_stack: *mut ::std::os::raw::c_char,
-pub cur_status: ::std::os::raw::c_int,
+pub the_stack: *mut crate::ctypes::c_char,
+pub cur_status: crate::ctypes::c_int,
 }
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __new_sigaction {
 pub sa_handler: __sighandler_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: __new_sigset_t,
 }
@@ -2925,22 +2925,22 @@ pub sa_mask: __new_sigset_t,
 pub struct sigaction {
 pub sa_handler: __sighandler_t,
 pub sa_mask: sigset_t,
-pub sa_flags: ::std::os::raw::c_ulong,
-pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: ::core::option::Option<unsafe extern "C" fn()>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2964,9 +2964,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2980,49 +2980,49 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
-pub _trapno: ::std::os::raw::c_int,
+pub _addr: *mut crate::ctypes::c_void,
+pub _trapno: crate::ctypes::c_int,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 4usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 4usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 4usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 4usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3033,14 +3033,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -3048,22 +3048,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 13usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 13usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -3100,18 +3100,18 @@ pub stx_mnt_id: __u64,
 pub __spare2: __u64,
 pub __spare3: [__u64; 12usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_ulong;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_ulong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 8usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3150,10 +3150,10 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3166,14 +3166,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3183,57 +3183,57 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulonglong,
-pub d_off: ::std::os::raw::c_longlong,
+pub d_ino: crate::ctypes::c_ulonglong,
+pub d_off: crate::ctypes::c_longlong,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ushort,
+pub st_dev: crate::ctypes::c_ushort,
 pub st_ino: __kernel_ino_t,
 pub st_mode: __kernel_mode_t,
-pub st_nlink: ::std::os::raw::c_short,
-pub st_uid: ::std::os::raw::c_ushort,
-pub st_gid: ::std::os::raw::c_ushort,
-pub st_rdev: ::std::os::raw::c_ushort,
-pub st_size: ::std::os::raw::c_long,
-pub st_atime: ::std::os::raw::c_long,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_long,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_long,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub st_blksize: ::std::os::raw::c_long,
-pub st_blocks: ::std::os::raw::c_long,
-pub __unused4: [::std::os::raw::c_ulong; 2usize],
+pub st_nlink: crate::ctypes::c_short,
+pub st_uid: crate::ctypes::c_ushort,
+pub st_gid: crate::ctypes::c_ushort,
+pub st_rdev: crate::ctypes::c_ushort,
+pub st_size: crate::ctypes::c_long,
+pub st_atime: crate::ctypes::c_long,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_long,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_long,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub st_blksize: crate::ctypes::c_long,
+pub st_blocks: crate::ctypes::c_long,
+pub __unused4: [crate::ctypes::c_ulong; 2usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat64 {
-pub st_dev: ::std::os::raw::c_ulonglong,
-pub st_ino: ::std::os::raw::c_ulonglong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_nlink: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub st_rdev: ::std::os::raw::c_ulonglong,
-pub __pad3: [::std::os::raw::c_uchar; 8usize],
-pub st_size: ::std::os::raw::c_longlong,
-pub st_blksize: ::std::os::raw::c_uint,
-pub __pad4: [::std::os::raw::c_uchar; 8usize],
-pub st_blocks: ::std::os::raw::c_uint,
-pub st_atime: ::std::os::raw::c_uint,
-pub st_atime_nsec: ::std::os::raw::c_uint,
-pub st_mtime: ::std::os::raw::c_uint,
-pub st_mtime_nsec: ::std::os::raw::c_uint,
-pub st_ctime: ::std::os::raw::c_uint,
-pub st_ctime_nsec: ::std::os::raw::c_uint,
-pub __unused4: ::std::os::raw::c_uint,
-pub __unused5: ::std::os::raw::c_uint,
+pub st_dev: crate::ctypes::c_ulonglong,
+pub st_ino: crate::ctypes::c_ulonglong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_nlink: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub st_rdev: crate::ctypes::c_ulonglong,
+pub __pad3: [crate::ctypes::c_uchar; 8usize],
+pub st_size: crate::ctypes::c_longlong,
+pub st_blksize: crate::ctypes::c_uint,
+pub __pad4: [crate::ctypes::c_uchar; 8usize],
+pub st_blocks: crate::ctypes::c_uint,
+pub st_atime: crate::ctypes::c_uint,
+pub st_atime_nsec: crate::ctypes::c_uint,
+pub st_mtime: crate::ctypes::c_uint,
+pub st_mtime_nsec: crate::ctypes::c_uint,
+pub st_ctime: crate::ctypes::c_uint,
+pub st_ctime_nsec: crate::ctypes::c_uint,
+pub __unused4: crate::ctypes::c_uint,
+pub __unused5: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v5_11/sparc/netlink.rs
+++ b/src/v5_11/sparc/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -223,9 +223,9 @@ pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
 pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -235,64 +235,64 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_long;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_ushort;
-pub type __kernel_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_mode_t = ::std::os::raw::c_ushort;
-pub type __kernel_daddr_t = ::std::os::raw::c_long;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ushort;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_long;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_ushort;
+pub type __kernel_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_mode_t = crate::ctypes::c_ushort;
+pub type __kernel_daddr_t = crate::ctypes::c_long;
+pub type __kernel_old_dev_t = crate::ctypes::c_ushort;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_pid_t = crate::ctypes::c_int;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -301,12 +301,12 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -322,7 +322,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -347,16 +347,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2239,21 +2239,21 @@ __RTM_MAX = 115,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNICAST;
@@ -2347,10 +2347,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2451,29 +2451,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_ADDRESS;
@@ -2497,10 +2497,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2547,14 +2547,14 @@ __TCA_MAX = 16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_SRCADDR;
@@ -2610,9 +2610,9 @@ __RTNLGRP_MAX = 34,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_TAB;

--- a/src/v5_11/sparc64/general.rs
+++ b/src/v5_11/sparc64/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -2268,29 +2268,29 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 4210688;
 pub const TFD_CREATE_FLAGS: u32 = 4210688;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_suseconds_t = ::std::os::raw::c_int;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_old_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_suseconds_t = crate::ctypes::c_int;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_old_timeval {
@@ -2298,34 +2298,34 @@ pub tv_sec: __kernel_long_t,
 pub tv_usec: __kernel_suseconds_t,
 }
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2334,32 +2334,32 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
-pub __unused: ::std::os::raw::c_short,
+pub __unused: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
-pub __unused: ::std::os::raw::c_short,
+pub __unused: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2509,16 +2509,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2528,9 +2528,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2540,10 +2540,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2553,13 +2553,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2638,7 +2638,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2681,7 +2681,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2691,7 +2691,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2708,7 +2708,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2718,7 +2718,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2745,9 +2745,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2770,15 +2770,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2790,7 +2790,7 @@ pub it_value: __kernel_timespec,
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_old_timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2808,7 +2808,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2831,8 +2831,8 @@ pub it_value: timeval,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2866,27 +2866,27 @@ pub struct rlimit64 {
 pub rlim_cur: __u64,
 pub rlim_max: __u64,
 }
-pub type sigset_t = ::std::os::raw::c_ulong;
+pub type sigset_t = crate::ctypes::c_ulong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __new_sigset_t {
-pub sig: [::std::os::raw::c_ulong; 1usize],
+pub sig: [crate::ctypes::c_ulong; 1usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigstack {
-pub the_stack: *mut ::std::os::raw::c_char,
-pub cur_status: ::std::os::raw::c_int,
+pub the_stack: *mut crate::ctypes::c_char,
+pub cur_status: crate::ctypes::c_int,
 }
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __new_sigaction {
 pub sa_handler: __sighandler_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: __new_sigset_t,
 }
@@ -2895,22 +2895,22 @@ pub sa_mask: __new_sigset_t,
 pub struct sigaction {
 pub sa_handler: __sighandler_t,
 pub sa_mask: sigset_t,
-pub sa_flags: ::std::os::raw::c_ulong,
-pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: ::core::option::Option<unsafe extern "C" fn()>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2934,9 +2934,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2950,49 +2950,49 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
-pub _trapno: ::std::os::raw::c_int,
+pub _addr: *mut crate::ctypes::c_void,
+pub _trapno: crate::ctypes::c_int,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 8usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 8usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 8usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 8usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_int,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_int,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3003,14 +3003,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -3018,22 +3018,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 12usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 12usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -3070,18 +3070,18 @@ pub stx_mnt_id: __u64,
 pub __spare2: __u64,
 pub __spare3: [__u64; 12usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 8usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3120,10 +3120,10 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3136,14 +3136,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3153,52 +3153,52 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulong,
-pub d_off: ::std::os::raw::c_long,
+pub d_ino: crate::ctypes::c_ulong,
+pub d_off: crate::ctypes::c_long,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_uint,
+pub st_dev: crate::ctypes::c_uint,
 pub st_ino: __kernel_ino_t,
 pub st_mode: __kernel_mode_t,
-pub st_nlink: ::std::os::raw::c_short,
+pub st_nlink: crate::ctypes::c_short,
 pub st_uid: __kernel_uid_t,
 pub st_gid: __kernel_gid_t,
-pub st_rdev: ::std::os::raw::c_uint,
-pub st_size: ::std::os::raw::c_long,
-pub st_atime: ::std::os::raw::c_long,
-pub st_mtime: ::std::os::raw::c_long,
-pub st_ctime: ::std::os::raw::c_long,
-pub st_blksize: ::std::os::raw::c_long,
-pub st_blocks: ::std::os::raw::c_long,
-pub __unused4: [::std::os::raw::c_ulong; 2usize],
+pub st_rdev: crate::ctypes::c_uint,
+pub st_size: crate::ctypes::c_long,
+pub st_atime: crate::ctypes::c_long,
+pub st_mtime: crate::ctypes::c_long,
+pub st_ctime: crate::ctypes::c_long,
+pub st_blksize: crate::ctypes::c_long,
+pub st_blocks: crate::ctypes::c_long,
+pub __unused4: [crate::ctypes::c_ulong; 2usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat64 {
-pub st_dev: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulong,
-pub st_nlink: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub __pad0: ::std::os::raw::c_uint,
-pub st_rdev: ::std::os::raw::c_ulong,
-pub st_size: ::std::os::raw::c_long,
-pub st_blksize: ::std::os::raw::c_long,
-pub st_blocks: ::std::os::raw::c_long,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub __unused: [::std::os::raw::c_long; 3usize],
+pub st_dev: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulong,
+pub st_nlink: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub __pad0: crate::ctypes::c_uint,
+pub st_rdev: crate::ctypes::c_ulong,
+pub st_size: crate::ctypes::c_long,
+pub st_blksize: crate::ctypes::c_long,
+pub st_blocks: crate::ctypes::c_long,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub __unused: [crate::ctypes::c_long; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v5_11/sparc64/netlink.rs
+++ b/src/v5_11/sparc64/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -223,9 +223,9 @@ pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
 pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -235,35 +235,35 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_suseconds_t = ::std::os::raw::c_int;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_old_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_suseconds_t = crate::ctypes::c_int;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_old_timeval {
@@ -271,34 +271,34 @@ pub tv_sec: __kernel_long_t,
 pub tv_usec: __kernel_suseconds_t,
 }
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -307,12 +307,12 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -328,7 +328,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -353,16 +353,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2245,21 +2245,21 @@ __RTM_MAX = 115,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNICAST;
@@ -2353,10 +2353,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2457,29 +2457,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_ADDRESS;
@@ -2503,10 +2503,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2553,14 +2553,14 @@ __TCA_MAX = 16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_SRCADDR;
@@ -2616,9 +2616,9 @@ __RTNLGRP_MAX = 34,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_TAB;

--- a/src/v5_11/x86/general.rs
+++ b/src/v5_11/x86/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -2114,58 +2114,58 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_mode_t = ::std::os::raw::c_ushort;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_ushort;
-pub type __kernel_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ushort;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_mode_t = crate::ctypes::c_ushort;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_ushort;
+pub type __kernel_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_dev_t = crate::ctypes::c_ushort;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_pid_t = crate::ctypes::c_int;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_int;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2174,18 +2174,18 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -2193,8 +2193,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -2347,16 +2347,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2366,9 +2366,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2378,10 +2378,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2391,13 +2391,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2476,7 +2476,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2519,7 +2519,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2529,7 +2529,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2546,7 +2546,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2556,7 +2556,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2583,9 +2583,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2608,15 +2608,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2634,7 +2634,7 @@ pub tv_usec: __kernel_long_t,
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_old_timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2652,7 +2652,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2675,8 +2675,8 @@ pub it_value: timeval,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2710,38 +2710,38 @@ pub struct rlimit64 {
 pub rlim_cur: __u64,
 pub rlim_max: __u64,
 }
-pub type sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sigaction {
 pub _u: sigaction__bindgen_ty_1,
 pub sa_mask: sigset_t,
-pub sa_flags: ::std::os::raw::c_ulong,
-pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: ::core::option::Option<unsafe extern "C" fn()>,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigaction__bindgen_ty_1 {
 pub _sa_handler: __sighandler_t,
-pub _sa_sigaction: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int, arg2: *mut siginfo, arg3: *mut ::std::os::raw::c_void)>,
+pub _sa_sigaction: ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int, arg2: *mut siginfo, arg3: *mut crate::ctypes::c_void)>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2765,9 +2765,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2781,48 +2781,48 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
+pub _addr: *mut crate::ctypes::c_void,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 4usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 4usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 4usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 4usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2833,14 +2833,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2848,22 +2848,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 13usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 13usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -2900,9 +2900,9 @@ pub stx_mnt_id: __u64,
 pub __spare2: __u64,
 pub __spare3: [__u64; 12usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2940,20 +2940,20 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 8usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2966,14 +2966,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2983,72 +2983,72 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulonglong,
-pub d_off: ::std::os::raw::c_longlong,
+pub d_ino: crate::ctypes::c_ulonglong,
+pub d_off: crate::ctypes::c_longlong,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_ushort,
-pub st_nlink: ::std::os::raw::c_ushort,
-pub st_uid: ::std::os::raw::c_ushort,
-pub st_gid: ::std::os::raw::c_ushort,
-pub st_rdev: ::std::os::raw::c_ulong,
-pub st_size: ::std::os::raw::c_ulong,
-pub st_blksize: ::std::os::raw::c_ulong,
-pub st_blocks: ::std::os::raw::c_ulong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub __unused4: ::std::os::raw::c_ulong,
-pub __unused5: ::std::os::raw::c_ulong,
+pub st_dev: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_ushort,
+pub st_nlink: crate::ctypes::c_ushort,
+pub st_uid: crate::ctypes::c_ushort,
+pub st_gid: crate::ctypes::c_ushort,
+pub st_rdev: crate::ctypes::c_ulong,
+pub st_size: crate::ctypes::c_ulong,
+pub st_blksize: crate::ctypes::c_ulong,
+pub st_blocks: crate::ctypes::c_ulong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub __unused4: crate::ctypes::c_ulong,
+pub __unused5: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat64 {
-pub st_dev: ::std::os::raw::c_ulonglong,
-pub __pad0: [::std::os::raw::c_uchar; 4usize],
-pub __st_ino: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_nlink: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_ulong,
-pub st_gid: ::std::os::raw::c_ulong,
-pub st_rdev: ::std::os::raw::c_ulonglong,
-pub __pad3: [::std::os::raw::c_uchar; 4usize],
-pub st_size: ::std::os::raw::c_longlong,
-pub st_blksize: ::std::os::raw::c_ulong,
-pub st_blocks: ::std::os::raw::c_ulonglong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_mtime_nsec: ::std::os::raw::c_uint,
-pub st_ctime: ::std::os::raw::c_ulong,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulonglong,
+pub st_dev: crate::ctypes::c_ulonglong,
+pub __pad0: [crate::ctypes::c_uchar; 4usize],
+pub __st_ino: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_nlink: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_ulong,
+pub st_gid: crate::ctypes::c_ulong,
+pub st_rdev: crate::ctypes::c_ulonglong,
+pub __pad3: [crate::ctypes::c_uchar; 4usize],
+pub st_size: crate::ctypes::c_longlong,
+pub st_blksize: crate::ctypes::c_ulong,
+pub st_blocks: crate::ctypes::c_ulonglong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_uint,
+pub st_ctime: crate::ctypes::c_ulong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulonglong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __old_kernel_stat {
-pub st_dev: ::std::os::raw::c_ushort,
-pub st_ino: ::std::os::raw::c_ushort,
-pub st_mode: ::std::os::raw::c_ushort,
-pub st_nlink: ::std::os::raw::c_ushort,
-pub st_uid: ::std::os::raw::c_ushort,
-pub st_gid: ::std::os::raw::c_ushort,
-pub st_rdev: ::std::os::raw::c_ushort,
-pub st_size: ::std::os::raw::c_ulong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
+pub st_dev: crate::ctypes::c_ushort,
+pub st_ino: crate::ctypes::c_ushort,
+pub st_mode: crate::ctypes::c_ushort,
+pub st_nlink: crate::ctypes::c_ushort,
+pub st_uid: crate::ctypes::c_ushort,
+pub st_gid: crate::ctypes::c_ushort,
+pub st_rdev: crate::ctypes::c_ushort,
+pub st_size: crate::ctypes::c_ulong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v5_11/x86/netlink.rs
+++ b/src/v5_11/x86/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -223,9 +223,9 @@ pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
 pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -235,64 +235,64 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_mode_t = ::std::os::raw::c_ushort;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_ushort;
-pub type __kernel_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ushort;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_mode_t = crate::ctypes::c_ushort;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_ushort;
+pub type __kernel_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_dev_t = crate::ctypes::c_ushort;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_pid_t = crate::ctypes::c_int;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_int;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -301,12 +301,12 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -322,7 +322,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -347,16 +347,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2239,21 +2239,21 @@ __RTM_MAX = 115,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNICAST;
@@ -2347,10 +2347,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2451,29 +2451,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_ADDRESS;
@@ -2497,10 +2497,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2547,14 +2547,14 @@ __TCA_MAX = 16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_SRCADDR;
@@ -2610,9 +2610,9 @@ __RTNLGRP_MAX = 34,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_TAB;

--- a/src/v5_11/x86_64/general.rs
+++ b/src/v5_11/x86_64/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -2043,58 +2043,58 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_old_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_dev_t = crate::ctypes::c_ulong;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2103,18 +2103,18 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -2122,8 +2122,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -2276,16 +2276,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2295,9 +2295,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2307,10 +2307,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2320,13 +2320,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2405,7 +2405,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2448,7 +2448,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2458,7 +2458,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2475,7 +2475,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2485,7 +2485,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2512,9 +2512,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2537,15 +2537,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2563,7 +2563,7 @@ pub tv_usec: __kernel_long_t,
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_old_timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2581,7 +2581,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2604,8 +2604,8 @@ pub it_value: timeval,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2639,32 +2639,32 @@ pub struct rlimit64 {
 pub rlim_cur: __u64,
 pub rlim_max: __u64,
 }
-pub type sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaction {
 pub sa_handler: __sighandler_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2688,9 +2688,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2704,48 +2704,48 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
+pub _addr: *mut crate::ctypes::c_void,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 8usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 8usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 8usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 8usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2756,14 +2756,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2771,22 +2771,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 12usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 12usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -2823,9 +2823,9 @@ pub stx_mnt_id: __u64,
 pub __spare2: __u64,
 pub __spare3: [__u64; 12usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2863,20 +2863,20 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 8usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2889,14 +2889,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2906,23 +2906,23 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulong,
-pub d_off: ::std::os::raw::c_long,
+pub d_ino: crate::ctypes::c_ulong,
+pub d_off: crate::ctypes::c_long,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
 pub st_dev: __kernel_ulong_t,
 pub st_ino: __kernel_ulong_t,
 pub st_nlink: __kernel_ulong_t,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub __pad0: ::std::os::raw::c_uint,
+pub st_mode: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub __pad0: crate::ctypes::c_uint,
 pub st_rdev: __kernel_ulong_t,
 pub st_size: __kernel_long_t,
 pub st_blksize: __kernel_long_t,
@@ -2938,17 +2938,17 @@ pub __unused: [__kernel_long_t; 3usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __old_kernel_stat {
-pub st_dev: ::std::os::raw::c_ushort,
-pub st_ino: ::std::os::raw::c_ushort,
-pub st_mode: ::std::os::raw::c_ushort,
-pub st_nlink: ::std::os::raw::c_ushort,
-pub st_uid: ::std::os::raw::c_ushort,
-pub st_gid: ::std::os::raw::c_ushort,
-pub st_rdev: ::std::os::raw::c_ushort,
-pub st_size: ::std::os::raw::c_uint,
-pub st_atime: ::std::os::raw::c_uint,
-pub st_mtime: ::std::os::raw::c_uint,
-pub st_ctime: ::std::os::raw::c_uint,
+pub st_dev: crate::ctypes::c_ushort,
+pub st_ino: crate::ctypes::c_ushort,
+pub st_mode: crate::ctypes::c_ushort,
+pub st_nlink: crate::ctypes::c_ushort,
+pub st_uid: crate::ctypes::c_ushort,
+pub st_gid: crate::ctypes::c_ushort,
+pub st_rdev: crate::ctypes::c_ushort,
+pub st_size: crate::ctypes::c_uint,
+pub st_atime: crate::ctypes::c_uint,
+pub st_mtime: crate::ctypes::c_uint,
+pub st_ctime: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v5_11/x86_64/netlink.rs
+++ b/src/v5_11/x86_64/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -223,9 +223,9 @@ pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
 pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -235,64 +235,64 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_old_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_dev_t = crate::ctypes::c_ulong;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_old_time_t = __kernel_long_t;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -301,12 +301,12 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -322,7 +322,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -347,16 +347,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2239,21 +2239,21 @@ __RTM_MAX = 115,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_54 = _bindgen_ty_54::RTN_UNICAST;
@@ -2347,10 +2347,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2451,29 +2451,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_56 = _bindgen_ty_56::PREFIX_ADDRESS;
@@ -2497,10 +2497,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2547,14 +2547,14 @@ __TCA_MAX = 16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_58 = _bindgen_ty_58::NDUSEROPT_SRCADDR;
@@ -2610,9 +2610,9 @@ __RTNLGRP_MAX = 34,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_59 = _bindgen_ty_59::TCA_ROOT_TAB;

--- a/src/v5_4/aarch64/general.rs
+++ b/src/v5_4/aarch64/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -1950,57 +1950,57 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_old_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2009,18 +2009,18 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -2028,8 +2028,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -2167,16 +2167,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2186,9 +2186,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2198,10 +2198,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2211,13 +2211,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2292,7 +2292,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2335,7 +2335,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2345,7 +2345,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2362,7 +2362,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2372,7 +2372,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2399,9 +2399,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2424,15 +2424,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2456,7 +2456,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2467,8 +2467,8 @@ pub tv_usec: __kernel_suseconds_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2517,34 +2517,34 @@ pub rlim_max: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigset_t {
-pub sig: [::std::os::raw::c_ulong; 1usize],
+pub sig: [crate::ctypes::c_ulong; 1usize],
 }
-pub type old_sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type old_sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaction {
 pub sa_handler: __sighandler_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2568,9 +2568,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2584,48 +2584,48 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
+pub _addr: *mut crate::ctypes::c_void,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 8usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 8usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 8usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 8usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2636,14 +2636,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2651,22 +2651,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 12usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 12usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -2701,9 +2701,9 @@ pub stx_dev_major: __u32,
 pub stx_dev_minor: __u32,
 pub __spare2: [__u64; 14usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2741,20 +2741,20 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 8usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2767,14 +2767,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2784,36 +2784,36 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulong,
-pub d_off: ::std::os::raw::c_long,
+pub d_ino: crate::ctypes::c_ulong,
+pub d_off: crate::ctypes::c_long,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_nlink: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub st_rdev: ::std::os::raw::c_ulong,
-pub __pad1: ::std::os::raw::c_ulong,
-pub st_size: ::std::os::raw::c_long,
-pub st_blksize: ::std::os::raw::c_int,
-pub __pad2: ::std::os::raw::c_int,
-pub st_blocks: ::std::os::raw::c_long,
-pub st_atime: ::std::os::raw::c_long,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_long,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_long,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub __unused4: ::std::os::raw::c_uint,
-pub __unused5: ::std::os::raw::c_uint,
+pub st_dev: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_nlink: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub st_rdev: crate::ctypes::c_ulong,
+pub __pad1: crate::ctypes::c_ulong,
+pub st_size: crate::ctypes::c_long,
+pub st_blksize: crate::ctypes::c_int,
+pub __pad2: crate::ctypes::c_int,
+pub st_blocks: crate::ctypes::c_long,
+pub st_atime: crate::ctypes::c_long,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_long,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_long,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub __unused4: crate::ctypes::c_uint,
+pub __unused5: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v5_4/aarch64/netlink.rs
+++ b/src/v5_4/aarch64/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -213,57 +213,57 @@ pub const RTEXT_FILTER_VF: u32 = 1;
 pub const RTEXT_FILTER_BRVLAN: u32 = 2;
 pub const RTEXT_FILTER_BRVLAN_COMPRESSED: u32 = 4;
 pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_old_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -272,7 +272,7 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug)]
 pub struct sysinfo {
@@ -289,9 +289,9 @@ pub pad: __u16,
 pub totalhigh: __kernel_ulong_t,
 pub freehigh: __kernel_ulong_t,
 pub mem_unit: __u32,
-pub _f: __IncompleteArrayField<::std::os::raw::c_char>,
+pub _f: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -301,19 +301,19 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -329,7 +329,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -353,16 +353,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2088,21 +2088,21 @@ __RTM_MAX = 107,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNICAST;
@@ -2196,10 +2196,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2300,29 +2300,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_ADDRESS;
@@ -2346,10 +2346,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2394,14 +2394,14 @@ __TCA_MAX = 15,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_SRCADDR;
@@ -2456,9 +2456,9 @@ __RTNLGRP_MAX = 33,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_TAB;

--- a/src/v5_4/arm/general.rs
+++ b/src/v5_4/arm/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -2039,57 +2039,57 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_mode_t = ::std::os::raw::c_ushort;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_ushort;
-pub type __kernel_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ushort;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_mode_t = crate::ctypes::c_ushort;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_ushort;
+pub type __kernel_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_dev_t = crate::ctypes::c_ushort;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_pid_t = crate::ctypes::c_int;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_int;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2098,18 +2098,18 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -2117,8 +2117,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -2256,16 +2256,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2275,9 +2275,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2287,10 +2287,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2300,13 +2300,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2381,7 +2381,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2424,7 +2424,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2434,7 +2434,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2451,7 +2451,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2461,7 +2461,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2488,9 +2488,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2513,15 +2513,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2545,7 +2545,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2556,8 +2556,8 @@ pub tv_usec: __kernel_suseconds_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2603,38 +2603,38 @@ pub struct rlimit64 {
 pub rlim_cur: __u64,
 pub rlim_max: __u64,
 }
-pub type sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sigaction {
 pub _u: sigaction__bindgen_ty_1,
 pub sa_mask: sigset_t,
-pub sa_flags: ::std::os::raw::c_ulong,
-pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: ::core::option::Option<unsafe extern "C" fn()>,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigaction__bindgen_ty_1 {
 pub _sa_handler: __sighandler_t,
-pub _sa_sigaction: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int, arg2: *mut siginfo, arg3: *mut ::std::os::raw::c_void)>,
+pub _sa_sigaction: ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int, arg2: *mut siginfo, arg3: *mut crate::ctypes::c_void)>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2658,9 +2658,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2674,48 +2674,48 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
+pub _addr: *mut crate::ctypes::c_void,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 4usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 4usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 4usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 4usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2726,14 +2726,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2741,22 +2741,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 13usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 13usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -2791,9 +2791,9 @@ pub stx_dev_major: __u32,
 pub stx_dev_minor: __u32,
 pub __spare2: [__u64; 14usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2831,20 +2831,20 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 8usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2857,14 +2857,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2874,72 +2874,72 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulonglong,
-pub d_off: ::std::os::raw::c_longlong,
+pub d_ino: crate::ctypes::c_ulonglong,
+pub d_off: crate::ctypes::c_longlong,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __old_kernel_stat {
-pub st_dev: ::std::os::raw::c_ushort,
-pub st_ino: ::std::os::raw::c_ushort,
-pub st_mode: ::std::os::raw::c_ushort,
-pub st_nlink: ::std::os::raw::c_ushort,
-pub st_uid: ::std::os::raw::c_ushort,
-pub st_gid: ::std::os::raw::c_ushort,
-pub st_rdev: ::std::os::raw::c_ushort,
-pub st_size: ::std::os::raw::c_ulong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
+pub st_dev: crate::ctypes::c_ushort,
+pub st_ino: crate::ctypes::c_ushort,
+pub st_mode: crate::ctypes::c_ushort,
+pub st_nlink: crate::ctypes::c_ushort,
+pub st_uid: crate::ctypes::c_ushort,
+pub st_gid: crate::ctypes::c_ushort,
+pub st_rdev: crate::ctypes::c_ushort,
+pub st_size: crate::ctypes::c_ulong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_ushort,
-pub st_nlink: ::std::os::raw::c_ushort,
-pub st_uid: ::std::os::raw::c_ushort,
-pub st_gid: ::std::os::raw::c_ushort,
-pub st_rdev: ::std::os::raw::c_ulong,
-pub st_size: ::std::os::raw::c_ulong,
-pub st_blksize: ::std::os::raw::c_ulong,
-pub st_blocks: ::std::os::raw::c_ulong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub __unused4: ::std::os::raw::c_ulong,
-pub __unused5: ::std::os::raw::c_ulong,
+pub st_dev: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_ushort,
+pub st_nlink: crate::ctypes::c_ushort,
+pub st_uid: crate::ctypes::c_ushort,
+pub st_gid: crate::ctypes::c_ushort,
+pub st_rdev: crate::ctypes::c_ulong,
+pub st_size: crate::ctypes::c_ulong,
+pub st_blksize: crate::ctypes::c_ulong,
+pub st_blocks: crate::ctypes::c_ulong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub __unused4: crate::ctypes::c_ulong,
+pub __unused5: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat64 {
-pub st_dev: ::std::os::raw::c_ulonglong,
-pub __pad0: [::std::os::raw::c_uchar; 4usize],
-pub __st_ino: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_nlink: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_ulong,
-pub st_gid: ::std::os::raw::c_ulong,
-pub st_rdev: ::std::os::raw::c_ulonglong,
-pub __pad3: [::std::os::raw::c_uchar; 4usize],
-pub st_size: ::std::os::raw::c_longlong,
-pub st_blksize: ::std::os::raw::c_ulong,
-pub st_blocks: ::std::os::raw::c_ulonglong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulonglong,
+pub st_dev: crate::ctypes::c_ulonglong,
+pub __pad0: [crate::ctypes::c_uchar; 4usize],
+pub __st_ino: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_nlink: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_ulong,
+pub st_gid: crate::ctypes::c_ulong,
+pub st_rdev: crate::ctypes::c_ulonglong,
+pub __pad3: [crate::ctypes::c_uchar; 4usize],
+pub st_size: crate::ctypes::c_longlong,
+pub st_blksize: crate::ctypes::c_ulong,
+pub st_blocks: crate::ctypes::c_ulonglong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulonglong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v5_4/arm/netlink.rs
+++ b/src/v5_4/arm/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -213,57 +213,57 @@ pub const RTEXT_FILTER_VF: u32 = 1;
 pub const RTEXT_FILTER_BRVLAN: u32 = 2;
 pub const RTEXT_FILTER_BRVLAN_COMPRESSED: u32 = 4;
 pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_mode_t = ::std::os::raw::c_ushort;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_ushort;
-pub type __kernel_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ushort;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_mode_t = crate::ctypes::c_ushort;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_ushort;
+pub type __kernel_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_dev_t = crate::ctypes::c_ushort;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_pid_t = crate::ctypes::c_int;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_int;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -272,7 +272,7 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sysinfo {
@@ -289,9 +289,9 @@ pub pad: __u16,
 pub totalhigh: __kernel_ulong_t,
 pub freehigh: __kernel_ulong_t,
 pub mem_unit: __u32,
-pub _f: [::std::os::raw::c_char; 8usize],
+pub _f: [crate::ctypes::c_char; 8usize],
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -301,19 +301,19 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -329,7 +329,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -353,16 +353,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2088,21 +2088,21 @@ __RTM_MAX = 107,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNICAST;
@@ -2196,10 +2196,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2300,29 +2300,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_ADDRESS;
@@ -2346,10 +2346,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2394,14 +2394,14 @@ __TCA_MAX = 15,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_SRCADDR;
@@ -2456,9 +2456,9 @@ __RTNLGRP_MAX = 33,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_TAB;

--- a/src/v5_4/mips/general.rs
+++ b/src/v5_4/mips/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -2180,57 +2180,57 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 524416;
 pub const TFD_CREATE_FLAGS: u32 = 524416;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_daddr_t = ::std::os::raw::c_long;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_daddr_t = crate::ctypes::c_long;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_int;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2239,29 +2239,29 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
-pub l_sysid: ::std::os::raw::c_long,
+pub l_sysid: crate::ctypes::c_long,
 pub l_pid: __kernel_pid_t,
-pub pad: [::std::os::raw::c_long; 4usize],
+pub pad: [crate::ctypes::c_long; 4usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -2399,16 +2399,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2418,9 +2418,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2430,10 +2430,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2443,13 +2443,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2524,7 +2524,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2567,7 +2567,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2577,7 +2577,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2594,7 +2594,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2604,7 +2604,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2631,9 +2631,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2656,15 +2656,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2688,7 +2688,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2699,8 +2699,8 @@ pub tv_usec: __kernel_suseconds_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2749,33 +2749,33 @@ pub rlim_max: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigset_t {
-pub sig: [::std::os::raw::c_ulong; 4usize],
+pub sig: [crate::ctypes::c_ulong; 4usize],
 }
-pub type old_sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type old_sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaction {
-pub sa_flags: ::std::os::raw::c_uint,
+pub sa_flags: crate::ctypes::c_uint,
 pub sa_handler: __sighandler_t,
 pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
+pub ss_sp: *mut crate::ctypes::c_void,
 pub ss_size: size_t,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_flags: crate::ctypes::c_int,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2799,9 +2799,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2815,48 +2815,48 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
+pub _addr: *mut crate::ctypes::c_void,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 4usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 4usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 4usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 4usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2867,14 +2867,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2882,22 +2882,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 13usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 13usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -2932,9 +2932,9 @@ pub stx_dev_major: __u32,
 pub stx_dev_minor: __u32,
 pub __spare2: [__u64; 14usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2972,49 +2972,49 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sgttyb {
-pub sg_ispeed: ::std::os::raw::c_char,
-pub sg_ospeed: ::std::os::raw::c_char,
-pub sg_erase: ::std::os::raw::c_char,
-pub sg_kill: ::std::os::raw::c_char,
-pub sg_flags: ::std::os::raw::c_int,
+pub sg_ispeed: crate::ctypes::c_char,
+pub sg_ospeed: crate::ctypes::c_char,
+pub sg_erase: crate::ctypes::c_char,
+pub sg_kill: crate::ctypes::c_char,
+pub sg_flags: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tchars {
-pub t_intrc: ::std::os::raw::c_char,
-pub t_quitc: ::std::os::raw::c_char,
-pub t_startc: ::std::os::raw::c_char,
-pub t_stopc: ::std::os::raw::c_char,
-pub t_eofc: ::std::os::raw::c_char,
-pub t_brkc: ::std::os::raw::c_char,
+pub t_intrc: crate::ctypes::c_char,
+pub t_quitc: crate::ctypes::c_char,
+pub t_startc: crate::ctypes::c_char,
+pub t_stopc: crate::ctypes::c_char,
+pub t_eofc: crate::ctypes::c_char,
+pub t_brkc: crate::ctypes::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ltchars {
-pub t_suspc: ::std::os::raw::c_char,
-pub t_dsuspc: ::std::os::raw::c_char,
-pub t_rprntc: ::std::os::raw::c_char,
-pub t_flushc: ::std::os::raw::c_char,
-pub t_werasc: ::std::os::raw::c_char,
-pub t_lnextc: ::std::os::raw::c_char,
+pub t_suspc: crate::ctypes::c_char,
+pub t_dsuspc: crate::ctypes::c_char,
+pub t_rprntc: crate::ctypes::c_char,
+pub t_flushc: crate::ctypes::c_char,
+pub t_werasc: crate::ctypes::c_char,
+pub t_lnextc: crate::ctypes::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_char,
-pub c_cc: [::std::os::raw::c_uchar; 23usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_char,
+pub c_cc: [crate::ctypes::c_uchar; 23usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3027,14 +3027,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3044,76 +3044,76 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulonglong,
-pub d_off: ::std::os::raw::c_longlong,
+pub d_ino: crate::ctypes::c_ulonglong,
+pub d_off: crate::ctypes::c_longlong,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_uint,
-pub st_pad1: [::std::os::raw::c_long; 3usize],
+pub st_dev: crate::ctypes::c_uint,
+pub st_pad1: [crate::ctypes::c_long; 3usize],
 pub st_ino: __kernel_ino_t,
 pub st_mode: __kernel_mode_t,
 pub st_nlink: __u32,
 pub st_uid: __kernel_uid_t,
 pub st_gid: __kernel_gid_t,
-pub st_rdev: ::std::os::raw::c_uint,
-pub st_pad2: [::std::os::raw::c_long; 2usize],
+pub st_rdev: crate::ctypes::c_uint,
+pub st_pad2: [crate::ctypes::c_long; 2usize],
 pub st_size: __kernel_off_t,
-pub st_pad3: ::std::os::raw::c_long,
+pub st_pad3: crate::ctypes::c_long,
 pub st_atime: __kernel_time_t,
-pub st_atime_nsec: ::std::os::raw::c_long,
+pub st_atime_nsec: crate::ctypes::c_long,
 pub st_mtime: __kernel_time_t,
-pub st_mtime_nsec: ::std::os::raw::c_long,
+pub st_mtime_nsec: crate::ctypes::c_long,
 pub st_ctime: __kernel_time_t,
-pub st_ctime_nsec: ::std::os::raw::c_long,
-pub st_blksize: ::std::os::raw::c_long,
-pub st_blocks: ::std::os::raw::c_long,
-pub st_pad4: [::std::os::raw::c_long; 14usize],
+pub st_ctime_nsec: crate::ctypes::c_long,
+pub st_blksize: crate::ctypes::c_long,
+pub st_blocks: crate::ctypes::c_long,
+pub st_pad4: [crate::ctypes::c_long; 14usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat64 {
-pub st_dev: ::std::os::raw::c_ulong,
-pub st_pad0: [::std::os::raw::c_ulong; 3usize],
-pub st_ino: ::std::os::raw::c_ulonglong,
+pub st_dev: crate::ctypes::c_ulong,
+pub st_pad0: [crate::ctypes::c_ulong; 3usize],
+pub st_ino: crate::ctypes::c_ulonglong,
 pub st_mode: __kernel_mode_t,
 pub st_nlink: __u32,
 pub st_uid: __kernel_uid_t,
 pub st_gid: __kernel_gid_t,
-pub st_rdev: ::std::os::raw::c_ulong,
-pub st_pad1: [::std::os::raw::c_ulong; 3usize],
-pub st_size: ::std::os::raw::c_longlong,
+pub st_rdev: crate::ctypes::c_ulong,
+pub st_pad1: [crate::ctypes::c_ulong; 3usize],
+pub st_size: crate::ctypes::c_longlong,
 pub st_atime: __kernel_time_t,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
 pub st_mtime: __kernel_time_t,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
 pub st_ctime: __kernel_time_t,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub st_blksize: ::std::os::raw::c_ulong,
-pub st_pad2: ::std::os::raw::c_ulong,
-pub st_blocks: ::std::os::raw::c_longlong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub st_blksize: crate::ctypes::c_ulong,
+pub st_pad2: crate::ctypes::c_ulong,
+pub st_blocks: crate::ctypes::c_longlong,
 }
 pub type fsid_t = __kernel_fsid_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct statfs {
-pub f_type: ::std::os::raw::c_long,
-pub f_bsize: ::std::os::raw::c_long,
-pub f_frsize: ::std::os::raw::c_long,
-pub f_blocks: ::std::os::raw::c_long,
-pub f_bfree: ::std::os::raw::c_long,
-pub f_files: ::std::os::raw::c_long,
-pub f_ffree: ::std::os::raw::c_long,
-pub f_bavail: ::std::os::raw::c_long,
+pub f_type: crate::ctypes::c_long,
+pub f_bsize: crate::ctypes::c_long,
+pub f_frsize: crate::ctypes::c_long,
+pub f_blocks: crate::ctypes::c_long,
+pub f_bfree: crate::ctypes::c_long,
+pub f_files: crate::ctypes::c_long,
+pub f_ffree: crate::ctypes::c_long,
+pub f_bavail: crate::ctypes::c_long,
 pub f_fsid: __kernel_fsid_t,
-pub f_namelen: ::std::os::raw::c_long,
-pub f_flags: ::std::os::raw::c_long,
-pub f_spare: [::std::os::raw::c_long; 5usize],
+pub f_namelen: crate::ctypes::c_long,
+pub f_flags: crate::ctypes::c_long,
+pub f_spare: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v5_4/mips/netlink.rs
+++ b/src/v5_4/mips/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -222,57 +222,57 @@ pub const RTEXT_FILTER_VF: u32 = 1;
 pub const RTEXT_FILTER_BRVLAN: u32 = 2;
 pub const RTEXT_FILTER_BRVLAN_COMPRESSED: u32 = 4;
 pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_daddr_t = ::std::os::raw::c_long;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_daddr_t = crate::ctypes::c_long;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_int;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -281,7 +281,7 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sysinfo {
@@ -298,9 +298,9 @@ pub pad: __u16,
 pub totalhigh: __kernel_ulong_t,
 pub freehigh: __kernel_ulong_t,
 pub mem_unit: __u32,
-pub _f: [::std::os::raw::c_char; 8usize],
+pub _f: [crate::ctypes::c_char; 8usize],
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -310,19 +310,19 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -338,7 +338,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -362,16 +362,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2097,21 +2097,21 @@ __RTM_MAX = 107,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNICAST;
@@ -2205,10 +2205,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2309,29 +2309,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_ADDRESS;
@@ -2355,10 +2355,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2403,14 +2403,14 @@ __TCA_MAX = 15,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_SRCADDR;
@@ -2465,9 +2465,9 @@ __RTNLGRP_MAX = 33,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_TAB;

--- a/src/v5_4/mips64/general.rs
+++ b/src/v5_4/mips64/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -2118,57 +2118,57 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 524416;
 pub const TFD_CREATE_FLAGS: u32 = 524416;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_long;
-pub type __u64 = ::std::os::raw::c_ulong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_long;
+pub type __u64 = crate::ctypes::c_ulong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_daddr_t = ::std::os::raw::c_long;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_daddr_t = crate::ctypes::c_long;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2177,18 +2177,18 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -2196,8 +2196,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -2335,16 +2335,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2354,9 +2354,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2366,10 +2366,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2379,13 +2379,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2460,7 +2460,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2503,7 +2503,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2513,7 +2513,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2530,7 +2530,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2540,7 +2540,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2567,9 +2567,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2592,15 +2592,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2624,7 +2624,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2635,8 +2635,8 @@ pub tv_usec: __kernel_suseconds_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2685,33 +2685,33 @@ pub rlim_max: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigset_t {
-pub sig: [::std::os::raw::c_ulong; 2usize],
+pub sig: [crate::ctypes::c_ulong; 2usize],
 }
-pub type old_sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type old_sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaction {
-pub sa_flags: ::std::os::raw::c_uint,
+pub sa_flags: crate::ctypes::c_uint,
 pub sa_handler: __sighandler_t,
 pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
+pub ss_sp: *mut crate::ctypes::c_void,
 pub ss_size: size_t,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_flags: crate::ctypes::c_int,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2735,9 +2735,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2751,48 +2751,48 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
+pub _addr: *mut crate::ctypes::c_void,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 8usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 8usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 8usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 8usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2803,14 +2803,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2818,22 +2818,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 12usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 12usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -2868,9 +2868,9 @@ pub stx_dev_major: __u32,
 pub stx_dev_minor: __u32,
 pub __spare2: [__u64; 14usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2908,49 +2908,49 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sgttyb {
-pub sg_ispeed: ::std::os::raw::c_char,
-pub sg_ospeed: ::std::os::raw::c_char,
-pub sg_erase: ::std::os::raw::c_char,
-pub sg_kill: ::std::os::raw::c_char,
-pub sg_flags: ::std::os::raw::c_int,
+pub sg_ispeed: crate::ctypes::c_char,
+pub sg_ospeed: crate::ctypes::c_char,
+pub sg_erase: crate::ctypes::c_char,
+pub sg_kill: crate::ctypes::c_char,
+pub sg_flags: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tchars {
-pub t_intrc: ::std::os::raw::c_char,
-pub t_quitc: ::std::os::raw::c_char,
-pub t_startc: ::std::os::raw::c_char,
-pub t_stopc: ::std::os::raw::c_char,
-pub t_eofc: ::std::os::raw::c_char,
-pub t_brkc: ::std::os::raw::c_char,
+pub t_intrc: crate::ctypes::c_char,
+pub t_quitc: crate::ctypes::c_char,
+pub t_startc: crate::ctypes::c_char,
+pub t_stopc: crate::ctypes::c_char,
+pub t_eofc: crate::ctypes::c_char,
+pub t_brkc: crate::ctypes::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ltchars {
-pub t_suspc: ::std::os::raw::c_char,
-pub t_dsuspc: ::std::os::raw::c_char,
-pub t_rprntc: ::std::os::raw::c_char,
-pub t_flushc: ::std::os::raw::c_char,
-pub t_werasc: ::std::os::raw::c_char,
-pub t_lnextc: ::std::os::raw::c_char,
+pub t_suspc: crate::ctypes::c_char,
+pub t_dsuspc: crate::ctypes::c_char,
+pub t_rprntc: crate::ctypes::c_char,
+pub t_flushc: crate::ctypes::c_char,
+pub t_werasc: crate::ctypes::c_char,
+pub t_lnextc: crate::ctypes::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_char,
-pub c_cc: [::std::os::raw::c_uchar; 23usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_char,
+pub c_cc: [crate::ctypes::c_uchar; 23usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2963,14 +2963,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2980,68 +2980,68 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulong,
-pub d_off: ::std::os::raw::c_long,
+pub d_ino: crate::ctypes::c_ulong,
+pub d_off: crate::ctypes::c_long,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_uint,
-pub st_pad0: [::std::os::raw::c_uint; 3usize],
-pub st_ino: ::std::os::raw::c_ulong,
+pub st_dev: crate::ctypes::c_uint,
+pub st_pad0: [crate::ctypes::c_uint; 3usize],
+pub st_ino: crate::ctypes::c_ulong,
 pub st_mode: __kernel_mode_t,
 pub st_nlink: __u32,
 pub st_uid: __kernel_uid_t,
 pub st_gid: __kernel_gid_t,
-pub st_rdev: ::std::os::raw::c_uint,
-pub st_pad1: [::std::os::raw::c_uint; 3usize],
+pub st_rdev: crate::ctypes::c_uint,
+pub st_pad1: [crate::ctypes::c_uint; 3usize],
 pub st_size: __kernel_off_t,
-pub st_atime: ::std::os::raw::c_uint,
-pub st_atime_nsec: ::std::os::raw::c_uint,
-pub st_mtime: ::std::os::raw::c_uint,
-pub st_mtime_nsec: ::std::os::raw::c_uint,
-pub st_ctime: ::std::os::raw::c_uint,
-pub st_ctime_nsec: ::std::os::raw::c_uint,
-pub st_blksize: ::std::os::raw::c_uint,
-pub st_pad2: ::std::os::raw::c_uint,
-pub st_blocks: ::std::os::raw::c_ulong,
+pub st_atime: crate::ctypes::c_uint,
+pub st_atime_nsec: crate::ctypes::c_uint,
+pub st_mtime: crate::ctypes::c_uint,
+pub st_mtime_nsec: crate::ctypes::c_uint,
+pub st_ctime: crate::ctypes::c_uint,
+pub st_ctime_nsec: crate::ctypes::c_uint,
+pub st_blksize: crate::ctypes::c_uint,
+pub st_pad2: crate::ctypes::c_uint,
+pub st_blocks: crate::ctypes::c_ulong,
 }
 pub type fsid_t = __kernel_fsid_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct statfs {
-pub f_type: ::std::os::raw::c_long,
-pub f_bsize: ::std::os::raw::c_long,
-pub f_frsize: ::std::os::raw::c_long,
-pub f_blocks: ::std::os::raw::c_long,
-pub f_bfree: ::std::os::raw::c_long,
-pub f_files: ::std::os::raw::c_long,
-pub f_ffree: ::std::os::raw::c_long,
-pub f_bavail: ::std::os::raw::c_long,
+pub f_type: crate::ctypes::c_long,
+pub f_bsize: crate::ctypes::c_long,
+pub f_frsize: crate::ctypes::c_long,
+pub f_blocks: crate::ctypes::c_long,
+pub f_bfree: crate::ctypes::c_long,
+pub f_files: crate::ctypes::c_long,
+pub f_ffree: crate::ctypes::c_long,
+pub f_bavail: crate::ctypes::c_long,
 pub f_fsid: __kernel_fsid_t,
-pub f_namelen: ::std::os::raw::c_long,
-pub f_flags: ::std::os::raw::c_long,
-pub f_spare: [::std::os::raw::c_long; 5usize],
+pub f_namelen: crate::ctypes::c_long,
+pub f_flags: crate::ctypes::c_long,
+pub f_spare: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct statfs64 {
-pub f_type: ::std::os::raw::c_long,
-pub f_bsize: ::std::os::raw::c_long,
-pub f_frsize: ::std::os::raw::c_long,
-pub f_blocks: ::std::os::raw::c_long,
-pub f_bfree: ::std::os::raw::c_long,
-pub f_files: ::std::os::raw::c_long,
-pub f_ffree: ::std::os::raw::c_long,
-pub f_bavail: ::std::os::raw::c_long,
+pub f_type: crate::ctypes::c_long,
+pub f_bsize: crate::ctypes::c_long,
+pub f_frsize: crate::ctypes::c_long,
+pub f_blocks: crate::ctypes::c_long,
+pub f_bfree: crate::ctypes::c_long,
+pub f_files: crate::ctypes::c_long,
+pub f_ffree: crate::ctypes::c_long,
+pub f_bavail: crate::ctypes::c_long,
 pub f_fsid: __kernel_fsid_t,
-pub f_namelen: ::std::os::raw::c_long,
-pub f_flags: ::std::os::raw::c_long,
-pub f_spare: [::std::os::raw::c_long; 5usize],
+pub f_namelen: crate::ctypes::c_long,
+pub f_flags: crate::ctypes::c_long,
+pub f_spare: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v5_4/mips64/netlink.rs
+++ b/src/v5_4/mips64/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -222,57 +222,57 @@ pub const RTEXT_FILTER_VF: u32 = 1;
 pub const RTEXT_FILTER_BRVLAN: u32 = 2;
 pub const RTEXT_FILTER_BRVLAN_COMPRESSED: u32 = 4;
 pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_long;
-pub type __u64 = ::std::os::raw::c_ulong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_long;
+pub type __u64 = crate::ctypes::c_ulong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_daddr_t = ::std::os::raw::c_long;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_daddr_t = crate::ctypes::c_long;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -281,7 +281,7 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug)]
 pub struct sysinfo {
@@ -298,9 +298,9 @@ pub pad: __u16,
 pub totalhigh: __kernel_ulong_t,
 pub freehigh: __kernel_ulong_t,
 pub mem_unit: __u32,
-pub _f: __IncompleteArrayField<::std::os::raw::c_char>,
+pub _f: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -310,19 +310,19 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -338,7 +338,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -362,16 +362,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2097,21 +2097,21 @@ __RTM_MAX = 107,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNICAST;
@@ -2205,10 +2205,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2309,29 +2309,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_ADDRESS;
@@ -2355,10 +2355,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2403,14 +2403,14 @@ __TCA_MAX = 15,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_SRCADDR;
@@ -2465,9 +2465,9 @@ __RTNLGRP_MAX = 33,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_TAB;

--- a/src/v5_4/powerpc/general.rs
+++ b/src/v5_4/powerpc/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -2046,16 +2046,16 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Copy, Clone)]
@@ -2065,44 +2065,44 @@ pub u: [__u32; 4usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_long;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_short;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_long;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_short;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2111,18 +2111,18 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -2130,8 +2130,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -2269,16 +2269,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2288,9 +2288,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2300,10 +2300,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2313,13 +2313,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2394,7 +2394,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2437,7 +2437,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2447,7 +2447,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2464,7 +2464,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2474,7 +2474,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2501,9 +2501,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2526,15 +2526,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2558,7 +2558,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2569,8 +2569,8 @@ pub tv_usec: __kernel_suseconds_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2616,51 +2616,51 @@ pub struct rlimit64 {
 pub rlim_cur: __u64,
 pub rlim_max: __u64,
 }
-pub type old_sigset_t = ::std::os::raw::c_ulong;
+pub type old_sigset_t = crate::ctypes::c_ulong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigset_t {
-pub sig: [::std::os::raw::c_ulong; 2usize],
+pub sig: [crate::ctypes::c_ulong; 2usize],
 }
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct old_sigaction {
 pub sa_handler: __sighandler_t,
 pub sa_mask: old_sigset_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaction {
 pub sa_handler: __sighandler_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sig_dbg_op {
-pub dbg_type: ::std::os::raw::c_int,
-pub dbg_value: ::std::os::raw::c_ulong,
+pub dbg_type: crate::ctypes::c_int,
+pub dbg_value: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2684,9 +2684,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2700,48 +2700,48 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
+pub _addr: *mut crate::ctypes::c_void,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 4usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 4usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 4usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 4usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2752,14 +2752,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2767,22 +2767,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 13usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 13usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -2817,9 +2817,9 @@ pub stx_dev_major: __u32,
 pub stx_dev_minor: __u32,
 pub __spare2: [__u64; 14usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2847,49 +2847,49 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sgttyb {
-pub sg_ispeed: ::std::os::raw::c_char,
-pub sg_ospeed: ::std::os::raw::c_char,
-pub sg_erase: ::std::os::raw::c_char,
-pub sg_kill: ::std::os::raw::c_char,
-pub sg_flags: ::std::os::raw::c_short,
+pub sg_ispeed: crate::ctypes::c_char,
+pub sg_ospeed: crate::ctypes::c_char,
+pub sg_erase: crate::ctypes::c_char,
+pub sg_kill: crate::ctypes::c_char,
+pub sg_flags: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tchars {
-pub t_intrc: ::std::os::raw::c_char,
-pub t_quitc: ::std::os::raw::c_char,
-pub t_startc: ::std::os::raw::c_char,
-pub t_stopc: ::std::os::raw::c_char,
-pub t_eofc: ::std::os::raw::c_char,
-pub t_brkc: ::std::os::raw::c_char,
+pub t_intrc: crate::ctypes::c_char,
+pub t_quitc: crate::ctypes::c_char,
+pub t_startc: crate::ctypes::c_char,
+pub t_stopc: crate::ctypes::c_char,
+pub t_eofc: crate::ctypes::c_char,
+pub t_brkc: crate::ctypes::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ltchars {
-pub t_suspc: ::std::os::raw::c_char,
-pub t_dsuspc: ::std::os::raw::c_char,
-pub t_rprntc: ::std::os::raw::c_char,
-pub t_flushc: ::std::os::raw::c_char,
-pub t_werasc: ::std::os::raw::c_char,
-pub t_lnextc: ::std::os::raw::c_char,
+pub t_suspc: crate::ctypes::c_char,
+pub t_dsuspc: crate::ctypes::c_char,
+pub t_rprntc: crate::ctypes::c_char,
+pub t_flushc: crate::ctypes::c_char,
+pub t_werasc: crate::ctypes::c_char,
+pub t_lnextc: crate::ctypes::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 10usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 10usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2902,14 +2902,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2919,72 +2919,72 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulonglong,
-pub d_off: ::std::os::raw::c_longlong,
+pub d_ino: crate::ctypes::c_ulonglong,
+pub d_off: crate::ctypes::c_longlong,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __old_kernel_stat {
-pub st_dev: ::std::os::raw::c_ushort,
-pub st_ino: ::std::os::raw::c_ushort,
-pub st_mode: ::std::os::raw::c_ushort,
-pub st_nlink: ::std::os::raw::c_ushort,
-pub st_uid: ::std::os::raw::c_ushort,
-pub st_gid: ::std::os::raw::c_ushort,
-pub st_rdev: ::std::os::raw::c_ushort,
-pub st_size: ::std::os::raw::c_ulong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
+pub st_dev: crate::ctypes::c_ushort,
+pub st_ino: crate::ctypes::c_ushort,
+pub st_mode: crate::ctypes::c_ushort,
+pub st_nlink: crate::ctypes::c_ushort,
+pub st_uid: crate::ctypes::c_ushort,
+pub st_gid: crate::ctypes::c_ushort,
+pub st_rdev: crate::ctypes::c_ushort,
+pub st_size: crate::ctypes::c_ulong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ulong,
+pub st_dev: crate::ctypes::c_ulong,
 pub st_ino: __kernel_ino_t,
 pub st_mode: __kernel_mode_t,
-pub st_nlink: ::std::os::raw::c_ushort,
+pub st_nlink: crate::ctypes::c_ushort,
 pub st_uid: __kernel_uid_t,
 pub st_gid: __kernel_gid_t,
-pub st_rdev: ::std::os::raw::c_ulong,
+pub st_rdev: crate::ctypes::c_ulong,
 pub st_size: __kernel_off_t,
-pub st_blksize: ::std::os::raw::c_ulong,
-pub st_blocks: ::std::os::raw::c_ulong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub __unused4: ::std::os::raw::c_ulong,
-pub __unused5: ::std::os::raw::c_ulong,
+pub st_blksize: crate::ctypes::c_ulong,
+pub st_blocks: crate::ctypes::c_ulong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub __unused4: crate::ctypes::c_ulong,
+pub __unused5: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat64 {
-pub st_dev: ::std::os::raw::c_ulonglong,
-pub st_ino: ::std::os::raw::c_ulonglong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_nlink: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub st_rdev: ::std::os::raw::c_ulonglong,
-pub __pad2: ::std::os::raw::c_ushort,
-pub st_size: ::std::os::raw::c_longlong,
-pub st_blksize: ::std::os::raw::c_int,
-pub st_blocks: ::std::os::raw::c_longlong,
-pub st_atime: ::std::os::raw::c_int,
-pub st_atime_nsec: ::std::os::raw::c_uint,
-pub st_mtime: ::std::os::raw::c_int,
-pub st_mtime_nsec: ::std::os::raw::c_uint,
-pub st_ctime: ::std::os::raw::c_int,
-pub st_ctime_nsec: ::std::os::raw::c_uint,
-pub __unused4: ::std::os::raw::c_uint,
-pub __unused5: ::std::os::raw::c_uint,
+pub st_dev: crate::ctypes::c_ulonglong,
+pub st_ino: crate::ctypes::c_ulonglong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_nlink: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub st_rdev: crate::ctypes::c_ulonglong,
+pub __pad2: crate::ctypes::c_ushort,
+pub st_size: crate::ctypes::c_longlong,
+pub st_blksize: crate::ctypes::c_int,
+pub st_blocks: crate::ctypes::c_longlong,
+pub st_atime: crate::ctypes::c_int,
+pub st_atime_nsec: crate::ctypes::c_uint,
+pub st_mtime: crate::ctypes::c_int,
+pub st_mtime_nsec: crate::ctypes::c_uint,
+pub st_ctime: crate::ctypes::c_int,
+pub st_ctime_nsec: crate::ctypes::c_uint,
+pub __unused4: crate::ctypes::c_uint,
+pub __unused5: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v5_4/powerpc/netlink.rs
+++ b/src/v5_4/powerpc/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -213,16 +213,16 @@ pub const RTEXT_FILTER_VF: u32 = 1;
 pub const RTEXT_FILTER_BRVLAN: u32 = 2;
 pub const RTEXT_FILTER_BRVLAN_COMPRESSED: u32 = 4;
 pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Copy, Clone)]
@@ -232,44 +232,44 @@ pub u: [__u32; 4usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_long;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_short;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_long;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_short;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -278,7 +278,7 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sysinfo {
@@ -295,9 +295,9 @@ pub pad: __u16,
 pub totalhigh: __kernel_ulong_t,
 pub freehigh: __kernel_ulong_t,
 pub mem_unit: __u32,
-pub _f: [::std::os::raw::c_char; 8usize],
+pub _f: [crate::ctypes::c_char; 8usize],
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -307,19 +307,19 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -335,7 +335,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -359,16 +359,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2094,21 +2094,21 @@ __RTM_MAX = 107,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNICAST;
@@ -2202,10 +2202,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2306,29 +2306,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_ADDRESS;
@@ -2352,10 +2352,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2400,14 +2400,14 @@ __TCA_MAX = 15,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_SRCADDR;
@@ -2462,9 +2462,9 @@ __RTNLGRP_MAX = 33,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_TAB;

--- a/src/v5_4/powerpc64/general.rs
+++ b/src/v5_4/powerpc64/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -2024,16 +2024,16 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_long;
-pub type __u64 = ::std::os::raw::c_ulong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_long;
+pub type __u64 = crate::ctypes::c_ulong;
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Copy, Clone)]
@@ -2043,24 +2043,24 @@ pub u: [__u32; 4usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_old_dev_t = crate::ctypes::c_ulong;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
 pub type __kernel_size_t = __kernel_ulong_t;
@@ -2069,18 +2069,18 @@ pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2089,18 +2089,18 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -2108,8 +2108,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -2247,16 +2247,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2266,9 +2266,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2278,10 +2278,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2291,13 +2291,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2372,7 +2372,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2415,7 +2415,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2425,7 +2425,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2442,7 +2442,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2452,7 +2452,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2479,9 +2479,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2504,15 +2504,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2536,7 +2536,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2547,8 +2547,8 @@ pub tv_usec: __kernel_suseconds_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2594,45 +2594,45 @@ pub struct rlimit64 {
 pub rlim_cur: __u64,
 pub rlim_max: __u64,
 }
-pub type old_sigset_t = ::std::os::raw::c_ulong;
+pub type old_sigset_t = crate::ctypes::c_ulong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigset_t {
-pub sig: [::std::os::raw::c_ulong; 1usize],
+pub sig: [crate::ctypes::c_ulong; 1usize],
 }
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct old_sigaction {
 pub sa_handler: __sighandler_t,
 pub sa_mask: old_sigset_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaction {
 pub sa_handler: __sighandler_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2656,9 +2656,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2672,48 +2672,48 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
+pub _addr: *mut crate::ctypes::c_void,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 8usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 8usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 8usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 8usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2724,14 +2724,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2739,22 +2739,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 12usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 12usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -2789,9 +2789,9 @@ pub stx_dev_major: __u32,
 pub stx_dev_minor: __u32,
 pub __spare2: [__u64; 14usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2819,49 +2819,49 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sgttyb {
-pub sg_ispeed: ::std::os::raw::c_char,
-pub sg_ospeed: ::std::os::raw::c_char,
-pub sg_erase: ::std::os::raw::c_char,
-pub sg_kill: ::std::os::raw::c_char,
-pub sg_flags: ::std::os::raw::c_short,
+pub sg_ispeed: crate::ctypes::c_char,
+pub sg_ospeed: crate::ctypes::c_char,
+pub sg_erase: crate::ctypes::c_char,
+pub sg_kill: crate::ctypes::c_char,
+pub sg_flags: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tchars {
-pub t_intrc: ::std::os::raw::c_char,
-pub t_quitc: ::std::os::raw::c_char,
-pub t_startc: ::std::os::raw::c_char,
-pub t_stopc: ::std::os::raw::c_char,
-pub t_eofc: ::std::os::raw::c_char,
-pub t_brkc: ::std::os::raw::c_char,
+pub t_intrc: crate::ctypes::c_char,
+pub t_quitc: crate::ctypes::c_char,
+pub t_startc: crate::ctypes::c_char,
+pub t_stopc: crate::ctypes::c_char,
+pub t_eofc: crate::ctypes::c_char,
+pub t_brkc: crate::ctypes::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ltchars {
-pub t_suspc: ::std::os::raw::c_char,
-pub t_dsuspc: ::std::os::raw::c_char,
-pub t_rprntc: ::std::os::raw::c_char,
-pub t_flushc: ::std::os::raw::c_char,
-pub t_werasc: ::std::os::raw::c_char,
-pub t_lnextc: ::std::os::raw::c_char,
+pub t_suspc: crate::ctypes::c_char,
+pub t_dsuspc: crate::ctypes::c_char,
+pub t_rprntc: crate::ctypes::c_char,
+pub t_flushc: crate::ctypes::c_char,
+pub t_werasc: crate::ctypes::c_char,
+pub t_lnextc: crate::ctypes::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 10usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 10usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2874,14 +2874,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2891,58 +2891,58 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulong,
-pub d_off: ::std::os::raw::c_long,
+pub d_ino: crate::ctypes::c_ulong,
+pub d_off: crate::ctypes::c_long,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ulong,
+pub st_dev: crate::ctypes::c_ulong,
 pub st_ino: __kernel_ino_t,
-pub st_nlink: ::std::os::raw::c_ulong,
+pub st_nlink: crate::ctypes::c_ulong,
 pub st_mode: __kernel_mode_t,
 pub st_uid: __kernel_uid_t,
 pub st_gid: __kernel_gid_t,
-pub st_rdev: ::std::os::raw::c_ulong,
+pub st_rdev: crate::ctypes::c_ulong,
 pub st_size: __kernel_off_t,
-pub st_blksize: ::std::os::raw::c_ulong,
-pub st_blocks: ::std::os::raw::c_ulong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub __unused4: ::std::os::raw::c_ulong,
-pub __unused5: ::std::os::raw::c_ulong,
-pub __unused6: ::std::os::raw::c_ulong,
+pub st_blksize: crate::ctypes::c_ulong,
+pub st_blocks: crate::ctypes::c_ulong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub __unused4: crate::ctypes::c_ulong,
+pub __unused5: crate::ctypes::c_ulong,
+pub __unused6: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat64 {
-pub st_dev: ::std::os::raw::c_ulonglong,
-pub st_ino: ::std::os::raw::c_ulonglong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_nlink: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub st_rdev: ::std::os::raw::c_ulonglong,
-pub __pad2: ::std::os::raw::c_ushort,
-pub st_size: ::std::os::raw::c_longlong,
-pub st_blksize: ::std::os::raw::c_int,
-pub st_blocks: ::std::os::raw::c_longlong,
-pub st_atime: ::std::os::raw::c_int,
-pub st_atime_nsec: ::std::os::raw::c_uint,
-pub st_mtime: ::std::os::raw::c_int,
-pub st_mtime_nsec: ::std::os::raw::c_uint,
-pub st_ctime: ::std::os::raw::c_int,
-pub st_ctime_nsec: ::std::os::raw::c_uint,
-pub __unused4: ::std::os::raw::c_uint,
-pub __unused5: ::std::os::raw::c_uint,
+pub st_dev: crate::ctypes::c_ulonglong,
+pub st_ino: crate::ctypes::c_ulonglong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_nlink: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub st_rdev: crate::ctypes::c_ulonglong,
+pub __pad2: crate::ctypes::c_ushort,
+pub st_size: crate::ctypes::c_longlong,
+pub st_blksize: crate::ctypes::c_int,
+pub st_blocks: crate::ctypes::c_longlong,
+pub st_atime: crate::ctypes::c_int,
+pub st_atime_nsec: crate::ctypes::c_uint,
+pub st_mtime: crate::ctypes::c_int,
+pub st_mtime_nsec: crate::ctypes::c_uint,
+pub st_ctime: crate::ctypes::c_int,
+pub st_ctime_nsec: crate::ctypes::c_uint,
+pub __unused4: crate::ctypes::c_uint,
+pub __unused5: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v5_4/powerpc64/netlink.rs
+++ b/src/v5_4/powerpc64/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -213,16 +213,16 @@ pub const RTEXT_FILTER_VF: u32 = 1;
 pub const RTEXT_FILTER_BRVLAN: u32 = 2;
 pub const RTEXT_FILTER_BRVLAN_COMPRESSED: u32 = 4;
 pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_long;
-pub type __u64 = ::std::os::raw::c_ulong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_long;
+pub type __u64 = crate::ctypes::c_ulong;
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Copy, Clone)]
@@ -232,24 +232,24 @@ pub u: [__u32; 4usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_old_dev_t = crate::ctypes::c_ulong;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
 pub type __kernel_size_t = __kernel_ulong_t;
@@ -258,18 +258,18 @@ pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -278,7 +278,7 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug)]
 pub struct sysinfo {
@@ -295,9 +295,9 @@ pub pad: __u16,
 pub totalhigh: __kernel_ulong_t,
 pub freehigh: __kernel_ulong_t,
 pub mem_unit: __u32,
-pub _f: __IncompleteArrayField<::std::os::raw::c_char>,
+pub _f: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -307,19 +307,19 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -335,7 +335,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -359,16 +359,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2094,21 +2094,21 @@ __RTM_MAX = 107,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNICAST;
@@ -2202,10 +2202,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2306,29 +2306,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_ADDRESS;
@@ -2352,10 +2352,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2400,14 +2400,14 @@ __TCA_MAX = 15,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_SRCADDR;
@@ -2462,9 +2462,9 @@ __RTNLGRP_MAX = 33,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_TAB;

--- a/src/v5_4/riscv32/general.rs
+++ b/src/v5_4/riscv32/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -1926,57 +1926,57 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_int;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -1985,18 +1985,18 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -2004,8 +2004,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -2143,16 +2143,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2162,9 +2162,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2174,10 +2174,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2187,13 +2187,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2268,7 +2268,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2311,7 +2311,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2321,7 +2321,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2338,7 +2338,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2348,7 +2348,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2375,9 +2375,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2400,15 +2400,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2432,7 +2432,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2443,8 +2443,8 @@ pub tv_usec: __kernel_suseconds_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2493,33 +2493,33 @@ pub rlim_max: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigset_t {
-pub sig: [::std::os::raw::c_ulong; 2usize],
+pub sig: [crate::ctypes::c_ulong; 2usize],
 }
-pub type old_sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type old_sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaction {
 pub sa_handler: __sighandler_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2543,9 +2543,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2559,48 +2559,48 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
+pub _addr: *mut crate::ctypes::c_void,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 4usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 4usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 4usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 4usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2611,14 +2611,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2626,22 +2626,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 13usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 13usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -2676,9 +2676,9 @@ pub stx_dev_major: __u32,
 pub stx_dev_minor: __u32,
 pub __spare2: [__u64; 14usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2716,20 +2716,20 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 8usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2742,14 +2742,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2759,60 +2759,60 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulonglong,
-pub d_off: ::std::os::raw::c_longlong,
+pub d_ino: crate::ctypes::c_ulonglong,
+pub d_off: crate::ctypes::c_longlong,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_nlink: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub st_rdev: ::std::os::raw::c_ulong,
-pub __pad1: ::std::os::raw::c_ulong,
-pub st_size: ::std::os::raw::c_long,
-pub st_blksize: ::std::os::raw::c_int,
-pub __pad2: ::std::os::raw::c_int,
-pub st_blocks: ::std::os::raw::c_long,
-pub st_atime: ::std::os::raw::c_long,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_long,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_long,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub __unused4: ::std::os::raw::c_uint,
-pub __unused5: ::std::os::raw::c_uint,
+pub st_dev: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_nlink: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub st_rdev: crate::ctypes::c_ulong,
+pub __pad1: crate::ctypes::c_ulong,
+pub st_size: crate::ctypes::c_long,
+pub st_blksize: crate::ctypes::c_int,
+pub __pad2: crate::ctypes::c_int,
+pub st_blocks: crate::ctypes::c_long,
+pub st_atime: crate::ctypes::c_long,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_long,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_long,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub __unused4: crate::ctypes::c_uint,
+pub __unused5: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat64 {
-pub st_dev: ::std::os::raw::c_ulonglong,
-pub st_ino: ::std::os::raw::c_ulonglong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_nlink: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub st_rdev: ::std::os::raw::c_ulonglong,
-pub __pad1: ::std::os::raw::c_ulonglong,
-pub st_size: ::std::os::raw::c_longlong,
-pub st_blksize: ::std::os::raw::c_int,
-pub __pad2: ::std::os::raw::c_int,
-pub st_blocks: ::std::os::raw::c_longlong,
-pub st_atime: ::std::os::raw::c_int,
-pub st_atime_nsec: ::std::os::raw::c_uint,
-pub st_mtime: ::std::os::raw::c_int,
-pub st_mtime_nsec: ::std::os::raw::c_uint,
-pub st_ctime: ::std::os::raw::c_int,
-pub st_ctime_nsec: ::std::os::raw::c_uint,
-pub __unused4: ::std::os::raw::c_uint,
-pub __unused5: ::std::os::raw::c_uint,
+pub st_dev: crate::ctypes::c_ulonglong,
+pub st_ino: crate::ctypes::c_ulonglong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_nlink: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub st_rdev: crate::ctypes::c_ulonglong,
+pub __pad1: crate::ctypes::c_ulonglong,
+pub st_size: crate::ctypes::c_longlong,
+pub st_blksize: crate::ctypes::c_int,
+pub __pad2: crate::ctypes::c_int,
+pub st_blocks: crate::ctypes::c_longlong,
+pub st_atime: crate::ctypes::c_int,
+pub st_atime_nsec: crate::ctypes::c_uint,
+pub st_mtime: crate::ctypes::c_int,
+pub st_mtime_nsec: crate::ctypes::c_uint,
+pub st_ctime: crate::ctypes::c_int,
+pub st_ctime_nsec: crate::ctypes::c_uint,
+pub __unused4: crate::ctypes::c_uint,
+pub __unused5: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v5_4/riscv32/netlink.rs
+++ b/src/v5_4/riscv32/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -212,57 +212,57 @@ pub const RTEXT_FILTER_VF: u32 = 1;
 pub const RTEXT_FILTER_BRVLAN: u32 = 2;
 pub const RTEXT_FILTER_BRVLAN_COMPRESSED: u32 = 4;
 pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_int;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -271,7 +271,7 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sysinfo {
@@ -288,9 +288,9 @@ pub pad: __u16,
 pub totalhigh: __kernel_ulong_t,
 pub freehigh: __kernel_ulong_t,
 pub mem_unit: __u32,
-pub _f: [::std::os::raw::c_char; 8usize],
+pub _f: [crate::ctypes::c_char; 8usize],
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -300,19 +300,19 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -328,7 +328,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -352,16 +352,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2087,21 +2087,21 @@ __RTM_MAX = 107,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNICAST;
@@ -2195,10 +2195,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2299,29 +2299,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_ADDRESS;
@@ -2345,10 +2345,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2393,14 +2393,14 @@ __TCA_MAX = 15,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_SRCADDR;
@@ -2455,9 +2455,9 @@ __RTNLGRP_MAX = 33,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_TAB;

--- a/src/v5_4/riscv64/general.rs
+++ b/src/v5_4/riscv64/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -1947,57 +1947,57 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2006,18 +2006,18 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -2025,8 +2025,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -2164,16 +2164,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2183,9 +2183,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2195,10 +2195,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2208,13 +2208,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2289,7 +2289,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2332,7 +2332,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2342,7 +2342,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2359,7 +2359,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2369,7 +2369,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2396,9 +2396,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2421,15 +2421,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2453,7 +2453,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2464,8 +2464,8 @@ pub tv_usec: __kernel_suseconds_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2514,33 +2514,33 @@ pub rlim_max: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigset_t {
-pub sig: [::std::os::raw::c_ulong; 1usize],
+pub sig: [crate::ctypes::c_ulong; 1usize],
 }
-pub type old_sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type old_sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaction {
 pub sa_handler: __sighandler_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2564,9 +2564,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2580,48 +2580,48 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
+pub _addr: *mut crate::ctypes::c_void,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 8usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 8usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 8usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 8usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2632,14 +2632,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2647,22 +2647,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 12usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 12usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -2697,9 +2697,9 @@ pub stx_dev_major: __u32,
 pub stx_dev_minor: __u32,
 pub __spare2: [__u64; 14usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2737,20 +2737,20 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 8usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2763,14 +2763,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2780,36 +2780,36 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulong,
-pub d_off: ::std::os::raw::c_long,
+pub d_ino: crate::ctypes::c_ulong,
+pub d_off: crate::ctypes::c_long,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_nlink: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub st_rdev: ::std::os::raw::c_ulong,
-pub __pad1: ::std::os::raw::c_ulong,
-pub st_size: ::std::os::raw::c_long,
-pub st_blksize: ::std::os::raw::c_int,
-pub __pad2: ::std::os::raw::c_int,
-pub st_blocks: ::std::os::raw::c_long,
-pub st_atime: ::std::os::raw::c_long,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_long,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_long,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub __unused4: ::std::os::raw::c_uint,
-pub __unused5: ::std::os::raw::c_uint,
+pub st_dev: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_nlink: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub st_rdev: crate::ctypes::c_ulong,
+pub __pad1: crate::ctypes::c_ulong,
+pub st_size: crate::ctypes::c_long,
+pub st_blksize: crate::ctypes::c_int,
+pub __pad2: crate::ctypes::c_int,
+pub st_blocks: crate::ctypes::c_long,
+pub st_atime: crate::ctypes::c_long,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_long,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_long,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub __unused4: crate::ctypes::c_uint,
+pub __unused5: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v5_4/riscv64/netlink.rs
+++ b/src/v5_4/riscv64/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -212,57 +212,57 @@ pub const RTEXT_FILTER_VF: u32 = 1;
 pub const RTEXT_FILTER_BRVLAN: u32 = 2;
 pub const RTEXT_FILTER_BRVLAN_COMPRESSED: u32 = 4;
 pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -271,7 +271,7 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug)]
 pub struct sysinfo {
@@ -288,9 +288,9 @@ pub pad: __u16,
 pub totalhigh: __kernel_ulong_t,
 pub freehigh: __kernel_ulong_t,
 pub mem_unit: __u32,
-pub _f: __IncompleteArrayField<::std::os::raw::c_char>,
+pub _f: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -300,19 +300,19 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -328,7 +328,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -352,16 +352,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2087,21 +2087,21 @@ __RTM_MAX = 107,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNICAST;
@@ -2195,10 +2195,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2299,29 +2299,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_ADDRESS;
@@ -2345,10 +2345,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2393,14 +2393,14 @@ __TCA_MAX = 15,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_SRCADDR;
@@ -2455,9 +2455,9 @@ __RTNLGRP_MAX = 33,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_TAB;

--- a/src/v5_4/s390x/general.rs
+++ b/src/v5_4/s390x/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -1998,18 +1998,18 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
-pub type addr_t = ::std::os::raw::c_ulong;
-pub type saddr_t = ::std::os::raw::c_long;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
+pub type addr_t = crate::ctypes::c_ulong;
+pub type saddr_t = crate::ctypes::c_long;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __vector128 {
@@ -2018,45 +2018,45 @@ pub u: [__u32; 4usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_size_t = ::std::os::raw::c_ulong;
-pub type __kernel_ssize_t = ::std::os::raw::c_long;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ushort;
-pub type __kernel_ino_t = ::std::os::raw::c_uint;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_long;
-pub type __kernel_sigset_t = ::std::os::raw::c_ulong;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_size_t = crate::ctypes::c_ulong;
+pub type __kernel_ssize_t = crate::ctypes::c_long;
+pub type __kernel_old_dev_t = crate::ctypes::c_ushort;
+pub type __kernel_ino_t = crate::ctypes::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_long;
+pub type __kernel_sigset_t = crate::ctypes::c_ulong;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
+pub type __kernel_pid_t = crate::ctypes::c_int;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2065,18 +2065,18 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -2084,8 +2084,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -2223,16 +2223,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2242,9 +2242,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2254,10 +2254,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2267,13 +2267,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2348,7 +2348,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2391,7 +2391,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2401,7 +2401,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2418,7 +2418,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2428,7 +2428,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2455,9 +2455,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2480,15 +2480,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2512,7 +2512,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2523,8 +2523,8 @@ pub tv_usec: __kernel_suseconds_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2575,38 +2575,38 @@ pub rlim_max: __u64,
 pub struct pt_regs {
 _unused: [u8; 0],
 }
-pub type sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sigaction {
 pub _u: sigaction__bindgen_ty_1,
-pub sa_flags: ::std::os::raw::c_ulong,
-pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: ::core::option::Option<unsafe extern "C" fn()>,
 pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigaction__bindgen_ty_1 {
 pub _sa_handler: __sighandler_t,
-pub _sa_sigaction: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int, arg2: *mut siginfo, arg3: *mut ::std::os::raw::c_void)>,
+pub _sa_sigaction: ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int, arg2: *mut siginfo, arg3: *mut crate::ctypes::c_void)>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2630,9 +2630,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2646,48 +2646,48 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
+pub _addr: *mut crate::ctypes::c_void,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 8usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 8usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 8usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 8usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2698,14 +2698,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2713,22 +2713,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 12usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 12usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -2763,9 +2763,9 @@ pub stx_dev_major: __u32,
 pub stx_dev_minor: __u32,
 pub __spare2: [__u64; 14usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2803,20 +2803,20 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 8usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2829,14 +2829,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2846,66 +2846,66 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulong,
-pub d_off: ::std::os::raw::c_long,
+pub d_ino: crate::ctypes::c_ulong,
+pub d_off: crate::ctypes::c_long,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulong,
-pub st_nlink: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub __pad1: ::std::os::raw::c_uint,
-pub st_rdev: ::std::os::raw::c_ulong,
-pub st_size: ::std::os::raw::c_ulong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub st_blksize: ::std::os::raw::c_ulong,
-pub st_blocks: ::std::os::raw::c_long,
-pub __unused: [::std::os::raw::c_ulong; 3usize],
+pub st_dev: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulong,
+pub st_nlink: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub __pad1: crate::ctypes::c_uint,
+pub st_rdev: crate::ctypes::c_ulong,
+pub st_size: crate::ctypes::c_ulong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub st_blksize: crate::ctypes::c_ulong,
+pub st_blocks: crate::ctypes::c_long,
+pub __unused: [crate::ctypes::c_ulong; 3usize],
 }
 pub type fsid_t = __kernel_fsid_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct statfs {
-pub f_type: ::std::os::raw::c_uint,
-pub f_bsize: ::std::os::raw::c_uint,
-pub f_blocks: ::std::os::raw::c_ulong,
-pub f_bfree: ::std::os::raw::c_ulong,
-pub f_bavail: ::std::os::raw::c_ulong,
-pub f_files: ::std::os::raw::c_ulong,
-pub f_ffree: ::std::os::raw::c_ulong,
+pub f_type: crate::ctypes::c_uint,
+pub f_bsize: crate::ctypes::c_uint,
+pub f_blocks: crate::ctypes::c_ulong,
+pub f_bfree: crate::ctypes::c_ulong,
+pub f_bavail: crate::ctypes::c_ulong,
+pub f_files: crate::ctypes::c_ulong,
+pub f_ffree: crate::ctypes::c_ulong,
 pub f_fsid: __kernel_fsid_t,
-pub f_namelen: ::std::os::raw::c_uint,
-pub f_frsize: ::std::os::raw::c_uint,
-pub f_flags: ::std::os::raw::c_uint,
-pub f_spare: [::std::os::raw::c_uint; 4usize],
+pub f_namelen: crate::ctypes::c_uint,
+pub f_frsize: crate::ctypes::c_uint,
+pub f_flags: crate::ctypes::c_uint,
+pub f_spare: [crate::ctypes::c_uint; 4usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct statfs64 {
-pub f_type: ::std::os::raw::c_uint,
-pub f_bsize: ::std::os::raw::c_uint,
-pub f_blocks: ::std::os::raw::c_ulonglong,
-pub f_bfree: ::std::os::raw::c_ulonglong,
-pub f_bavail: ::std::os::raw::c_ulonglong,
-pub f_files: ::std::os::raw::c_ulonglong,
-pub f_ffree: ::std::os::raw::c_ulonglong,
+pub f_type: crate::ctypes::c_uint,
+pub f_bsize: crate::ctypes::c_uint,
+pub f_blocks: crate::ctypes::c_ulonglong,
+pub f_bfree: crate::ctypes::c_ulonglong,
+pub f_bavail: crate::ctypes::c_ulonglong,
+pub f_files: crate::ctypes::c_ulonglong,
+pub f_ffree: crate::ctypes::c_ulonglong,
 pub f_fsid: __kernel_fsid_t,
-pub f_namelen: ::std::os::raw::c_uint,
-pub f_frsize: ::std::os::raw::c_uint,
-pub f_flags: ::std::os::raw::c_uint,
-pub f_spare: [::std::os::raw::c_uint; 4usize],
+pub f_namelen: crate::ctypes::c_uint,
+pub f_frsize: crate::ctypes::c_uint,
+pub f_flags: crate::ctypes::c_uint,
+pub f_spare: [crate::ctypes::c_uint; 4usize],
 }
 pub type __fsword_t = __u32;

--- a/src/v5_4/s390x/netlink.rs
+++ b/src/v5_4/s390x/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -213,18 +213,18 @@ pub const RTEXT_FILTER_VF: u32 = 1;
 pub const RTEXT_FILTER_BRVLAN: u32 = 2;
 pub const RTEXT_FILTER_BRVLAN_COMPRESSED: u32 = 4;
 pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
-pub type addr_t = ::std::os::raw::c_ulong;
-pub type saddr_t = ::std::os::raw::c_long;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
+pub type addr_t = crate::ctypes::c_ulong;
+pub type saddr_t = crate::ctypes::c_long;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __vector128 {
@@ -233,45 +233,45 @@ pub u: [__u32; 4usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_size_t = ::std::os::raw::c_ulong;
-pub type __kernel_ssize_t = ::std::os::raw::c_long;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ushort;
-pub type __kernel_ino_t = ::std::os::raw::c_uint;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_long;
-pub type __kernel_sigset_t = ::std::os::raw::c_ulong;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_size_t = crate::ctypes::c_ulong;
+pub type __kernel_ssize_t = crate::ctypes::c_long;
+pub type __kernel_old_dev_t = crate::ctypes::c_ushort;
+pub type __kernel_ino_t = crate::ctypes::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_long;
+pub type __kernel_sigset_t = crate::ctypes::c_ulong;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
+pub type __kernel_pid_t = crate::ctypes::c_int;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -280,7 +280,7 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug)]
 pub struct sysinfo {
@@ -297,9 +297,9 @@ pub pad: __u16,
 pub totalhigh: __kernel_ulong_t,
 pub freehigh: __kernel_ulong_t,
 pub mem_unit: __u32,
-pub _f: __IncompleteArrayField<::std::os::raw::c_char>,
+pub _f: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -309,19 +309,19 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -337,7 +337,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -361,16 +361,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2096,21 +2096,21 @@ __RTM_MAX = 107,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNICAST;
@@ -2204,10 +2204,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2308,29 +2308,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_ADDRESS;
@@ -2354,10 +2354,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2402,14 +2402,14 @@ __TCA_MAX = 15,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_SRCADDR;
@@ -2464,9 +2464,9 @@ __RTNLGRP_MAX = 33,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_TAB;

--- a/src/v5_4/sparc/general.rs
+++ b/src/v5_4/sparc/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -2248,57 +2248,57 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 4210688;
 pub const TFD_CREATE_FLAGS: u32 = 4210688;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_long;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_ushort;
-pub type __kernel_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_mode_t = ::std::os::raw::c_ushort;
-pub type __kernel_daddr_t = ::std::os::raw::c_long;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ushort;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_long;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_ushort;
+pub type __kernel_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_mode_t = crate::ctypes::c_ushort;
+pub type __kernel_daddr_t = crate::ctypes::c_long;
+pub type __kernel_old_dev_t = crate::ctypes::c_ushort;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_pid_t = crate::ctypes::c_int;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2307,32 +2307,32 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
-pub __unused: ::std::os::raw::c_short,
+pub __unused: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
-pub __unused: ::std::os::raw::c_short,
+pub __unused: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2467,16 +2467,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2486,9 +2486,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2498,10 +2498,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2511,13 +2511,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2592,7 +2592,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2635,7 +2635,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2645,7 +2645,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2662,7 +2662,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2672,7 +2672,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2699,9 +2699,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2724,15 +2724,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2756,7 +2756,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2767,8 +2767,8 @@ pub tv_usec: __kernel_suseconds_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2814,27 +2814,27 @@ pub struct rlimit64 {
 pub rlim_cur: __u64,
 pub rlim_max: __u64,
 }
-pub type sigset_t = ::std::os::raw::c_ulong;
+pub type sigset_t = crate::ctypes::c_ulong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __new_sigset_t {
-pub sig: [::std::os::raw::c_ulong; 2usize],
+pub sig: [crate::ctypes::c_ulong; 2usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigstack {
-pub the_stack: *mut ::std::os::raw::c_char,
-pub cur_status: ::std::os::raw::c_int,
+pub the_stack: *mut crate::ctypes::c_char,
+pub cur_status: crate::ctypes::c_int,
 }
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __new_sigaction {
 pub sa_handler: __sighandler_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: __new_sigset_t,
 }
@@ -2843,22 +2843,22 @@ pub sa_mask: __new_sigset_t,
 pub struct sigaction {
 pub sa_handler: __sighandler_t,
 pub sa_mask: sigset_t,
-pub sa_flags: ::std::os::raw::c_ulong,
-pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: ::core::option::Option<unsafe extern "C" fn()>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2882,9 +2882,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2898,49 +2898,49 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
-pub _trapno: ::std::os::raw::c_int,
+pub _addr: *mut crate::ctypes::c_void,
+pub _trapno: crate::ctypes::c_int,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 4usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 4usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 4usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 4usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2951,14 +2951,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2966,22 +2966,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 13usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 13usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -3016,18 +3016,18 @@ pub stx_dev_major: __u32,
 pub stx_dev_minor: __u32,
 pub __spare2: [__u64; 14usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_ulong;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_ulong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 8usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3066,10 +3066,10 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3082,14 +3082,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3099,57 +3099,57 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulonglong,
-pub d_off: ::std::os::raw::c_longlong,
+pub d_ino: crate::ctypes::c_ulonglong,
+pub d_off: crate::ctypes::c_longlong,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ushort,
+pub st_dev: crate::ctypes::c_ushort,
 pub st_ino: __kernel_ino_t,
 pub st_mode: __kernel_mode_t,
-pub st_nlink: ::std::os::raw::c_short,
-pub st_uid: ::std::os::raw::c_ushort,
-pub st_gid: ::std::os::raw::c_ushort,
-pub st_rdev: ::std::os::raw::c_ushort,
+pub st_nlink: crate::ctypes::c_short,
+pub st_uid: crate::ctypes::c_ushort,
+pub st_gid: crate::ctypes::c_ushort,
+pub st_rdev: crate::ctypes::c_ushort,
 pub st_size: __kernel_off_t,
 pub st_atime: __kernel_time_t,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
 pub st_mtime: __kernel_time_t,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
 pub st_ctime: __kernel_time_t,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
 pub st_blksize: __kernel_off_t,
 pub st_blocks: __kernel_off_t,
-pub __unused4: [::std::os::raw::c_ulong; 2usize],
+pub __unused4: [crate::ctypes::c_ulong; 2usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat64 {
-pub st_dev: ::std::os::raw::c_ulonglong,
-pub st_ino: ::std::os::raw::c_ulonglong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_nlink: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub st_rdev: ::std::os::raw::c_ulonglong,
-pub __pad3: [::std::os::raw::c_uchar; 8usize],
-pub st_size: ::std::os::raw::c_longlong,
-pub st_blksize: ::std::os::raw::c_uint,
-pub __pad4: [::std::os::raw::c_uchar; 8usize],
-pub st_blocks: ::std::os::raw::c_uint,
-pub st_atime: ::std::os::raw::c_uint,
-pub st_atime_nsec: ::std::os::raw::c_uint,
-pub st_mtime: ::std::os::raw::c_uint,
-pub st_mtime_nsec: ::std::os::raw::c_uint,
-pub st_ctime: ::std::os::raw::c_uint,
-pub st_ctime_nsec: ::std::os::raw::c_uint,
-pub __unused4: ::std::os::raw::c_uint,
-pub __unused5: ::std::os::raw::c_uint,
+pub st_dev: crate::ctypes::c_ulonglong,
+pub st_ino: crate::ctypes::c_ulonglong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_nlink: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub st_rdev: crate::ctypes::c_ulonglong,
+pub __pad3: [crate::ctypes::c_uchar; 8usize],
+pub st_size: crate::ctypes::c_longlong,
+pub st_blksize: crate::ctypes::c_uint,
+pub __pad4: [crate::ctypes::c_uchar; 8usize],
+pub st_blocks: crate::ctypes::c_uint,
+pub st_atime: crate::ctypes::c_uint,
+pub st_atime_nsec: crate::ctypes::c_uint,
+pub st_mtime: crate::ctypes::c_uint,
+pub st_mtime_nsec: crate::ctypes::c_uint,
+pub st_ctime: crate::ctypes::c_uint,
+pub st_ctime_nsec: crate::ctypes::c_uint,
+pub __unused4: crate::ctypes::c_uint,
+pub __unused5: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v5_4/sparc/netlink.rs
+++ b/src/v5_4/sparc/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -213,57 +213,57 @@ pub const RTEXT_FILTER_VF: u32 = 1;
 pub const RTEXT_FILTER_BRVLAN: u32 = 2;
 pub const RTEXT_FILTER_BRVLAN_COMPRESSED: u32 = 4;
 pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_long;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_ushort;
-pub type __kernel_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_mode_t = ::std::os::raw::c_ushort;
-pub type __kernel_daddr_t = ::std::os::raw::c_long;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ushort;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_long;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_ushort;
+pub type __kernel_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_mode_t = crate::ctypes::c_ushort;
+pub type __kernel_daddr_t = crate::ctypes::c_long;
+pub type __kernel_old_dev_t = crate::ctypes::c_ushort;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_pid_t = crate::ctypes::c_int;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -272,7 +272,7 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sysinfo {
@@ -289,9 +289,9 @@ pub pad: __u16,
 pub totalhigh: __kernel_ulong_t,
 pub freehigh: __kernel_ulong_t,
 pub mem_unit: __u32,
-pub _f: [::std::os::raw::c_char; 8usize],
+pub _f: [crate::ctypes::c_char; 8usize],
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -301,19 +301,19 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -329,7 +329,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -353,16 +353,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2088,21 +2088,21 @@ __RTM_MAX = 107,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNICAST;
@@ -2196,10 +2196,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2300,29 +2300,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_ADDRESS;
@@ -2346,10 +2346,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2394,14 +2394,14 @@ __TCA_MAX = 15,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_SRCADDR;
@@ -2456,9 +2456,9 @@ __RTNLGRP_MAX = 33,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_TAB;

--- a/src/v5_4/sparc64/general.rs
+++ b/src/v5_4/sparc64/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -2218,29 +2218,29 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 4210688;
 pub const TFD_CREATE_FLAGS: u32 = 4210688;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_suseconds_t = ::std::os::raw::c_int;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_old_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_suseconds_t = crate::ctypes::c_int;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_old_timeval {
@@ -2248,33 +2248,33 @@ pub tv_sec: __kernel_long_t,
 pub tv_usec: __kernel_suseconds_t,
 }
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2283,32 +2283,32 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
-pub __unused: ::std::os::raw::c_short,
+pub __unused: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
-pub __unused: ::std::os::raw::c_short,
+pub __unused: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2443,16 +2443,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2462,9 +2462,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2474,10 +2474,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2487,13 +2487,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2568,7 +2568,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2611,7 +2611,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2621,7 +2621,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2638,7 +2638,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2648,7 +2648,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2675,9 +2675,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2700,15 +2700,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2726,7 +2726,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2737,8 +2737,8 @@ pub tv_usec: __kernel_suseconds_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2784,27 +2784,27 @@ pub struct rlimit64 {
 pub rlim_cur: __u64,
 pub rlim_max: __u64,
 }
-pub type sigset_t = ::std::os::raw::c_ulong;
+pub type sigset_t = crate::ctypes::c_ulong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __new_sigset_t {
-pub sig: [::std::os::raw::c_ulong; 1usize],
+pub sig: [crate::ctypes::c_ulong; 1usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigstack {
-pub the_stack: *mut ::std::os::raw::c_char,
-pub cur_status: ::std::os::raw::c_int,
+pub the_stack: *mut crate::ctypes::c_char,
+pub cur_status: crate::ctypes::c_int,
 }
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __new_sigaction {
 pub sa_handler: __sighandler_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: __new_sigset_t,
 }
@@ -2813,22 +2813,22 @@ pub sa_mask: __new_sigset_t,
 pub struct sigaction {
 pub sa_handler: __sighandler_t,
 pub sa_mask: sigset_t,
-pub sa_flags: ::std::os::raw::c_ulong,
-pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: ::core::option::Option<unsafe extern "C" fn()>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2852,9 +2852,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2868,49 +2868,49 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
-pub _trapno: ::std::os::raw::c_int,
+pub _addr: *mut crate::ctypes::c_void,
+pub _trapno: crate::ctypes::c_int,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 8usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 8usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 8usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 8usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_int,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_int,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2921,14 +2921,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2936,22 +2936,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 12usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 12usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -2986,18 +2986,18 @@ pub stx_dev_major: __u32,
 pub stx_dev_minor: __u32,
 pub __spare2: [__u64; 14usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 8usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3036,10 +3036,10 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3052,14 +3052,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3069,52 +3069,52 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulong,
-pub d_off: ::std::os::raw::c_long,
+pub d_ino: crate::ctypes::c_ulong,
+pub d_off: crate::ctypes::c_long,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_uint,
+pub st_dev: crate::ctypes::c_uint,
 pub st_ino: __kernel_ino_t,
 pub st_mode: __kernel_mode_t,
-pub st_nlink: ::std::os::raw::c_short,
+pub st_nlink: crate::ctypes::c_short,
 pub st_uid: __kernel_uid_t,
 pub st_gid: __kernel_gid_t,
-pub st_rdev: ::std::os::raw::c_uint,
+pub st_rdev: crate::ctypes::c_uint,
 pub st_size: __kernel_off_t,
 pub st_atime: __kernel_time_t,
 pub st_mtime: __kernel_time_t,
 pub st_ctime: __kernel_time_t,
 pub st_blksize: __kernel_off_t,
 pub st_blocks: __kernel_off_t,
-pub __unused4: [::std::os::raw::c_ulong; 2usize],
+pub __unused4: [crate::ctypes::c_ulong; 2usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat64 {
-pub st_dev: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulong,
-pub st_nlink: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub __pad0: ::std::os::raw::c_uint,
-pub st_rdev: ::std::os::raw::c_ulong,
-pub st_size: ::std::os::raw::c_long,
-pub st_blksize: ::std::os::raw::c_long,
-pub st_blocks: ::std::os::raw::c_long,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub __unused: [::std::os::raw::c_long; 3usize],
+pub st_dev: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulong,
+pub st_nlink: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub __pad0: crate::ctypes::c_uint,
+pub st_rdev: crate::ctypes::c_ulong,
+pub st_size: crate::ctypes::c_long,
+pub st_blksize: crate::ctypes::c_long,
+pub st_blocks: crate::ctypes::c_long,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub __unused: [crate::ctypes::c_long; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v5_4/sparc64/netlink.rs
+++ b/src/v5_4/sparc64/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -213,29 +213,29 @@ pub const RTEXT_FILTER_VF: u32 = 1;
 pub const RTEXT_FILTER_BRVLAN: u32 = 2;
 pub const RTEXT_FILTER_BRVLAN_COMPRESSED: u32 = 4;
 pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_suseconds_t = ::std::os::raw::c_int;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_old_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_suseconds_t = crate::ctypes::c_int;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_old_timeval {
@@ -243,33 +243,33 @@ pub tv_sec: __kernel_long_t,
 pub tv_usec: __kernel_suseconds_t,
 }
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
-pub type __kernel_old_dev_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
+pub type __kernel_old_dev_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -278,7 +278,7 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug)]
 pub struct sysinfo {
@@ -295,9 +295,9 @@ pub pad: __u16,
 pub totalhigh: __kernel_ulong_t,
 pub freehigh: __kernel_ulong_t,
 pub mem_unit: __u32,
-pub _f: __IncompleteArrayField<::std::os::raw::c_char>,
+pub _f: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -307,19 +307,19 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -335,7 +335,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -359,16 +359,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2094,21 +2094,21 @@ __RTM_MAX = 107,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNICAST;
@@ -2202,10 +2202,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2306,29 +2306,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_ADDRESS;
@@ -2352,10 +2352,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2400,14 +2400,14 @@ __TCA_MAX = 15,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_SRCADDR;
@@ -2462,9 +2462,9 @@ __RTNLGRP_MAX = 33,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_TAB;

--- a/src/v5_4/x86/general.rs
+++ b/src/v5_4/x86/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -2065,57 +2065,57 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_mode_t = ::std::os::raw::c_ushort;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_ushort;
-pub type __kernel_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ushort;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_mode_t = crate::ctypes::c_ushort;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_ushort;
+pub type __kernel_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_dev_t = crate::ctypes::c_ushort;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_pid_t = crate::ctypes::c_int;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_int;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2124,18 +2124,18 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -2143,8 +2143,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -2282,16 +2282,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2301,9 +2301,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2313,10 +2313,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2326,13 +2326,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2407,7 +2407,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2450,7 +2450,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2460,7 +2460,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2477,7 +2477,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2487,7 +2487,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2514,9 +2514,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2539,15 +2539,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2571,7 +2571,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2582,8 +2582,8 @@ pub tv_usec: __kernel_suseconds_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2629,38 +2629,38 @@ pub struct rlimit64 {
 pub rlim_cur: __u64,
 pub rlim_max: __u64,
 }
-pub type sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sigaction {
 pub _u: sigaction__bindgen_ty_1,
 pub sa_mask: sigset_t,
-pub sa_flags: ::std::os::raw::c_ulong,
-pub sa_restorer: ::std::option::Option<unsafe extern "C" fn()>,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: ::core::option::Option<unsafe extern "C" fn()>,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigaction__bindgen_ty_1 {
 pub _sa_handler: __sighandler_t,
-pub _sa_sigaction: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int, arg2: *mut siginfo, arg3: *mut ::std::os::raw::c_void)>,
+pub _sa_sigaction: ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int, arg2: *mut siginfo, arg3: *mut crate::ctypes::c_void)>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2684,9 +2684,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2700,48 +2700,48 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
+pub _addr: *mut crate::ctypes::c_void,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 4usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 4usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 4usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 4usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2752,14 +2752,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2767,22 +2767,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 13usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 13usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -2817,9 +2817,9 @@ pub stx_dev_major: __u32,
 pub stx_dev_minor: __u32,
 pub __spare2: [__u64; 14usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2857,20 +2857,20 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 8usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2883,14 +2883,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2900,72 +2900,72 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulonglong,
-pub d_off: ::std::os::raw::c_longlong,
+pub d_ino: crate::ctypes::c_ulonglong,
+pub d_off: crate::ctypes::c_longlong,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
-pub st_dev: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_ushort,
-pub st_nlink: ::std::os::raw::c_ushort,
-pub st_uid: ::std::os::raw::c_ushort,
-pub st_gid: ::std::os::raw::c_ushort,
-pub st_rdev: ::std::os::raw::c_ulong,
-pub st_size: ::std::os::raw::c_ulong,
-pub st_blksize: ::std::os::raw::c_ulong,
-pub st_blocks: ::std::os::raw::c_ulong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_mtime_nsec: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub __unused4: ::std::os::raw::c_ulong,
-pub __unused5: ::std::os::raw::c_ulong,
+pub st_dev: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_ushort,
+pub st_nlink: crate::ctypes::c_ushort,
+pub st_uid: crate::ctypes::c_ushort,
+pub st_gid: crate::ctypes::c_ushort,
+pub st_rdev: crate::ctypes::c_ulong,
+pub st_size: crate::ctypes::c_ulong,
+pub st_blksize: crate::ctypes::c_ulong,
+pub st_blocks: crate::ctypes::c_ulong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub __unused4: crate::ctypes::c_ulong,
+pub __unused5: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat64 {
-pub st_dev: ::std::os::raw::c_ulonglong,
-pub __pad0: [::std::os::raw::c_uchar; 4usize],
-pub __st_ino: ::std::os::raw::c_ulong,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_nlink: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_ulong,
-pub st_gid: ::std::os::raw::c_ulong,
-pub st_rdev: ::std::os::raw::c_ulonglong,
-pub __pad3: [::std::os::raw::c_uchar; 4usize],
-pub st_size: ::std::os::raw::c_longlong,
-pub st_blksize: ::std::os::raw::c_ulong,
-pub st_blocks: ::std::os::raw::c_ulonglong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_atime_nsec: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_mtime_nsec: ::std::os::raw::c_uint,
-pub st_ctime: ::std::os::raw::c_ulong,
-pub st_ctime_nsec: ::std::os::raw::c_ulong,
-pub st_ino: ::std::os::raw::c_ulonglong,
+pub st_dev: crate::ctypes::c_ulonglong,
+pub __pad0: [crate::ctypes::c_uchar; 4usize],
+pub __st_ino: crate::ctypes::c_ulong,
+pub st_mode: crate::ctypes::c_uint,
+pub st_nlink: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_ulong,
+pub st_gid: crate::ctypes::c_ulong,
+pub st_rdev: crate::ctypes::c_ulonglong,
+pub __pad3: [crate::ctypes::c_uchar; 4usize],
+pub st_size: crate::ctypes::c_longlong,
+pub st_blksize: crate::ctypes::c_ulong,
+pub st_blocks: crate::ctypes::c_ulonglong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_atime_nsec: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_mtime_nsec: crate::ctypes::c_uint,
+pub st_ctime: crate::ctypes::c_ulong,
+pub st_ctime_nsec: crate::ctypes::c_ulong,
+pub st_ino: crate::ctypes::c_ulonglong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __old_kernel_stat {
-pub st_dev: ::std::os::raw::c_ushort,
-pub st_ino: ::std::os::raw::c_ushort,
-pub st_mode: ::std::os::raw::c_ushort,
-pub st_nlink: ::std::os::raw::c_ushort,
-pub st_uid: ::std::os::raw::c_ushort,
-pub st_gid: ::std::os::raw::c_ushort,
-pub st_rdev: ::std::os::raw::c_ushort,
-pub st_size: ::std::os::raw::c_ulong,
-pub st_atime: ::std::os::raw::c_ulong,
-pub st_mtime: ::std::os::raw::c_ulong,
-pub st_ctime: ::std::os::raw::c_ulong,
+pub st_dev: crate::ctypes::c_ushort,
+pub st_ino: crate::ctypes::c_ushort,
+pub st_mode: crate::ctypes::c_ushort,
+pub st_nlink: crate::ctypes::c_ushort,
+pub st_uid: crate::ctypes::c_ushort,
+pub st_gid: crate::ctypes::c_ushort,
+pub st_rdev: crate::ctypes::c_ushort,
+pub st_size: crate::ctypes::c_ulong,
+pub st_atime: crate::ctypes::c_ulong,
+pub st_mtime: crate::ctypes::c_ulong,
+pub st_ctime: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v5_4/x86/netlink.rs
+++ b/src/v5_4/x86/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -213,57 +213,57 @@ pub const RTEXT_FILTER_VF: u32 = 1;
 pub const RTEXT_FILTER_BRVLAN: u32 = 2;
 pub const RTEXT_FILTER_BRVLAN_COMPRESSED: u32 = 4;
 pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
-pub type size_t = ::std::os::raw::c_uint;
-pub type ssize_t = ::std::os::raw::c_int;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_uint;
+pub type ssize_t = crate::ctypes::c_int;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 32usize],
+pub fds_bits: [crate::ctypes::c_ulong; 32usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_mode_t = ::std::os::raw::c_ushort;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_ushort;
-pub type __kernel_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ushort;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_mode_t = crate::ctypes::c_ushort;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_ushort;
+pub type __kernel_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_dev_t = crate::ctypes::c_ushort;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
+pub type __kernel_pid_t = crate::ctypes::c_int;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_old_uid_t = __kernel_uid_t;
 pub type __kernel_old_gid_t = __kernel_gid_t;
-pub type __kernel_size_t = ::std::os::raw::c_uint;
-pub type __kernel_ssize_t = ::std::os::raw::c_int;
-pub type __kernel_ptrdiff_t = ::std::os::raw::c_int;
+pub type __kernel_size_t = crate::ctypes::c_uint;
+pub type __kernel_ssize_t = crate::ctypes::c_int;
+pub type __kernel_ptrdiff_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -272,7 +272,7 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sysinfo {
@@ -289,9 +289,9 @@ pub pad: __u16,
 pub totalhigh: __kernel_ulong_t,
 pub freehigh: __kernel_ulong_t,
 pub mem_unit: __u32,
-pub _f: [::std::os::raw::c_char; 8usize],
+pub _f: [crate::ctypes::c_char; 8usize],
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -301,19 +301,19 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -329,7 +329,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -353,16 +353,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2088,21 +2088,21 @@ __RTM_MAX = 107,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNICAST;
@@ -2196,10 +2196,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2300,29 +2300,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_ADDRESS;
@@ -2346,10 +2346,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2394,14 +2394,14 @@ __TCA_MAX = 15,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_SRCADDR;
@@ -2456,9 +2456,9 @@ __RTNLGRP_MAX = 33,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_TAB;

--- a/src/v5_4/x86_64/general.rs
+++ b/src/v5_4/x86_64/general.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -1994,57 +1994,57 @@ pub const EPOLLET: u32 = 2147483648;
 pub const TFD_SHARED_FCNTL_FLAGS: u32 = 526336;
 pub const TFD_CREATE_FLAGS: u32 = 526336;
 pub const TFD_SETTIME_FLAGS: u32 = 1;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_old_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_dev_t = crate::ctypes::c_ulong;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -2053,18 +2053,18 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {
-pub type_: ::std::os::raw::c_int,
+pub type_: crate::ctypes::c_int,
 pub pid: __kernel_pid_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_off_t,
 pub l_len: __kernel_off_t,
 pub l_pid: __kernel_pid_t,
@@ -2072,8 +2072,8 @@ pub l_pid: __kernel_pid_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct flock64 {
-pub l_type: ::std::os::raw::c_short,
-pub l_whence: ::std::os::raw::c_short,
+pub l_type: crate::ctypes::c_short,
+pub l_whence: crate::ctypes::c_short,
 pub l_start: __kernel_loff_t,
 pub l_len: __kernel_loff_t,
 pub l_pid: __kernel_pid_t,
@@ -2211,16 +2211,16 @@ pub info: __IncompleteArrayField<file_dedupe_range_info>,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct files_stat_struct {
-pub nr_files: ::std::os::raw::c_ulong,
-pub nr_free_files: ::std::os::raw::c_ulong,
-pub max_files: ::std::os::raw::c_ulong,
+pub nr_files: crate::ctypes::c_ulong,
+pub nr_free_files: crate::ctypes::c_ulong,
+pub max_files: crate::ctypes::c_ulong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct inodes_stat_t {
-pub nr_inodes: ::std::os::raw::c_long,
-pub nr_unused: ::std::os::raw::c_long,
-pub dummy: [::std::os::raw::c_long; 5usize],
+pub nr_inodes: crate::ctypes::c_long,
+pub nr_unused: crate::ctypes::c_long,
+pub dummy: [crate::ctypes::c_long; 5usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2230,9 +2230,9 @@ pub fsx_extsize: __u32,
 pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
-pub fsx_pad: [::std::os::raw::c_uchar; 8usize],
+pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
-pub type __kernel_rwf_t = ::std::os::raw::c_int;
+pub type __kernel_rwf_t = crate::ctypes::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list {
@@ -2242,10 +2242,10 @@ pub next: *mut robust_list,
 #[derive(Debug, Copy, Clone)]
 pub struct robust_list_head {
 pub list: robust_list,
-pub futex_offset: ::std::os::raw::c_long,
+pub futex_offset: crate::ctypes::c_long,
 pub list_op_pending: *mut robust_list,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -2255,13 +2255,13 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 pub const IPPROTO_IP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_IP;
 pub const IPPROTO_ICMP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ICMP;
@@ -2336,7 +2336,7 @@ pub imr_interface: in_addr,
 pub struct ip_mreqn {
 pub imr_multiaddr: in_addr,
 pub imr_address: in_addr,
-pub imr_ifindex: ::std::os::raw::c_int,
+pub imr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2379,7 +2379,7 @@ pub gf_slist: [__kernel_sockaddr_storage; 1usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct in_pktinfo {
-pub ipi_ifindex: ::std::os::raw::c_int,
+pub ipi_ifindex: crate::ctypes::c_int,
 pub ipi_spec_dst: in_addr,
 pub ipi_addr: in_addr,
 }
@@ -2389,7 +2389,7 @@ pub struct sockaddr_in {
 pub sin_family: __kernel_sa_family_t,
 pub sin_port: __be16,
 pub sin_addr: in_addr,
-pub __pad: [::std::os::raw::c_uchar; 8usize],
+pub __pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2406,7 +2406,7 @@ pub u6_addr32: [__be32; 4usize],
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct sockaddr_in6 {
-pub sin6_family: ::std::os::raw::c_ushort,
+pub sin6_family: crate::ctypes::c_ushort,
 pub sin6_port: __be16,
 pub sin6_flowinfo: __be32,
 pub sin6_addr: in6_addr,
@@ -2416,7 +2416,7 @@ pub sin6_scope_id: __u32,
 #[derive(Copy, Clone)]
 pub struct ipv6_mreq {
 pub ipv6mr_multiaddr: in6_addr,
-pub ipv6mr_ifindex: ::std::os::raw::c_int,
+pub ipv6mr_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2443,9 +2443,9 @@ SS_DISCONNECTING = 4,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct pollfd {
-pub fd: ::std::os::raw::c_int,
-pub events: ::std::os::raw::c_short,
-pub revents: ::std::os::raw::c_short,
+pub fd: crate::ctypes::c_int,
+pub events: crate::ctypes::c_short,
+pub revents: crate::ctypes::c_short,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2468,15 +2468,15 @@ pub exe_fd: __u32,
 #[repr(C)]
 #[derive(Debug)]
 pub struct rand_pool_info {
-pub entropy_count: ::std::os::raw::c_int,
-pub buf_size: ::std::os::raw::c_int,
+pub entropy_count: crate::ctypes::c_int,
+pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
-pub tv_nsec: ::std::os::raw::c_longlong,
+pub tv_nsec: crate::ctypes::c_longlong,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2500,7 +2500,7 @@ pub tv_usec: __s64,
 #[derive(Debug, Copy, Clone)]
 pub struct timespec {
 pub tv_sec: __kernel_time_t,
-pub tv_nsec: ::std::os::raw::c_long,
+pub tv_nsec: crate::ctypes::c_long,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2511,8 +2511,8 @@ pub tv_usec: __kernel_suseconds_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timezone {
-pub tz_minuteswest: ::std::os::raw::c_int,
-pub tz_dsttime: ::std::os::raw::c_int,
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2558,32 +2558,32 @@ pub struct rlimit64 {
 pub rlim_cur: __u64,
 pub rlim_max: __u64,
 }
-pub type sigset_t = ::std::os::raw::c_ulong;
-pub type __signalfn_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
+pub type sigset_t = crate::ctypes::c_ulong;
+pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
-pub type __restorefn_t = ::std::option::Option<unsafe extern "C" fn()>;
+pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
 pub type __sigrestore_t = __restorefn_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaction {
 pub sa_handler: __sighandler_t,
-pub sa_flags: ::std::os::raw::c_ulong,
+pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigaltstack {
-pub ss_sp: *mut ::std::os::raw::c_void,
-pub ss_flags: ::std::os::raw::c_int,
+pub ss_sp: *mut crate::ctypes::c_void,
+pub ss_flags: crate::ctypes::c_int,
 pub ss_size: size_t,
 }
 pub type stack_t = sigaltstack;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigval {
-pub sival_int: ::std::os::raw::c_int,
-pub sival_ptr: *mut ::std::os::raw::c_void,
+pub sival_int: crate::ctypes::c_int,
+pub sival_ptr: *mut crate::ctypes::c_void,
 }
 pub type sigval_t = sigval;
 #[repr(C)]
@@ -2607,9 +2607,9 @@ pub _uid: __kernel_uid32_t,
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_2 {
 pub _tid: __kernel_timer_t,
-pub _overrun: ::std::os::raw::c_int,
+pub _overrun: crate::ctypes::c_int,
 pub _sigval: sigval_t,
-pub _sys_private: ::std::os::raw::c_int,
+pub _sys_private: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2623,48 +2623,48 @@ pub _sigval: sigval_t,
 pub struct __sifields__bindgen_ty_4 {
 pub _pid: __kernel_pid_t,
 pub _uid: __kernel_uid32_t,
-pub _status: ::std::os::raw::c_int,
+pub _status: crate::ctypes::c_int,
 pub _utime: __kernel_clock_t,
 pub _stime: __kernel_clock_t,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __sifields__bindgen_ty_5 {
-pub _addr: *mut ::std::os::raw::c_void,
+pub _addr: *mut crate::ctypes::c_void,
 pub __bindgen_anon_1: __sifields__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __sifields__bindgen_ty_5__bindgen_ty_1 {
-pub _addr_lsb: ::std::os::raw::c_short,
+pub _addr_lsb: crate::ctypes::c_short,
 pub _addr_bnd: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1,
 pub _addr_pkey: __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_1 {
-pub _dummy_bnd: [::std::os::raw::c_char; 8usize],
-pub _lower: *mut ::std::os::raw::c_void,
-pub _upper: *mut ::std::os::raw::c_void,
+pub _dummy_bnd: [crate::ctypes::c_char; 8usize],
+pub _lower: *mut crate::ctypes::c_void,
+pub _upper: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_5__bindgen_ty_1__bindgen_ty_2 {
-pub _dummy_pkey: [::std::os::raw::c_char; 8usize],
+pub _dummy_pkey: [crate::ctypes::c_char; 8usize],
 pub _pkey: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_6 {
-pub _band: ::std::os::raw::c_long,
-pub _fd: ::std::os::raw::c_int,
+pub _band: crate::ctypes::c_long,
+pub _fd: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sifields__bindgen_ty_7 {
-pub _call_addr: *mut ::std::os::raw::c_void,
-pub _syscall: ::std::os::raw::c_int,
-pub _arch: ::std::os::raw::c_uint,
+pub _call_addr: *mut crate::ctypes::c_void,
+pub _syscall: crate::ctypes::c_int,
+pub _arch: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2675,14 +2675,14 @@ pub __bindgen_anon_1: siginfo__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union siginfo__bindgen_ty_1 {
 pub __bindgen_anon_1: siginfo__bindgen_ty_1__bindgen_ty_1,
-pub _si_pad: [::std::os::raw::c_int; 32usize],
+pub _si_pad: [crate::ctypes::c_int; 32usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct siginfo__bindgen_ty_1__bindgen_ty_1 {
-pub si_signo: ::std::os::raw::c_int,
-pub si_errno: ::std::os::raw::c_int,
-pub si_code: ::std::os::raw::c_int,
+pub si_signo: crate::ctypes::c_int,
+pub si_errno: crate::ctypes::c_int,
+pub si_code: crate::ctypes::c_int,
 pub _sifields: __sifields,
 }
 pub type siginfo_t = siginfo;
@@ -2690,22 +2690,22 @@ pub type siginfo_t = siginfo;
 #[derive(Copy, Clone)]
 pub struct sigevent {
 pub sigev_value: sigval_t,
-pub sigev_signo: ::std::os::raw::c_int,
-pub sigev_notify: ::std::os::raw::c_int,
+pub sigev_signo: crate::ctypes::c_int,
+pub sigev_notify: crate::ctypes::c_int,
 pub _sigev_un: sigevent__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union sigevent__bindgen_ty_1 {
-pub _pad: [::std::os::raw::c_int; 12usize],
-pub _tid: ::std::os::raw::c_int,
+pub _pad: [crate::ctypes::c_int; 12usize],
+pub _tid: crate::ctypes::c_int,
 pub _sigev_thread: sigevent__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sigevent__bindgen_ty_1__bindgen_ty_1 {
-pub _function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
-pub _attribute: *mut ::std::os::raw::c_void,
+pub _function: ::core::option::Option<unsafe extern "C" fn(arg1: sigval_t)>,
+pub _attribute: *mut crate::ctypes::c_void,
 }
 pub type sigevent_t = sigevent;
 #[repr(C)]
@@ -2740,9 +2740,9 @@ pub stx_dev_major: __u32,
 pub stx_dev_minor: __u32,
 pub __spare2: [__u64; 14usize],
 }
-pub type cc_t = ::std::os::raw::c_uchar;
-pub type speed_t = ::std::os::raw::c_uint;
-pub type tcflag_t = ::std::os::raw::c_uint;
+pub type cc_t = crate::ctypes::c_uchar;
+pub type speed_t = crate::ctypes::c_uint;
+pub type tcflag_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termios {
@@ -2780,20 +2780,20 @@ pub c_ospeed: speed_t,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct winsize {
-pub ws_row: ::std::os::raw::c_ushort,
-pub ws_col: ::std::os::raw::c_ushort,
-pub ws_xpixel: ::std::os::raw::c_ushort,
-pub ws_ypixel: ::std::os::raw::c_ushort,
+pub ws_row: crate::ctypes::c_ushort,
+pub ws_col: crate::ctypes::c_ushort,
+pub ws_xpixel: crate::ctypes::c_ushort,
+pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct termio {
-pub c_iflag: ::std::os::raw::c_ushort,
-pub c_oflag: ::std::os::raw::c_ushort,
-pub c_cflag: ::std::os::raw::c_ushort,
-pub c_lflag: ::std::os::raw::c_ushort,
-pub c_line: ::std::os::raw::c_uchar,
-pub c_cc: [::std::os::raw::c_uchar; 8usize],
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2806,14 +2806,14 @@ pub x_sflag: __u16,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct iovec {
-pub iov_base: *mut ::std::os::raw::c_void,
+pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
-pub sun_path: [::std::os::raw::c_char; 108usize],
+pub sun_path: [crate::ctypes::c_char; 108usize],
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2823,23 +2823,23 @@ pub __storage: __kernel_sockaddr_storage,
 #[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
-pub d_ino: ::std::os::raw::c_ulong,
-pub d_off: ::std::os::raw::c_long,
+pub d_ino: crate::ctypes::c_ulong,
+pub d_off: crate::ctypes::c_long,
 pub d_reclen: __u16,
 pub d_type: __u8,
-pub d_name: __IncompleteArrayField<::std::os::raw::c_char>,
+pub d_name: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type socklen_t = ::std::os::raw::c_uint;
+pub type socklen_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct stat {
 pub st_dev: __kernel_ulong_t,
 pub st_ino: __kernel_ulong_t,
 pub st_nlink: __kernel_ulong_t,
-pub st_mode: ::std::os::raw::c_uint,
-pub st_uid: ::std::os::raw::c_uint,
-pub st_gid: ::std::os::raw::c_uint,
-pub __pad0: ::std::os::raw::c_uint,
+pub st_mode: crate::ctypes::c_uint,
+pub st_uid: crate::ctypes::c_uint,
+pub st_gid: crate::ctypes::c_uint,
+pub __pad0: crate::ctypes::c_uint,
 pub st_rdev: __kernel_ulong_t,
 pub st_size: __kernel_long_t,
 pub st_blksize: __kernel_long_t,
@@ -2855,17 +2855,17 @@ pub __unused: [__kernel_long_t; 3usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __old_kernel_stat {
-pub st_dev: ::std::os::raw::c_ushort,
-pub st_ino: ::std::os::raw::c_ushort,
-pub st_mode: ::std::os::raw::c_ushort,
-pub st_nlink: ::std::os::raw::c_ushort,
-pub st_uid: ::std::os::raw::c_ushort,
-pub st_gid: ::std::os::raw::c_ushort,
-pub st_rdev: ::std::os::raw::c_ushort,
-pub st_size: ::std::os::raw::c_uint,
-pub st_atime: ::std::os::raw::c_uint,
-pub st_mtime: ::std::os::raw::c_uint,
-pub st_ctime: ::std::os::raw::c_uint,
+pub st_dev: crate::ctypes::c_ushort,
+pub st_ino: crate::ctypes::c_ushort,
+pub st_mode: crate::ctypes::c_ushort,
+pub st_nlink: crate::ctypes::c_ushort,
+pub st_uid: crate::ctypes::c_ushort,
+pub st_gid: crate::ctypes::c_ushort,
+pub st_rdev: crate::ctypes::c_ushort,
+pub st_size: crate::ctypes::c_uint,
+pub st_atime: crate::ctypes::c_uint,
+pub st_mtime: crate::ctypes::c_uint,
+pub st_ctime: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/v5_4/x86_64/netlink.rs
+++ b/src/v5_4/x86_64/netlink.rs
@@ -2,11 +2,11 @@
 
 #[repr(C)]
 #[derive(Default)]
-pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
 #[inline]
 pub const fn new() -> Self {
-__IncompleteArrayField(::std::marker::PhantomData, [])
+__IncompleteArrayField(::core::marker::PhantomData, [])
 }
 #[inline]
 pub fn as_ptr(&self) -> *const T {
@@ -18,15 +18,15 @@ self as *mut _ as *mut T
 }
 #[inline]
 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::std::slice::from_raw_parts(self.as_ptr(), len)
+::core::slice::from_raw_parts(self.as_ptr(), len)
 }
 #[inline]
 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
 }
 }
-impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
+fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
 fmt.write_str("__IncompleteArrayField")
 }
 }
@@ -213,57 +213,57 @@ pub const RTEXT_FILTER_VF: u32 = 1;
 pub const RTEXT_FILTER_BRVLAN: u32 = 2;
 pub const RTEXT_FILTER_BRVLAN_COMPRESSED: u32 = 4;
 pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
-pub type size_t = ::std::os::raw::c_ulong;
-pub type ssize_t = ::std::os::raw::c_long;
-pub type __s8 = ::std::os::raw::c_schar;
-pub type __u8 = ::std::os::raw::c_uchar;
-pub type __s16 = ::std::os::raw::c_short;
-pub type __u16 = ::std::os::raw::c_ushort;
-pub type __s32 = ::std::os::raw::c_int;
-pub type __u32 = ::std::os::raw::c_uint;
-pub type __s64 = ::std::os::raw::c_longlong;
-pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type size_t = crate::ctypes::c_ulong;
+pub type ssize_t = crate::ctypes::c_long;
+pub type __s8 = crate::ctypes::c_schar;
+pub type __u8 = crate::ctypes::c_uchar;
+pub type __s16 = crate::ctypes::c_short;
+pub type __u16 = crate::ctypes::c_ushort;
+pub type __s32 = crate::ctypes::c_int;
+pub type __u32 = crate::ctypes::c_uint;
+pub type __s64 = crate::ctypes::c_longlong;
+pub type __u64 = crate::ctypes::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fd_set {
-pub fds_bits: [::std::os::raw::c_ulong; 16usize],
+pub fds_bits: [crate::ctypes::c_ulong; 16usize],
 }
-pub type __kernel_sighandler_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-pub type __kernel_key_t = ::std::os::raw::c_int;
-pub type __kernel_mqd_t = ::std::os::raw::c_int;
-pub type __kernel_old_uid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_gid_t = ::std::os::raw::c_ushort;
-pub type __kernel_old_dev_t = ::std::os::raw::c_ulong;
-pub type __kernel_long_t = ::std::os::raw::c_long;
-pub type __kernel_ulong_t = ::std::os::raw::c_ulong;
+pub type __kernel_sighandler_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
+pub type __kernel_key_t = crate::ctypes::c_int;
+pub type __kernel_mqd_t = crate::ctypes::c_int;
+pub type __kernel_old_uid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_gid_t = crate::ctypes::c_ushort;
+pub type __kernel_old_dev_t = crate::ctypes::c_ulong;
+pub type __kernel_long_t = crate::ctypes::c_long;
+pub type __kernel_ulong_t = crate::ctypes::c_ulong;
 pub type __kernel_ino_t = __kernel_ulong_t;
-pub type __kernel_mode_t = ::std::os::raw::c_uint;
-pub type __kernel_pid_t = ::std::os::raw::c_int;
-pub type __kernel_ipc_pid_t = ::std::os::raw::c_int;
-pub type __kernel_uid_t = ::std::os::raw::c_uint;
-pub type __kernel_gid_t = ::std::os::raw::c_uint;
+pub type __kernel_mode_t = crate::ctypes::c_uint;
+pub type __kernel_pid_t = crate::ctypes::c_int;
+pub type __kernel_ipc_pid_t = crate::ctypes::c_int;
+pub type __kernel_uid_t = crate::ctypes::c_uint;
+pub type __kernel_gid_t = crate::ctypes::c_uint;
 pub type __kernel_suseconds_t = __kernel_long_t;
-pub type __kernel_daddr_t = ::std::os::raw::c_int;
-pub type __kernel_uid32_t = ::std::os::raw::c_uint;
-pub type __kernel_gid32_t = ::std::os::raw::c_uint;
+pub type __kernel_daddr_t = crate::ctypes::c_int;
+pub type __kernel_uid32_t = crate::ctypes::c_uint;
+pub type __kernel_gid32_t = crate::ctypes::c_uint;
 pub type __kernel_size_t = __kernel_ulong_t;
 pub type __kernel_ssize_t = __kernel_long_t;
 pub type __kernel_ptrdiff_t = __kernel_long_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_fsid_t {
-pub val: [::std::os::raw::c_int; 2usize],
+pub val: [crate::ctypes::c_int; 2usize],
 }
 pub type __kernel_off_t = __kernel_long_t;
-pub type __kernel_loff_t = ::std::os::raw::c_longlong;
+pub type __kernel_loff_t = crate::ctypes::c_longlong;
 pub type __kernel_time_t = __kernel_long_t;
-pub type __kernel_time64_t = ::std::os::raw::c_longlong;
+pub type __kernel_time64_t = crate::ctypes::c_longlong;
 pub type __kernel_clock_t = __kernel_long_t;
-pub type __kernel_timer_t = ::std::os::raw::c_int;
-pub type __kernel_clockid_t = ::std::os::raw::c_int;
-pub type __kernel_caddr_t = *mut ::std::os::raw::c_char;
-pub type __kernel_uid16_t = ::std::os::raw::c_ushort;
-pub type __kernel_gid16_t = ::std::os::raw::c_ushort;
+pub type __kernel_timer_t = crate::ctypes::c_int;
+pub type __kernel_clockid_t = crate::ctypes::c_int;
+pub type __kernel_caddr_t = *mut crate::ctypes::c_char;
+pub type __kernel_uid16_t = crate::ctypes::c_ushort;
+pub type __kernel_gid16_t = crate::ctypes::c_ushort;
 pub type __le16 = __u16;
 pub type __be16 = __u16;
 pub type __le32 = __u32;
@@ -272,7 +272,7 @@ pub type __le64 = __u64;
 pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
-pub type __poll_t = ::std::os::raw::c_uint;
+pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
 #[derive(Debug)]
 pub struct sysinfo {
@@ -289,9 +289,9 @@ pub pad: __u16,
 pub totalhigh: __kernel_ulong_t,
 pub freehigh: __kernel_ulong_t,
 pub mem_unit: __u32,
-pub _f: __IncompleteArrayField<::std::os::raw::c_char>,
+pub _f: __IncompleteArrayField<crate::ctypes::c_char>,
 }
-pub type __kernel_sa_family_t = ::std::os::raw::c_ushort;
+pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
@@ -301,19 +301,19 @@ pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
 #[derive(Copy, Clone)]
 pub union __kernel_sockaddr_storage__bindgen_ty_1 {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1,
-pub __align: *mut ::std::os::raw::c_void,
+pub __align: *mut crate::ctypes::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_sockaddr_storage__bindgen_ty_1__bindgen_ty_1 {
 pub ss_family: __kernel_sa_family_t,
-pub __data: [::std::os::raw::c_char; 126usize],
+pub __data: [crate::ctypes::c_char; 126usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_nl {
 pub nl_family: __kernel_sa_family_t,
-pub nl_pad: ::std::os::raw::c_ushort,
+pub nl_pad: crate::ctypes::c_ushort,
 pub nl_pid: __u32,
 pub nl_groups: __u32,
 }
@@ -329,7 +329,7 @@ pub nlmsg_pid: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nlmsgerr {
-pub error: ::std::os::raw::c_int,
+pub error: crate::ctypes::c_int,
 pub msg: nlmsghdr,
 }
 impl nlmsgerr_attrs {
@@ -353,16 +353,16 @@ pub group: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_req {
-pub nm_block_size: ::std::os::raw::c_uint,
-pub nm_block_nr: ::std::os::raw::c_uint,
-pub nm_frame_size: ::std::os::raw::c_uint,
-pub nm_frame_nr: ::std::os::raw::c_uint,
+pub nm_block_size: crate::ctypes::c_uint,
+pub nm_block_nr: crate::ctypes::c_uint,
+pub nm_frame_size: crate::ctypes::c_uint,
+pub nm_frame_nr: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nl_mmap_hdr {
-pub nm_status: ::std::os::raw::c_uint,
-pub nm_len: ::std::os::raw::c_uint,
+pub nm_status: crate::ctypes::c_uint,
+pub nm_len: crate::ctypes::c_uint,
 pub nm_group: __u32,
 pub nm_pid: __u32,
 pub nm_uid: __u32,
@@ -2088,21 +2088,21 @@ __RTM_MAX = 107,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtattr {
-pub rta_len: ::std::os::raw::c_ushort,
-pub rta_type: ::std::os::raw::c_ushort,
+pub rta_len: crate::ctypes::c_ushort,
+pub rta_type: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtmsg {
-pub rtm_family: ::std::os::raw::c_uchar,
-pub rtm_dst_len: ::std::os::raw::c_uchar,
-pub rtm_src_len: ::std::os::raw::c_uchar,
-pub rtm_tos: ::std::os::raw::c_uchar,
-pub rtm_table: ::std::os::raw::c_uchar,
-pub rtm_protocol: ::std::os::raw::c_uchar,
-pub rtm_scope: ::std::os::raw::c_uchar,
-pub rtm_type: ::std::os::raw::c_uchar,
-pub rtm_flags: ::std::os::raw::c_uint,
+pub rtm_family: crate::ctypes::c_uchar,
+pub rtm_dst_len: crate::ctypes::c_uchar,
+pub rtm_src_len: crate::ctypes::c_uchar,
+pub rtm_tos: crate::ctypes::c_uchar,
+pub rtm_table: crate::ctypes::c_uchar,
+pub rtm_protocol: crate::ctypes::c_uchar,
+pub rtm_scope: crate::ctypes::c_uchar,
+pub rtm_type: crate::ctypes::c_uchar,
+pub rtm_flags: crate::ctypes::c_uint,
 }
 pub const RTN_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNSPEC;
 pub const RTN_UNICAST: _bindgen_ty_49 = _bindgen_ty_49::RTN_UNICAST;
@@ -2196,10 +2196,10 @@ __RTA_MAX = 31,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtnexthop {
-pub rtnh_len: ::std::os::raw::c_ushort,
-pub rtnh_flags: ::std::os::raw::c_uchar,
-pub rtnh_hops: ::std::os::raw::c_uchar,
-pub rtnh_ifindex: ::std::os::raw::c_int,
+pub rtnh_len: crate::ctypes::c_ushort,
+pub rtnh_flags: crate::ctypes::c_uchar,
+pub rtnh_hops: crate::ctypes::c_uchar,
+pub rtnh_ifindex: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -2300,29 +2300,29 @@ pub mfcs_wrong_if: __u64,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rtgenmsg {
-pub rtgen_family: ::std::os::raw::c_uchar,
+pub rtgen_family: crate::ctypes::c_uchar,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ifinfomsg {
-pub ifi_family: ::std::os::raw::c_uchar,
-pub __ifi_pad: ::std::os::raw::c_uchar,
-pub ifi_type: ::std::os::raw::c_ushort,
-pub ifi_index: ::std::os::raw::c_int,
-pub ifi_flags: ::std::os::raw::c_uint,
-pub ifi_change: ::std::os::raw::c_uint,
+pub ifi_family: crate::ctypes::c_uchar,
+pub __ifi_pad: crate::ctypes::c_uchar,
+pub ifi_type: crate::ctypes::c_ushort,
+pub ifi_index: crate::ctypes::c_int,
+pub ifi_flags: crate::ctypes::c_uint,
+pub ifi_change: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct prefixmsg {
-pub prefix_family: ::std::os::raw::c_uchar,
-pub prefix_pad1: ::std::os::raw::c_uchar,
-pub prefix_pad2: ::std::os::raw::c_ushort,
-pub prefix_ifindex: ::std::os::raw::c_int,
-pub prefix_type: ::std::os::raw::c_uchar,
-pub prefix_len: ::std::os::raw::c_uchar,
-pub prefix_flags: ::std::os::raw::c_uchar,
-pub prefix_pad3: ::std::os::raw::c_uchar,
+pub prefix_family: crate::ctypes::c_uchar,
+pub prefix_pad1: crate::ctypes::c_uchar,
+pub prefix_pad2: crate::ctypes::c_ushort,
+pub prefix_ifindex: crate::ctypes::c_int,
+pub prefix_type: crate::ctypes::c_uchar,
+pub prefix_len: crate::ctypes::c_uchar,
+pub prefix_flags: crate::ctypes::c_uchar,
+pub prefix_pad3: crate::ctypes::c_uchar,
 }
 pub const PREFIX_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_UNSPEC;
 pub const PREFIX_ADDRESS: _bindgen_ty_51 = _bindgen_ty_51::PREFIX_ADDRESS;
@@ -2346,10 +2346,10 @@ pub valid_time: __u32,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcmsg {
-pub tcm_family: ::std::os::raw::c_uchar,
-pub tcm__pad1: ::std::os::raw::c_uchar,
-pub tcm__pad2: ::std::os::raw::c_ushort,
-pub tcm_ifindex: ::std::os::raw::c_int,
+pub tcm_family: crate::ctypes::c_uchar,
+pub tcm__pad1: crate::ctypes::c_uchar,
+pub tcm__pad2: crate::ctypes::c_ushort,
+pub tcm_ifindex: crate::ctypes::c_int,
 pub tcm_handle: __u32,
 pub tcm_parent: __u32,
 pub tcm_info: __u32,
@@ -2394,14 +2394,14 @@ __TCA_MAX = 15,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nduseroptmsg {
-pub nduseropt_family: ::std::os::raw::c_uchar,
-pub nduseropt_pad1: ::std::os::raw::c_uchar,
-pub nduseropt_opts_len: ::std::os::raw::c_ushort,
-pub nduseropt_ifindex: ::std::os::raw::c_int,
+pub nduseropt_family: crate::ctypes::c_uchar,
+pub nduseropt_pad1: crate::ctypes::c_uchar,
+pub nduseropt_opts_len: crate::ctypes::c_ushort,
+pub nduseropt_ifindex: crate::ctypes::c_int,
 pub nduseropt_icmp_type: __u8,
 pub nduseropt_icmp_code: __u8,
-pub nduseropt_pad2: ::std::os::raw::c_ushort,
-pub nduseropt_pad3: ::std::os::raw::c_uint,
+pub nduseropt_pad2: crate::ctypes::c_ushort,
+pub nduseropt_pad3: crate::ctypes::c_uint,
 }
 pub const NDUSEROPT_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_UNSPEC;
 pub const NDUSEROPT_SRCADDR: _bindgen_ty_53 = _bindgen_ty_53::NDUSEROPT_SRCADDR;
@@ -2456,9 +2456,9 @@ __RTNLGRP_MAX = 33,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tcamsg {
-pub tca_family: ::std::os::raw::c_uchar,
-pub tca__pad1: ::std::os::raw::c_uchar,
-pub tca__pad2: ::std::os::raw::c_ushort,
+pub tca_family: crate::ctypes::c_uchar,
+pub tca__pad1: crate::ctypes::c_uchar,
+pub tca__pad2: crate::ctypes::c_ushort,
 }
 pub const TCA_ROOT_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_UNSPEC;
 pub const TCA_ROOT_TAB: _bindgen_ty_54 = _bindgen_ty_54::TCA_ROOT_TAB;


### PR DESCRIPTION
This will use libc to provide the definitions for C types when not using libstd. It did be nice to get rid of this dependency. Maybe I could copy the definitions from libc?

Should I make usage of the libc crate the default?