### PR TITLE
Define `ctypes` manually instead of depending on `cty`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,6 @@ exclude = ["gen"]
 all-features = true
 targets = ["x86_64-unknown-linux-gnu", "i686-unknown-linux-gnu"]
 
-[dependencies]
-cty = { version = "0.2.1", optional = true }
-
 # The rest of this file is auto-generated!
 [features]
 v2_6_32 = []
@@ -33,4 +30,4 @@ v5_4 = []
 v5_11 = []
 default = ["std", "general", "errno"]
 std = []
-no_std = ['cty']
+no_std = []

--- a/gen/src/main.rs
+++ b/gen/src/main.rs
@@ -241,7 +241,7 @@ fn main() {
 
     writeln!(cargo_toml, "default = [\"std\", {}]", DEFAULT_FEATURES).unwrap();
     writeln!(cargo_toml, "std = []").unwrap();
-    writeln!(cargo_toml, "no_std = ['cty']").unwrap();
+    writeln!(cargo_toml, "no_std = []").unwrap();
 
     // Reset the `linux` directory back to the original branch.
     git_checkout(LINUX_VERSIONS[0]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,30 @@
 pub use std::os::raw as ctypes;
 
 #[cfg(feature = "no_std")]
-pub use cty as ctypes;
+pub mod ctypes {
+    // The signedness of `char` is platform-specific, however a consequence
+    // of it being platform-specific is that any code which depends on the
+    // signedness of `char` is already non-portable. So we can just use `u8`
+    // here and no portable code will notice.
+    pub type c_char = u8;
+
+    // The following assumes that Linux is always either ILP32 or LP64,
+    // and char is always 8-bit.
+    pub type c_schar = i8;
+    pub type c_uchar = u8;
+    pub type c_short = i16;
+    pub type c_ushort = u16;
+    pub type c_int = i32;
+    pub type c_uint = u32;
+    pub type c_long = isize;
+    pub type c_ulong = usize;
+    pub type c_longlong = i64;
+    pub type c_ulonglong = u64;
+    pub type c_float = f32;
+    pub type c_double = f64;
+
+    pub use core::ffi::c_void;
+}
 
 // The rest of this file is auto-generated!
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "powerpc"))]


### PR DESCRIPTION
In `no_std` builds, define `ctypes` types manually instead of depending
on the `cty` crate. These types are straightforward to define for all
Linux targets.