### PR TITLE
Exclude the `.github` directory in the published package.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/sunfishcode/linux-raw-sys"
 edition = "2018"
 keywords = ["linux", "uapi", "ffi"]
 categories = ["external-ffi-bindings"]
-exclude = ["gen"]
+exclude = ["/gen", "/.*"]
 
 [dependencies]
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }


### PR DESCRIPTION
The .github, .rustfmt.toml, and .gitignore files aren't needed by
downstream users of the crate, so exclude them from the published
package.