### PR TITLE
Fix the docs.rs build.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core
 compiler_builtins = { version = '0.1.49', optional = true }
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["default", "ioctl", "netlink"]
 targets = ["x86_64-unknown-linux-gnu", "i686-unknown-linux-gnu"]
 
 # The rest of this file is auto-generated!


### PR DESCRIPTION
Avoid enabling the rustc-dep-of-std feature in the docs.rs build, as it
replaces core, which breaks rustdoc.