### PR TITLE
Add tests to ensure that the C type definitions match libc.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, beta, nightly]
+        rust: [stable, nightly, 1.48]
 
     env:
       RUSTFLAGS: -D warnings
@@ -27,6 +27,46 @@ jobs:
         cargo check --no-default-features --features "std netlink"
         cargo check --no-default-features --features "no_std netlink"
         cargo check --no-default-features --features "no_std general errno"
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      # -D warnings is commented out in our install-rust action; re-add it here.
+      RUSTFLAGS: -D warnings
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+      with:
+        toolchain: stable
+
+    - run: >
+        rustup target add
+        x86_64-unknown-linux-musl
+        x86_64-unknown-linux-gnux32
+        i686-unknown-linux-gnu
+        i686-unknown-linux-musl
+        riscv64gc-unknown-linux-gnu
+        aarch64-unknown-linux-gnu
+        aarch64-unknown-linux-musl
+        powerpc64le-unknown-linux-gnu
+        armv5te-unknown-linux-gnueabi
+        mipsel-unknown-linux-gnu
+        mips64el-unknown-linux-gnuabi64
+    - run: cargo test -vv
+    - run: cargo test -vv --target=x86_64-unknown-linux-musl
+    - run: cargo test -vv --target=x86_64-unknown-linux-gnux32
+    - run: cargo test -vv --target=i686-unknown-linux-gnu
+    - run: cargo test -vv --target=i686-unknown-linux-musl
+    - run: cargo test -vv --target=riscv64gc-unknown-linux-gnu
+    - run: cargo test -vv --target=aarch64-unknown-linux-gnu
+    - run: cargo test -vv --target=aarch64-unknown-linux-musl
+    - run: cargo test -vv --target=powerpc64le-unknown-linux-gnu
+    - run: cargo test -vv --target=armv5te-unknown-linux-gnueabi
+    - run: cargo test -vv --target=mipsel-unknown-linux-gnu
+    - run: cargo test -vv --target=mips64el-unknown-linux-gnuabi64
 
   gen:
     name: Update generated files

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ exclude = ["/gen", "/.*"]
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 compiler_builtins = { version = '0.1.49', optional = true }
 
+[dev-dependencies]
+static_assertions = "1.1.0"
+libc = "0.2.100"
+
 [package.metadata.docs.rs]
 features = ["default", "ioctl", "netlink"]
 targets = ["x86_64-unknown-linux-gnu", "i686-unknown-linux-gnu"]

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ rather than in a build.rs, making downstream builds simpler. And, this crate
 has bindings for more headers, as well as supplementary definitions not
 exported by Linux's headers but nonetheless needed by userspace.
 
-[linux-sys]: https://crates.io/crates/linux-sys
+# Minimum Supported Rust Version (MSRV)
 
+This crate currently works on the version of [Rust on Debian stable], which is
+currently Rust 1.48. This policy may change in the future, in minor version
+releases, so users using a fixed version of Rust should pin to a specific
+version of this crate.
+
+[linux-sys]: https://crates.io/crates/linux-sys
 [rustix crate]: https://github.com/bytecodealliance/rustix#linux-raw-syscall-support

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,34 @@ pub mod ctypes {
     pub use core::ffi::c_void;
 }
 
+// Confirm that our type definitions above match the actual type definitions.
+#[cfg(test)]
+static_assertions::assert_eq_size!(ctypes::c_char, libc::c_char);
+#[cfg(test)]
+static_assertions::assert_type_eq_all!(ctypes::c_schar, libc::c_schar);
+#[cfg(test)]
+static_assertions::assert_type_eq_all!(ctypes::c_uchar, libc::c_uchar);
+#[cfg(test)]
+static_assertions::assert_type_eq_all!(ctypes::c_short, libc::c_short);
+#[cfg(test)]
+static_assertions::assert_type_eq_all!(ctypes::c_ushort, libc::c_ushort);
+#[cfg(test)]
+static_assertions::assert_type_eq_all!(ctypes::c_int, libc::c_int);
+#[cfg(test)]
+static_assertions::assert_type_eq_all!(ctypes::c_uint, libc::c_uint);
+#[cfg(test)]
+static_assertions::assert_type_eq_all!(ctypes::c_long, libc::c_long);
+#[cfg(test)]
+static_assertions::assert_type_eq_all!(ctypes::c_ulong, libc::c_ulong);
+#[cfg(test)]
+static_assertions::assert_type_eq_all!(ctypes::c_longlong, libc::c_longlong);
+#[cfg(test)]
+static_assertions::assert_type_eq_all!(ctypes::c_ulonglong, libc::c_ulonglong);
+#[cfg(test)]
+static_assertions::assert_type_eq_all!(ctypes::c_float, libc::c_float);
+#[cfg(test)]
+static_assertions::assert_type_eq_all!(ctypes::c_double, libc::c_double);
+
 // The rest of this file is auto-generated!
 #[cfg(feature = "errno")]
 #[cfg(target_arch = "arm")]


### PR DESCRIPTION
In no-std mode, we don't depend on libc. But, we still want to be sure
that our types match those of libc. This adds a libc dev-dependency and
checks that the types are the same in cargo-test.