### PR TITLE
Add CMSG macros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 /gen/linux
+/.vscode

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,59 @@ impl PartialEq for general::__kernel_timespec {
 #[cfg(feature = "general")]
 impl Eq for general::__kernel_timespec {}
 
+mod cmsg_macros {
+    use crate::ctypes::{c_long, c_uint, c_uchar};
+    use crate::general::{cmsghdr, msghdr};
+    use core::mem::size_of;
+    use core::ptr;
+
+    pub unsafe fn CMSG_ALIGN(len: c_uint) -> c_uint {
+        let c_long_size = size_of::<c_long>() as c_uint;
+        (len + c_long_size - 1) & !(c_long_size - 1)
+    }
+
+    pub unsafe fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
+        (cmsg as *mut c_uchar).offset(size_of::<cmsghdr>() as isize)
+    }
+
+    pub unsafe fn CMSG_SPACE(len: c_uint) -> c_uint {
+        size_of::<cmsghdr>() as c_uint + CMSG_ALIGN(len)
+    }
+
+    pub unsafe fn CMSG_LEN(len: c_uint) -> c_uint {
+        size_of::<cmsghdr>() as c_uint + len
+    }
+
+    pub unsafe fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
+        if (*mhdr).msg_controllen < size_of::<cmsghdr>() as _ {
+            return ptr::null_mut();
+        }
+
+        (*mhdr).msg_control as *mut cmsghdr
+    }
+
+    pub unsafe fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
+        // TODO: This function should observe Rust's provenance rules once they're set in stone.
+
+        let cmsg_len = (*cmsg).cmsg_len;
+        let next_cmsg = (cmsg as *mut u8).offset(CMSG_ALIGN(cmsg_len as _) as isize) as *mut cmsghdr;
+        let max = ((*mhdr).msg_control as usize) + ((*mhdr).msg_controllen as usize);
+
+        if cmsg_len < size_of::<cmsghdr>() as _ {
+            return ptr::null_mut();
+        }
+
+        if next_cmsg.offset(1) as usize > max || next_cmsg as usize + CMSG_ALIGN(cmsg_len as _) as usize > max
+        {
+            return ptr::null_mut();
+        }
+
+        next_cmsg
+    }
+}
+
+pub use cmsg_macros::*;
+
 // The rest of this file is auto-generated!
 #[cfg(feature = "errno")]
 #[cfg(target_arch = "arm")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,7 @@ mod cmsg_macros {
     }
 }
 
+#[cfg(feature = "general")]
 pub use cmsg_macros::*;
 
 // The rest of this file is auto-generated!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ impl PartialEq for general::__kernel_timespec {
 impl Eq for general::__kernel_timespec {}
 
 #[cfg(feature = "general")]
-mod cmsg_macros {
+pub mod cmsg_macros {
     use crate::ctypes::{c_long, c_uint, c_uchar};
     use crate::general::{cmsghdr, msghdr};
     use core::mem::size_of;
@@ -130,9 +130,6 @@ mod cmsg_macros {
         next_cmsg
     }
 }
-
-#[cfg(feature = "general")]
-pub use cmsg_macros::*;
 
 // The rest of this file is auto-generated!
 #[cfg(feature = "errno")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ impl PartialEq for general::__kernel_timespec {
 #[cfg(feature = "general")]
 impl Eq for general::__kernel_timespec {}
 
+#[cfg(feature = "general")]
 mod cmsg_macros {
     use crate::ctypes::{c_long, c_uint, c_uchar};
     use crate::general::{cmsghdr, msghdr};
@@ -110,7 +111,8 @@ mod cmsg_macros {
     }
 
     pub unsafe fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
-        // TODO: This function should observe Rust's provenance rules once they're set in stone.
+        // We convert between isize/raw pointers here, which may not be sound in a future version of Rust.
+        // Once the provenance rules are set in stone, it will be a good idea to give this function a once-over.
 
         let cmsg_len = (*cmsg).cmsg_len;
         let next_cmsg = (cmsg as *mut u8).offset(CMSG_ALIGN(cmsg_len as _) as isize) as *mut cmsghdr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ mod cmsg_macros {
     }
 
     pub unsafe fn CMSG_NXTHDR(mhdr: *const msghdr, cmsg: *const cmsghdr) -> *mut cmsghdr {
-        // We convert between isize/raw pointers here, which may not be sound in a future version of Rust.
+        // We convert from raw pointers to isize here, which may not be sound in a future version of Rust.
         // Once the provenance rules are set in stone, it will be a good idea to give this function a once-over.
 
         let cmsg_len = (*cmsg).cmsg_len;


### PR DESCRIPTION
This PR adds CMSG macros based off of the ones found [here](https://github.com/torvalds/linux/blob/f86d1fbbe7858884d6754534a0afbb74fc30bc26/include/linux/socket.h#L107-L135). I want to add `sendmsg`/`recvmsg` to Rustix, but I'd rather not deduplicate these functions there.