### PR TITLE
Add <linux/capabilith.h> to the general module.

### DIFF
--- a/gen/modules/general.h
+++ b/gen/modules/general.h
@@ -6,6 +6,7 @@
 // Selected Linux headers.
 
 #include <linux/auxvec.h>
+#include <linux/capability.h>
 #include <linux/eventpoll.h>
 #include <linux/fadvise.h>
 #include <linux/falloc.h>

--- a/src/aarch64/general.rs
+++ b/src/aarch64/general.rs
@@ -167,12 +167,74 @@ pub const AT_BASE_PLATFORM: u32 = 24;
 pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_EXECFN: u32 = 31;
+pub const __BITS_PER_LONG: u32 = 64;
+pub const __FD_SETSIZE: u32 = 1024;
+pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
+pub const _LINUX_CAPABILITY_VERSION_2: u32 = 537333798;
+pub const _LINUX_CAPABILITY_U32S_2: u32 = 2;
+pub const _LINUX_CAPABILITY_VERSION_3: u32 = 537396514;
+pub const _LINUX_CAPABILITY_U32S_3: u32 = 2;
+pub const VFS_CAP_REVISION_MASK: u32 = 4278190080;
+pub const VFS_CAP_REVISION_SHIFT: u32 = 24;
+pub const VFS_CAP_FLAGS_MASK: i64 = -4278190081;
+pub const VFS_CAP_FLAGS_EFFECTIVE: u32 = 1;
+pub const VFS_CAP_REVISION_1: u32 = 16777216;
+pub const VFS_CAP_U32_1: u32 = 1;
+pub const VFS_CAP_REVISION_2: u32 = 33554432;
+pub const VFS_CAP_U32_2: u32 = 2;
+pub const VFS_CAP_REVISION_3: u32 = 50331648;
+pub const VFS_CAP_U32_3: u32 = 2;
+pub const VFS_CAP_U32: u32 = 2;
+pub const VFS_CAP_REVISION: u32 = 50331648;
+pub const _LINUX_CAPABILITY_VERSION: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S: u32 = 1;
+pub const CAP_CHOWN: u32 = 0;
+pub const CAP_DAC_OVERRIDE: u32 = 1;
+pub const CAP_DAC_READ_SEARCH: u32 = 2;
+pub const CAP_FOWNER: u32 = 3;
+pub const CAP_FSETID: u32 = 4;
+pub const CAP_KILL: u32 = 5;
+pub const CAP_SETGID: u32 = 6;
+pub const CAP_SETUID: u32 = 7;
+pub const CAP_SETPCAP: u32 = 8;
+pub const CAP_LINUX_IMMUTABLE: u32 = 9;
+pub const CAP_NET_BIND_SERVICE: u32 = 10;
+pub const CAP_NET_BROADCAST: u32 = 11;
+pub const CAP_NET_ADMIN: u32 = 12;
+pub const CAP_NET_RAW: u32 = 13;
+pub const CAP_IPC_LOCK: u32 = 14;
+pub const CAP_IPC_OWNER: u32 = 15;
+pub const CAP_SYS_MODULE: u32 = 16;
+pub const CAP_SYS_RAWIO: u32 = 17;
+pub const CAP_SYS_CHROOT: u32 = 18;
+pub const CAP_SYS_PTRACE: u32 = 19;
+pub const CAP_SYS_PACCT: u32 = 20;
+pub const CAP_SYS_ADMIN: u32 = 21;
+pub const CAP_SYS_BOOT: u32 = 22;
+pub const CAP_SYS_NICE: u32 = 23;
+pub const CAP_SYS_RESOURCE: u32 = 24;
+pub const CAP_SYS_TIME: u32 = 25;
+pub const CAP_SYS_TTY_CONFIG: u32 = 26;
+pub const CAP_MKNOD: u32 = 27;
+pub const CAP_LEASE: u32 = 28;
+pub const CAP_AUDIT_WRITE: u32 = 29;
+pub const CAP_AUDIT_CONTROL: u32 = 30;
+pub const CAP_SETFCAP: u32 = 31;
+pub const CAP_MAC_OVERRIDE: u32 = 32;
+pub const CAP_MAC_ADMIN: u32 = 33;
+pub const CAP_SYSLOG: u32 = 34;
+pub const CAP_WAKE_ALARM: u32 = 35;
+pub const CAP_BLOCK_SUSPEND: u32 = 36;
+pub const CAP_AUDIT_READ: u32 = 37;
+pub const CAP_PERFMON: u32 = 38;
+pub const CAP_BPF: u32 = 39;
+pub const CAP_CHECKPOINT_RESTORE: u32 = 40;
+pub const CAP_LAST_CAP: u32 = 40;
 pub const O_DIRECTORY: u32 = 16384;
 pub const O_NOFOLLOW: u32 = 32768;
 pub const O_DIRECT: u32 = 65536;
 pub const O_LARGEFILE: u32 = 131072;
-pub const __BITS_PER_LONG: u32 = 64;
-pub const __FD_SETSIZE: u32 = 1024;
 pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
@@ -2484,6 +2546,46 @@ pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_header_struct {
+pub version: __u32,
+pub pid: crate::ctypes::c_int,
+}
+pub type cap_user_header_t = *mut __user_cap_header_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_data_struct {
+pub effective: __u32,
+pub permitted: __u32,
+pub inheritable: __u32,
+}
+pub type cap_user_data_t = *mut __user_cap_data_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_cap_data__bindgen_ty_1; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_ns_cap_data__bindgen_ty_1; 2usize],
+pub rootid: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {

--- a/src/arm/general.rs
+++ b/src/arm/general.rs
@@ -166,12 +166,74 @@ pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_EXECFN: u32 = 31;
 pub const AT_MINSIGSTKSZ: u32 = 51;
+pub const __BITS_PER_LONG: u32 = 32;
+pub const __FD_SETSIZE: u32 = 1024;
+pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
+pub const _LINUX_CAPABILITY_VERSION_2: u32 = 537333798;
+pub const _LINUX_CAPABILITY_U32S_2: u32 = 2;
+pub const _LINUX_CAPABILITY_VERSION_3: u32 = 537396514;
+pub const _LINUX_CAPABILITY_U32S_3: u32 = 2;
+pub const VFS_CAP_REVISION_MASK: u32 = 4278190080;
+pub const VFS_CAP_REVISION_SHIFT: u32 = 24;
+pub const VFS_CAP_FLAGS_MASK: i64 = -4278190081;
+pub const VFS_CAP_FLAGS_EFFECTIVE: u32 = 1;
+pub const VFS_CAP_REVISION_1: u32 = 16777216;
+pub const VFS_CAP_U32_1: u32 = 1;
+pub const VFS_CAP_REVISION_2: u32 = 33554432;
+pub const VFS_CAP_U32_2: u32 = 2;
+pub const VFS_CAP_REVISION_3: u32 = 50331648;
+pub const VFS_CAP_U32_3: u32 = 2;
+pub const VFS_CAP_U32: u32 = 2;
+pub const VFS_CAP_REVISION: u32 = 50331648;
+pub const _LINUX_CAPABILITY_VERSION: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S: u32 = 1;
+pub const CAP_CHOWN: u32 = 0;
+pub const CAP_DAC_OVERRIDE: u32 = 1;
+pub const CAP_DAC_READ_SEARCH: u32 = 2;
+pub const CAP_FOWNER: u32 = 3;
+pub const CAP_FSETID: u32 = 4;
+pub const CAP_KILL: u32 = 5;
+pub const CAP_SETGID: u32 = 6;
+pub const CAP_SETUID: u32 = 7;
+pub const CAP_SETPCAP: u32 = 8;
+pub const CAP_LINUX_IMMUTABLE: u32 = 9;
+pub const CAP_NET_BIND_SERVICE: u32 = 10;
+pub const CAP_NET_BROADCAST: u32 = 11;
+pub const CAP_NET_ADMIN: u32 = 12;
+pub const CAP_NET_RAW: u32 = 13;
+pub const CAP_IPC_LOCK: u32 = 14;
+pub const CAP_IPC_OWNER: u32 = 15;
+pub const CAP_SYS_MODULE: u32 = 16;
+pub const CAP_SYS_RAWIO: u32 = 17;
+pub const CAP_SYS_CHROOT: u32 = 18;
+pub const CAP_SYS_PTRACE: u32 = 19;
+pub const CAP_SYS_PACCT: u32 = 20;
+pub const CAP_SYS_ADMIN: u32 = 21;
+pub const CAP_SYS_BOOT: u32 = 22;
+pub const CAP_SYS_NICE: u32 = 23;
+pub const CAP_SYS_RESOURCE: u32 = 24;
+pub const CAP_SYS_TIME: u32 = 25;
+pub const CAP_SYS_TTY_CONFIG: u32 = 26;
+pub const CAP_MKNOD: u32 = 27;
+pub const CAP_LEASE: u32 = 28;
+pub const CAP_AUDIT_WRITE: u32 = 29;
+pub const CAP_AUDIT_CONTROL: u32 = 30;
+pub const CAP_SETFCAP: u32 = 31;
+pub const CAP_MAC_OVERRIDE: u32 = 32;
+pub const CAP_MAC_ADMIN: u32 = 33;
+pub const CAP_SYSLOG: u32 = 34;
+pub const CAP_WAKE_ALARM: u32 = 35;
+pub const CAP_BLOCK_SUSPEND: u32 = 36;
+pub const CAP_AUDIT_READ: u32 = 37;
+pub const CAP_PERFMON: u32 = 38;
+pub const CAP_BPF: u32 = 39;
+pub const CAP_CHECKPOINT_RESTORE: u32 = 40;
+pub const CAP_LAST_CAP: u32 = 40;
 pub const O_DIRECTORY: u32 = 16384;
 pub const O_NOFOLLOW: u32 = 32768;
 pub const O_DIRECT: u32 = 65536;
 pub const O_LARGEFILE: u32 = 131072;
-pub const __BITS_PER_LONG: u32 = 32;
-pub const __FD_SETSIZE: u32 = 1024;
 pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
@@ -2570,6 +2632,46 @@ pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_header_struct {
+pub version: __u32,
+pub pid: crate::ctypes::c_int,
+}
+pub type cap_user_header_t = *mut __user_cap_header_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_data_struct {
+pub effective: __u32,
+pub permitted: __u32,
+pub inheritable: __u32,
+}
+pub type cap_user_data_t = *mut __user_cap_data_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_cap_data__bindgen_ty_1; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_ns_cap_data__bindgen_ty_1; 2usize],
+pub rootid: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {

--- a/src/mips/general.rs
+++ b/src/mips/general.rs
@@ -167,6 +167,7 @@ pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_EXECFN: u32 = 31;
 pub const AT_MINSIGSTKSZ: u32 = 51;
+pub const __FD_SETSIZE: u32 = 1024;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -177,6 +178,68 @@ pub const _MIPS_ISA_MIPS64: u32 = 7;
 pub const _MIPS_SIM_ABI32: u32 = 1;
 pub const _MIPS_SIM_NABI32: u32 = 2;
 pub const _MIPS_SIM_ABI64: u32 = 3;
+pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
+pub const _LINUX_CAPABILITY_VERSION_2: u32 = 537333798;
+pub const _LINUX_CAPABILITY_U32S_2: u32 = 2;
+pub const _LINUX_CAPABILITY_VERSION_3: u32 = 537396514;
+pub const _LINUX_CAPABILITY_U32S_3: u32 = 2;
+pub const VFS_CAP_REVISION_MASK: u32 = 4278190080;
+pub const VFS_CAP_REVISION_SHIFT: u32 = 24;
+pub const VFS_CAP_FLAGS_MASK: i64 = -4278190081;
+pub const VFS_CAP_FLAGS_EFFECTIVE: u32 = 1;
+pub const VFS_CAP_REVISION_1: u32 = 16777216;
+pub const VFS_CAP_U32_1: u32 = 1;
+pub const VFS_CAP_REVISION_2: u32 = 33554432;
+pub const VFS_CAP_U32_2: u32 = 2;
+pub const VFS_CAP_REVISION_3: u32 = 50331648;
+pub const VFS_CAP_U32_3: u32 = 2;
+pub const VFS_CAP_U32: u32 = 2;
+pub const VFS_CAP_REVISION: u32 = 50331648;
+pub const _LINUX_CAPABILITY_VERSION: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S: u32 = 1;
+pub const CAP_CHOWN: u32 = 0;
+pub const CAP_DAC_OVERRIDE: u32 = 1;
+pub const CAP_DAC_READ_SEARCH: u32 = 2;
+pub const CAP_FOWNER: u32 = 3;
+pub const CAP_FSETID: u32 = 4;
+pub const CAP_KILL: u32 = 5;
+pub const CAP_SETGID: u32 = 6;
+pub const CAP_SETUID: u32 = 7;
+pub const CAP_SETPCAP: u32 = 8;
+pub const CAP_LINUX_IMMUTABLE: u32 = 9;
+pub const CAP_NET_BIND_SERVICE: u32 = 10;
+pub const CAP_NET_BROADCAST: u32 = 11;
+pub const CAP_NET_ADMIN: u32 = 12;
+pub const CAP_NET_RAW: u32 = 13;
+pub const CAP_IPC_LOCK: u32 = 14;
+pub const CAP_IPC_OWNER: u32 = 15;
+pub const CAP_SYS_MODULE: u32 = 16;
+pub const CAP_SYS_RAWIO: u32 = 17;
+pub const CAP_SYS_CHROOT: u32 = 18;
+pub const CAP_SYS_PTRACE: u32 = 19;
+pub const CAP_SYS_PACCT: u32 = 20;
+pub const CAP_SYS_ADMIN: u32 = 21;
+pub const CAP_SYS_BOOT: u32 = 22;
+pub const CAP_SYS_NICE: u32 = 23;
+pub const CAP_SYS_RESOURCE: u32 = 24;
+pub const CAP_SYS_TIME: u32 = 25;
+pub const CAP_SYS_TTY_CONFIG: u32 = 26;
+pub const CAP_MKNOD: u32 = 27;
+pub const CAP_LEASE: u32 = 28;
+pub const CAP_AUDIT_WRITE: u32 = 29;
+pub const CAP_AUDIT_CONTROL: u32 = 30;
+pub const CAP_SETFCAP: u32 = 31;
+pub const CAP_MAC_OVERRIDE: u32 = 32;
+pub const CAP_MAC_ADMIN: u32 = 33;
+pub const CAP_SYSLOG: u32 = 34;
+pub const CAP_WAKE_ALARM: u32 = 35;
+pub const CAP_BLOCK_SUSPEND: u32 = 36;
+pub const CAP_AUDIT_READ: u32 = 37;
+pub const CAP_PERFMON: u32 = 38;
+pub const CAP_BPF: u32 = 39;
+pub const CAP_CHECKPOINT_RESTORE: u32 = 40;
+pub const CAP_LAST_CAP: u32 = 40;
 pub const O_APPEND: u32 = 8;
 pub const O_DSYNC: u32 = 16;
 pub const O_NONBLOCK: u32 = 128;
@@ -194,7 +257,9 @@ pub const F_SETLK: u32 = 6;
 pub const F_SETLKW: u32 = 7;
 pub const F_SETOWN: u32 = 24;
 pub const F_GETOWN: u32 = 23;
-pub const __FD_SETSIZE: u32 = 1024;
+pub const F_GETLK64: u32 = 33;
+pub const F_SETLK64: u32 = 34;
+pub const F_SETLKW64: u32 = 35;
 pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
@@ -215,9 +280,6 @@ pub const F_GETFL: u32 = 3;
 pub const F_SETFL: u32 = 4;
 pub const F_SETSIG: u32 = 10;
 pub const F_GETSIG: u32 = 11;
-pub const F_GETLK64: u32 = 12;
-pub const F_SETLK64: u32 = 13;
-pub const F_SETLKW64: u32 = 14;
 pub const F_SETOWN_EX: u32 = 15;
 pub const F_GETOWN_EX: u32 = 16;
 pub const F_GETOWNER_UIDS: u32 = 17;
@@ -2733,6 +2795,46 @@ pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_header_struct {
+pub version: __u32,
+pub pid: crate::ctypes::c_int,
+}
+pub type cap_user_header_t = *mut __user_cap_header_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_data_struct {
+pub effective: __u32,
+pub permitted: __u32,
+pub inheritable: __u32,
+}
+pub type cap_user_data_t = *mut __user_cap_data_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_cap_data__bindgen_ty_1; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_ns_cap_data__bindgen_ty_1; 2usize],
+pub rootid: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {

--- a/src/mips64/general.rs
+++ b/src/mips64/general.rs
@@ -167,6 +167,7 @@ pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_EXECFN: u32 = 31;
 pub const AT_MINSIGSTKSZ: u32 = 51;
+pub const __FD_SETSIZE: u32 = 1024;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -177,6 +178,68 @@ pub const _MIPS_ISA_MIPS64: u32 = 7;
 pub const _MIPS_SIM_ABI32: u32 = 1;
 pub const _MIPS_SIM_NABI32: u32 = 2;
 pub const _MIPS_SIM_ABI64: u32 = 3;
+pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
+pub const _LINUX_CAPABILITY_VERSION_2: u32 = 537333798;
+pub const _LINUX_CAPABILITY_U32S_2: u32 = 2;
+pub const _LINUX_CAPABILITY_VERSION_3: u32 = 537396514;
+pub const _LINUX_CAPABILITY_U32S_3: u32 = 2;
+pub const VFS_CAP_REVISION_MASK: u32 = 4278190080;
+pub const VFS_CAP_REVISION_SHIFT: u32 = 24;
+pub const VFS_CAP_FLAGS_MASK: i64 = -4278190081;
+pub const VFS_CAP_FLAGS_EFFECTIVE: u32 = 1;
+pub const VFS_CAP_REVISION_1: u32 = 16777216;
+pub const VFS_CAP_U32_1: u32 = 1;
+pub const VFS_CAP_REVISION_2: u32 = 33554432;
+pub const VFS_CAP_U32_2: u32 = 2;
+pub const VFS_CAP_REVISION_3: u32 = 50331648;
+pub const VFS_CAP_U32_3: u32 = 2;
+pub const VFS_CAP_U32: u32 = 2;
+pub const VFS_CAP_REVISION: u32 = 50331648;
+pub const _LINUX_CAPABILITY_VERSION: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S: u32 = 1;
+pub const CAP_CHOWN: u32 = 0;
+pub const CAP_DAC_OVERRIDE: u32 = 1;
+pub const CAP_DAC_READ_SEARCH: u32 = 2;
+pub const CAP_FOWNER: u32 = 3;
+pub const CAP_FSETID: u32 = 4;
+pub const CAP_KILL: u32 = 5;
+pub const CAP_SETGID: u32 = 6;
+pub const CAP_SETUID: u32 = 7;
+pub const CAP_SETPCAP: u32 = 8;
+pub const CAP_LINUX_IMMUTABLE: u32 = 9;
+pub const CAP_NET_BIND_SERVICE: u32 = 10;
+pub const CAP_NET_BROADCAST: u32 = 11;
+pub const CAP_NET_ADMIN: u32 = 12;
+pub const CAP_NET_RAW: u32 = 13;
+pub const CAP_IPC_LOCK: u32 = 14;
+pub const CAP_IPC_OWNER: u32 = 15;
+pub const CAP_SYS_MODULE: u32 = 16;
+pub const CAP_SYS_RAWIO: u32 = 17;
+pub const CAP_SYS_CHROOT: u32 = 18;
+pub const CAP_SYS_PTRACE: u32 = 19;
+pub const CAP_SYS_PACCT: u32 = 20;
+pub const CAP_SYS_ADMIN: u32 = 21;
+pub const CAP_SYS_BOOT: u32 = 22;
+pub const CAP_SYS_NICE: u32 = 23;
+pub const CAP_SYS_RESOURCE: u32 = 24;
+pub const CAP_SYS_TIME: u32 = 25;
+pub const CAP_SYS_TTY_CONFIG: u32 = 26;
+pub const CAP_MKNOD: u32 = 27;
+pub const CAP_LEASE: u32 = 28;
+pub const CAP_AUDIT_WRITE: u32 = 29;
+pub const CAP_AUDIT_CONTROL: u32 = 30;
+pub const CAP_SETFCAP: u32 = 31;
+pub const CAP_MAC_OVERRIDE: u32 = 32;
+pub const CAP_MAC_ADMIN: u32 = 33;
+pub const CAP_SYSLOG: u32 = 34;
+pub const CAP_WAKE_ALARM: u32 = 35;
+pub const CAP_BLOCK_SUSPEND: u32 = 36;
+pub const CAP_AUDIT_READ: u32 = 37;
+pub const CAP_PERFMON: u32 = 38;
+pub const CAP_BPF: u32 = 39;
+pub const CAP_CHECKPOINT_RESTORE: u32 = 40;
+pub const CAP_LAST_CAP: u32 = 40;
 pub const O_APPEND: u32 = 8;
 pub const O_DSYNC: u32 = 16;
 pub const O_NONBLOCK: u32 = 128;
@@ -194,7 +257,6 @@ pub const F_SETLK: u32 = 6;
 pub const F_SETLKW: u32 = 7;
 pub const F_SETOWN: u32 = 24;
 pub const F_GETOWN: u32 = 23;
-pub const __FD_SETSIZE: u32 = 1024;
 pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
@@ -2668,6 +2730,46 @@ pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_header_struct {
+pub version: __u32,
+pub pid: crate::ctypes::c_int,
+}
+pub type cap_user_header_t = *mut __user_cap_header_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_data_struct {
+pub effective: __u32,
+pub permitted: __u32,
+pub inheritable: __u32,
+}
+pub type cap_user_data_t = *mut __user_cap_data_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_cap_data__bindgen_ty_1; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_ns_cap_data__bindgen_ty_1; 2usize],
+pub rootid: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {

--- a/src/powerpc/general.rs
+++ b/src/powerpc/general.rs
@@ -179,12 +179,74 @@ pub const AT_BASE_PLATFORM: u32 = 24;
 pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_EXECFN: u32 = 31;
+pub const __BITS_PER_LONG: u32 = 32;
+pub const __FD_SETSIZE: u32 = 1024;
+pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
+pub const _LINUX_CAPABILITY_VERSION_2: u32 = 537333798;
+pub const _LINUX_CAPABILITY_U32S_2: u32 = 2;
+pub const _LINUX_CAPABILITY_VERSION_3: u32 = 537396514;
+pub const _LINUX_CAPABILITY_U32S_3: u32 = 2;
+pub const VFS_CAP_REVISION_MASK: u32 = 4278190080;
+pub const VFS_CAP_REVISION_SHIFT: u32 = 24;
+pub const VFS_CAP_FLAGS_MASK: i64 = -4278190081;
+pub const VFS_CAP_FLAGS_EFFECTIVE: u32 = 1;
+pub const VFS_CAP_REVISION_1: u32 = 16777216;
+pub const VFS_CAP_U32_1: u32 = 1;
+pub const VFS_CAP_REVISION_2: u32 = 33554432;
+pub const VFS_CAP_U32_2: u32 = 2;
+pub const VFS_CAP_REVISION_3: u32 = 50331648;
+pub const VFS_CAP_U32_3: u32 = 2;
+pub const VFS_CAP_U32: u32 = 2;
+pub const VFS_CAP_REVISION: u32 = 50331648;
+pub const _LINUX_CAPABILITY_VERSION: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S: u32 = 1;
+pub const CAP_CHOWN: u32 = 0;
+pub const CAP_DAC_OVERRIDE: u32 = 1;
+pub const CAP_DAC_READ_SEARCH: u32 = 2;
+pub const CAP_FOWNER: u32 = 3;
+pub const CAP_FSETID: u32 = 4;
+pub const CAP_KILL: u32 = 5;
+pub const CAP_SETGID: u32 = 6;
+pub const CAP_SETUID: u32 = 7;
+pub const CAP_SETPCAP: u32 = 8;
+pub const CAP_LINUX_IMMUTABLE: u32 = 9;
+pub const CAP_NET_BIND_SERVICE: u32 = 10;
+pub const CAP_NET_BROADCAST: u32 = 11;
+pub const CAP_NET_ADMIN: u32 = 12;
+pub const CAP_NET_RAW: u32 = 13;
+pub const CAP_IPC_LOCK: u32 = 14;
+pub const CAP_IPC_OWNER: u32 = 15;
+pub const CAP_SYS_MODULE: u32 = 16;
+pub const CAP_SYS_RAWIO: u32 = 17;
+pub const CAP_SYS_CHROOT: u32 = 18;
+pub const CAP_SYS_PTRACE: u32 = 19;
+pub const CAP_SYS_PACCT: u32 = 20;
+pub const CAP_SYS_ADMIN: u32 = 21;
+pub const CAP_SYS_BOOT: u32 = 22;
+pub const CAP_SYS_NICE: u32 = 23;
+pub const CAP_SYS_RESOURCE: u32 = 24;
+pub const CAP_SYS_TIME: u32 = 25;
+pub const CAP_SYS_TTY_CONFIG: u32 = 26;
+pub const CAP_MKNOD: u32 = 27;
+pub const CAP_LEASE: u32 = 28;
+pub const CAP_AUDIT_WRITE: u32 = 29;
+pub const CAP_AUDIT_CONTROL: u32 = 30;
+pub const CAP_SETFCAP: u32 = 31;
+pub const CAP_MAC_OVERRIDE: u32 = 32;
+pub const CAP_MAC_ADMIN: u32 = 33;
+pub const CAP_SYSLOG: u32 = 34;
+pub const CAP_WAKE_ALARM: u32 = 35;
+pub const CAP_BLOCK_SUSPEND: u32 = 36;
+pub const CAP_AUDIT_READ: u32 = 37;
+pub const CAP_PERFMON: u32 = 38;
+pub const CAP_BPF: u32 = 39;
+pub const CAP_CHECKPOINT_RESTORE: u32 = 40;
+pub const CAP_LAST_CAP: u32 = 40;
 pub const O_DIRECTORY: u32 = 16384;
 pub const O_NOFOLLOW: u32 = 32768;
 pub const O_LARGEFILE: u32 = 65536;
 pub const O_DIRECT: u32 = 131072;
-pub const __BITS_PER_LONG: u32 = 32;
-pub const __FD_SETSIZE: u32 = 1024;
 pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
@@ -2624,6 +2686,46 @@ pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_header_struct {
+pub version: __u32,
+pub pid: crate::ctypes::c_int,
+}
+pub type cap_user_header_t = *mut __user_cap_header_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_data_struct {
+pub effective: __u32,
+pub permitted: __u32,
+pub inheritable: __u32,
+}
+pub type cap_user_data_t = *mut __user_cap_data_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_cap_data__bindgen_ty_1; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_ns_cap_data__bindgen_ty_1; 2usize],
+pub rootid: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {

--- a/src/powerpc64/general.rs
+++ b/src/powerpc64/general.rs
@@ -179,12 +179,74 @@ pub const AT_BASE_PLATFORM: u32 = 24;
 pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_EXECFN: u32 = 31;
+pub const __BITS_PER_LONG: u32 = 64;
+pub const __FD_SETSIZE: u32 = 1024;
+pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
+pub const _LINUX_CAPABILITY_VERSION_2: u32 = 537333798;
+pub const _LINUX_CAPABILITY_U32S_2: u32 = 2;
+pub const _LINUX_CAPABILITY_VERSION_3: u32 = 537396514;
+pub const _LINUX_CAPABILITY_U32S_3: u32 = 2;
+pub const VFS_CAP_REVISION_MASK: u32 = 4278190080;
+pub const VFS_CAP_REVISION_SHIFT: u32 = 24;
+pub const VFS_CAP_FLAGS_MASK: i64 = -4278190081;
+pub const VFS_CAP_FLAGS_EFFECTIVE: u32 = 1;
+pub const VFS_CAP_REVISION_1: u32 = 16777216;
+pub const VFS_CAP_U32_1: u32 = 1;
+pub const VFS_CAP_REVISION_2: u32 = 33554432;
+pub const VFS_CAP_U32_2: u32 = 2;
+pub const VFS_CAP_REVISION_3: u32 = 50331648;
+pub const VFS_CAP_U32_3: u32 = 2;
+pub const VFS_CAP_U32: u32 = 2;
+pub const VFS_CAP_REVISION: u32 = 50331648;
+pub const _LINUX_CAPABILITY_VERSION: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S: u32 = 1;
+pub const CAP_CHOWN: u32 = 0;
+pub const CAP_DAC_OVERRIDE: u32 = 1;
+pub const CAP_DAC_READ_SEARCH: u32 = 2;
+pub const CAP_FOWNER: u32 = 3;
+pub const CAP_FSETID: u32 = 4;
+pub const CAP_KILL: u32 = 5;
+pub const CAP_SETGID: u32 = 6;
+pub const CAP_SETUID: u32 = 7;
+pub const CAP_SETPCAP: u32 = 8;
+pub const CAP_LINUX_IMMUTABLE: u32 = 9;
+pub const CAP_NET_BIND_SERVICE: u32 = 10;
+pub const CAP_NET_BROADCAST: u32 = 11;
+pub const CAP_NET_ADMIN: u32 = 12;
+pub const CAP_NET_RAW: u32 = 13;
+pub const CAP_IPC_LOCK: u32 = 14;
+pub const CAP_IPC_OWNER: u32 = 15;
+pub const CAP_SYS_MODULE: u32 = 16;
+pub const CAP_SYS_RAWIO: u32 = 17;
+pub const CAP_SYS_CHROOT: u32 = 18;
+pub const CAP_SYS_PTRACE: u32 = 19;
+pub const CAP_SYS_PACCT: u32 = 20;
+pub const CAP_SYS_ADMIN: u32 = 21;
+pub const CAP_SYS_BOOT: u32 = 22;
+pub const CAP_SYS_NICE: u32 = 23;
+pub const CAP_SYS_RESOURCE: u32 = 24;
+pub const CAP_SYS_TIME: u32 = 25;
+pub const CAP_SYS_TTY_CONFIG: u32 = 26;
+pub const CAP_MKNOD: u32 = 27;
+pub const CAP_LEASE: u32 = 28;
+pub const CAP_AUDIT_WRITE: u32 = 29;
+pub const CAP_AUDIT_CONTROL: u32 = 30;
+pub const CAP_SETFCAP: u32 = 31;
+pub const CAP_MAC_OVERRIDE: u32 = 32;
+pub const CAP_MAC_ADMIN: u32 = 33;
+pub const CAP_SYSLOG: u32 = 34;
+pub const CAP_WAKE_ALARM: u32 = 35;
+pub const CAP_BLOCK_SUSPEND: u32 = 36;
+pub const CAP_AUDIT_READ: u32 = 37;
+pub const CAP_PERFMON: u32 = 38;
+pub const CAP_BPF: u32 = 39;
+pub const CAP_CHECKPOINT_RESTORE: u32 = 40;
+pub const CAP_LAST_CAP: u32 = 40;
 pub const O_DIRECTORY: u32 = 16384;
 pub const O_NOFOLLOW: u32 = 32768;
 pub const O_LARGEFILE: u32 = 65536;
 pub const O_DIRECT: u32 = 131072;
-pub const __BITS_PER_LONG: u32 = 64;
-pub const __FD_SETSIZE: u32 = 1024;
 pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
@@ -2599,6 +2661,46 @@ pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_header_struct {
+pub version: __u32,
+pub pid: crate::ctypes::c_int,
+}
+pub type cap_user_header_t = *mut __user_cap_header_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_data_struct {
+pub effective: __u32,
+pub permitted: __u32,
+pub inheritable: __u32,
+}
+pub type cap_user_data_t = *mut __user_cap_data_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_cap_data__bindgen_ty_1; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_ns_cap_data__bindgen_ty_1; 2usize],
+pub rootid: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {

--- a/src/riscv32/general.rs
+++ b/src/riscv32/general.rs
@@ -176,6 +176,68 @@ pub const AT_HWCAP2: u32 = 26;
 pub const AT_EXECFN: u32 = 31;
 pub const AT_MINSIGSTKSZ: u32 = 51;
 pub const __FD_SETSIZE: u32 = 1024;
+pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
+pub const _LINUX_CAPABILITY_VERSION_2: u32 = 537333798;
+pub const _LINUX_CAPABILITY_U32S_2: u32 = 2;
+pub const _LINUX_CAPABILITY_VERSION_3: u32 = 537396514;
+pub const _LINUX_CAPABILITY_U32S_3: u32 = 2;
+pub const VFS_CAP_REVISION_MASK: u32 = 4278190080;
+pub const VFS_CAP_REVISION_SHIFT: u32 = 24;
+pub const VFS_CAP_FLAGS_MASK: i64 = -4278190081;
+pub const VFS_CAP_FLAGS_EFFECTIVE: u32 = 1;
+pub const VFS_CAP_REVISION_1: u32 = 16777216;
+pub const VFS_CAP_U32_1: u32 = 1;
+pub const VFS_CAP_REVISION_2: u32 = 33554432;
+pub const VFS_CAP_U32_2: u32 = 2;
+pub const VFS_CAP_REVISION_3: u32 = 50331648;
+pub const VFS_CAP_U32_3: u32 = 2;
+pub const VFS_CAP_U32: u32 = 2;
+pub const VFS_CAP_REVISION: u32 = 50331648;
+pub const _LINUX_CAPABILITY_VERSION: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S: u32 = 1;
+pub const CAP_CHOWN: u32 = 0;
+pub const CAP_DAC_OVERRIDE: u32 = 1;
+pub const CAP_DAC_READ_SEARCH: u32 = 2;
+pub const CAP_FOWNER: u32 = 3;
+pub const CAP_FSETID: u32 = 4;
+pub const CAP_KILL: u32 = 5;
+pub const CAP_SETGID: u32 = 6;
+pub const CAP_SETUID: u32 = 7;
+pub const CAP_SETPCAP: u32 = 8;
+pub const CAP_LINUX_IMMUTABLE: u32 = 9;
+pub const CAP_NET_BIND_SERVICE: u32 = 10;
+pub const CAP_NET_BROADCAST: u32 = 11;
+pub const CAP_NET_ADMIN: u32 = 12;
+pub const CAP_NET_RAW: u32 = 13;
+pub const CAP_IPC_LOCK: u32 = 14;
+pub const CAP_IPC_OWNER: u32 = 15;
+pub const CAP_SYS_MODULE: u32 = 16;
+pub const CAP_SYS_RAWIO: u32 = 17;
+pub const CAP_SYS_CHROOT: u32 = 18;
+pub const CAP_SYS_PTRACE: u32 = 19;
+pub const CAP_SYS_PACCT: u32 = 20;
+pub const CAP_SYS_ADMIN: u32 = 21;
+pub const CAP_SYS_BOOT: u32 = 22;
+pub const CAP_SYS_NICE: u32 = 23;
+pub const CAP_SYS_RESOURCE: u32 = 24;
+pub const CAP_SYS_TIME: u32 = 25;
+pub const CAP_SYS_TTY_CONFIG: u32 = 26;
+pub const CAP_MKNOD: u32 = 27;
+pub const CAP_LEASE: u32 = 28;
+pub const CAP_AUDIT_WRITE: u32 = 29;
+pub const CAP_AUDIT_CONTROL: u32 = 30;
+pub const CAP_SETFCAP: u32 = 31;
+pub const CAP_MAC_OVERRIDE: u32 = 32;
+pub const CAP_MAC_ADMIN: u32 = 33;
+pub const CAP_SYSLOG: u32 = 34;
+pub const CAP_WAKE_ALARM: u32 = 35;
+pub const CAP_BLOCK_SUSPEND: u32 = 36;
+pub const CAP_AUDIT_READ: u32 = 37;
+pub const CAP_PERFMON: u32 = 38;
+pub const CAP_BPF: u32 = 39;
+pub const CAP_CHECKPOINT_RESTORE: u32 = 40;
+pub const CAP_LAST_CAP: u32 = 40;
 pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
@@ -2469,6 +2531,46 @@ pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_header_struct {
+pub version: __u32,
+pub pid: crate::ctypes::c_int,
+}
+pub type cap_user_header_t = *mut __user_cap_header_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_data_struct {
+pub effective: __u32,
+pub permitted: __u32,
+pub inheritable: __u32,
+}
+pub type cap_user_data_t = *mut __user_cap_data_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_cap_data__bindgen_ty_1; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_ns_cap_data__bindgen_ty_1; 2usize],
+pub rootid: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {

--- a/src/riscv64/general.rs
+++ b/src/riscv64/general.rs
@@ -176,6 +176,68 @@ pub const AT_HWCAP2: u32 = 26;
 pub const AT_EXECFN: u32 = 31;
 pub const AT_MINSIGSTKSZ: u32 = 51;
 pub const __FD_SETSIZE: u32 = 1024;
+pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
+pub const _LINUX_CAPABILITY_VERSION_2: u32 = 537333798;
+pub const _LINUX_CAPABILITY_U32S_2: u32 = 2;
+pub const _LINUX_CAPABILITY_VERSION_3: u32 = 537396514;
+pub const _LINUX_CAPABILITY_U32S_3: u32 = 2;
+pub const VFS_CAP_REVISION_MASK: u32 = 4278190080;
+pub const VFS_CAP_REVISION_SHIFT: u32 = 24;
+pub const VFS_CAP_FLAGS_MASK: i64 = -4278190081;
+pub const VFS_CAP_FLAGS_EFFECTIVE: u32 = 1;
+pub const VFS_CAP_REVISION_1: u32 = 16777216;
+pub const VFS_CAP_U32_1: u32 = 1;
+pub const VFS_CAP_REVISION_2: u32 = 33554432;
+pub const VFS_CAP_U32_2: u32 = 2;
+pub const VFS_CAP_REVISION_3: u32 = 50331648;
+pub const VFS_CAP_U32_3: u32 = 2;
+pub const VFS_CAP_U32: u32 = 2;
+pub const VFS_CAP_REVISION: u32 = 50331648;
+pub const _LINUX_CAPABILITY_VERSION: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S: u32 = 1;
+pub const CAP_CHOWN: u32 = 0;
+pub const CAP_DAC_OVERRIDE: u32 = 1;
+pub const CAP_DAC_READ_SEARCH: u32 = 2;
+pub const CAP_FOWNER: u32 = 3;
+pub const CAP_FSETID: u32 = 4;
+pub const CAP_KILL: u32 = 5;
+pub const CAP_SETGID: u32 = 6;
+pub const CAP_SETUID: u32 = 7;
+pub const CAP_SETPCAP: u32 = 8;
+pub const CAP_LINUX_IMMUTABLE: u32 = 9;
+pub const CAP_NET_BIND_SERVICE: u32 = 10;
+pub const CAP_NET_BROADCAST: u32 = 11;
+pub const CAP_NET_ADMIN: u32 = 12;
+pub const CAP_NET_RAW: u32 = 13;
+pub const CAP_IPC_LOCK: u32 = 14;
+pub const CAP_IPC_OWNER: u32 = 15;
+pub const CAP_SYS_MODULE: u32 = 16;
+pub const CAP_SYS_RAWIO: u32 = 17;
+pub const CAP_SYS_CHROOT: u32 = 18;
+pub const CAP_SYS_PTRACE: u32 = 19;
+pub const CAP_SYS_PACCT: u32 = 20;
+pub const CAP_SYS_ADMIN: u32 = 21;
+pub const CAP_SYS_BOOT: u32 = 22;
+pub const CAP_SYS_NICE: u32 = 23;
+pub const CAP_SYS_RESOURCE: u32 = 24;
+pub const CAP_SYS_TIME: u32 = 25;
+pub const CAP_SYS_TTY_CONFIG: u32 = 26;
+pub const CAP_MKNOD: u32 = 27;
+pub const CAP_LEASE: u32 = 28;
+pub const CAP_AUDIT_WRITE: u32 = 29;
+pub const CAP_AUDIT_CONTROL: u32 = 30;
+pub const CAP_SETFCAP: u32 = 31;
+pub const CAP_MAC_OVERRIDE: u32 = 32;
+pub const CAP_MAC_ADMIN: u32 = 33;
+pub const CAP_SYSLOG: u32 = 34;
+pub const CAP_WAKE_ALARM: u32 = 35;
+pub const CAP_BLOCK_SUSPEND: u32 = 36;
+pub const CAP_AUDIT_READ: u32 = 37;
+pub const CAP_PERFMON: u32 = 38;
+pub const CAP_BPF: u32 = 39;
+pub const CAP_CHECKPOINT_RESTORE: u32 = 40;
+pub const CAP_LAST_CAP: u32 = 40;
 pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
@@ -2486,6 +2548,46 @@ pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_header_struct {
+pub version: __u32,
+pub pid: crate::ctypes::c_int,
+}
+pub type cap_user_header_t = *mut __user_cap_header_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_data_struct {
+pub effective: __u32,
+pub permitted: __u32,
+pub inheritable: __u32,
+}
+pub type cap_user_data_t = *mut __user_cap_data_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_cap_data__bindgen_ty_1; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_ns_cap_data__bindgen_ty_1; 2usize],
+pub rootid: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {

--- a/src/s390x/general.rs
+++ b/src/s390x/general.rs
@@ -169,6 +169,68 @@ pub const AT_EXECFN: u32 = 31;
 pub const AT_MINSIGSTKSZ: u32 = 51;
 pub const __BITS_PER_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
+pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
+pub const _LINUX_CAPABILITY_VERSION_2: u32 = 537333798;
+pub const _LINUX_CAPABILITY_U32S_2: u32 = 2;
+pub const _LINUX_CAPABILITY_VERSION_3: u32 = 537396514;
+pub const _LINUX_CAPABILITY_U32S_3: u32 = 2;
+pub const VFS_CAP_REVISION_MASK: u32 = 4278190080;
+pub const VFS_CAP_REVISION_SHIFT: u32 = 24;
+pub const VFS_CAP_FLAGS_MASK: i64 = -4278190081;
+pub const VFS_CAP_FLAGS_EFFECTIVE: u32 = 1;
+pub const VFS_CAP_REVISION_1: u32 = 16777216;
+pub const VFS_CAP_U32_1: u32 = 1;
+pub const VFS_CAP_REVISION_2: u32 = 33554432;
+pub const VFS_CAP_U32_2: u32 = 2;
+pub const VFS_CAP_REVISION_3: u32 = 50331648;
+pub const VFS_CAP_U32_3: u32 = 2;
+pub const VFS_CAP_U32: u32 = 2;
+pub const VFS_CAP_REVISION: u32 = 50331648;
+pub const _LINUX_CAPABILITY_VERSION: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S: u32 = 1;
+pub const CAP_CHOWN: u32 = 0;
+pub const CAP_DAC_OVERRIDE: u32 = 1;
+pub const CAP_DAC_READ_SEARCH: u32 = 2;
+pub const CAP_FOWNER: u32 = 3;
+pub const CAP_FSETID: u32 = 4;
+pub const CAP_KILL: u32 = 5;
+pub const CAP_SETGID: u32 = 6;
+pub const CAP_SETUID: u32 = 7;
+pub const CAP_SETPCAP: u32 = 8;
+pub const CAP_LINUX_IMMUTABLE: u32 = 9;
+pub const CAP_NET_BIND_SERVICE: u32 = 10;
+pub const CAP_NET_BROADCAST: u32 = 11;
+pub const CAP_NET_ADMIN: u32 = 12;
+pub const CAP_NET_RAW: u32 = 13;
+pub const CAP_IPC_LOCK: u32 = 14;
+pub const CAP_IPC_OWNER: u32 = 15;
+pub const CAP_SYS_MODULE: u32 = 16;
+pub const CAP_SYS_RAWIO: u32 = 17;
+pub const CAP_SYS_CHROOT: u32 = 18;
+pub const CAP_SYS_PTRACE: u32 = 19;
+pub const CAP_SYS_PACCT: u32 = 20;
+pub const CAP_SYS_ADMIN: u32 = 21;
+pub const CAP_SYS_BOOT: u32 = 22;
+pub const CAP_SYS_NICE: u32 = 23;
+pub const CAP_SYS_RESOURCE: u32 = 24;
+pub const CAP_SYS_TIME: u32 = 25;
+pub const CAP_SYS_TTY_CONFIG: u32 = 26;
+pub const CAP_MKNOD: u32 = 27;
+pub const CAP_LEASE: u32 = 28;
+pub const CAP_AUDIT_WRITE: u32 = 29;
+pub const CAP_AUDIT_CONTROL: u32 = 30;
+pub const CAP_SETFCAP: u32 = 31;
+pub const CAP_MAC_OVERRIDE: u32 = 32;
+pub const CAP_MAC_ADMIN: u32 = 33;
+pub const CAP_SYSLOG: u32 = 34;
+pub const CAP_WAKE_ALARM: u32 = 35;
+pub const CAP_BLOCK_SUSPEND: u32 = 36;
+pub const CAP_AUDIT_READ: u32 = 37;
+pub const CAP_PERFMON: u32 = 38;
+pub const CAP_BPF: u32 = 39;
+pub const CAP_CHECKPOINT_RESTORE: u32 = 40;
+pub const CAP_LAST_CAP: u32 = 40;
 pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
@@ -2536,6 +2598,46 @@ pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_header_struct {
+pub version: __u32,
+pub pid: crate::ctypes::c_int,
+}
+pub type cap_user_header_t = *mut __user_cap_header_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_data_struct {
+pub effective: __u32,
+pub permitted: __u32,
+pub inheritable: __u32,
+}
+pub type cap_user_data_t = *mut __user_cap_data_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_cap_data__bindgen_ty_1; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_ns_cap_data__bindgen_ty_1; 2usize],
+pub rootid: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {

--- a/src/sparc/general.rs
+++ b/src/sparc/general.rs
@@ -170,6 +170,70 @@ pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_EXECFN: u32 = 31;
 pub const AT_MINSIGSTKSZ: u32 = 51;
+pub const __BITS_PER_LONG: u32 = 32;
+pub const __FD_SETSIZE: u32 = 1024;
+pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
+pub const _LINUX_CAPABILITY_VERSION_2: u32 = 537333798;
+pub const _LINUX_CAPABILITY_U32S_2: u32 = 2;
+pub const _LINUX_CAPABILITY_VERSION_3: u32 = 537396514;
+pub const _LINUX_CAPABILITY_U32S_3: u32 = 2;
+pub const VFS_CAP_REVISION_MASK: u32 = 4278190080;
+pub const VFS_CAP_REVISION_SHIFT: u32 = 24;
+pub const VFS_CAP_FLAGS_MASK: i64 = -4278190081;
+pub const VFS_CAP_FLAGS_EFFECTIVE: u32 = 1;
+pub const VFS_CAP_REVISION_1: u32 = 16777216;
+pub const VFS_CAP_U32_1: u32 = 1;
+pub const VFS_CAP_REVISION_2: u32 = 33554432;
+pub const VFS_CAP_U32_2: u32 = 2;
+pub const VFS_CAP_REVISION_3: u32 = 50331648;
+pub const VFS_CAP_U32_3: u32 = 2;
+pub const VFS_CAP_U32: u32 = 2;
+pub const VFS_CAP_REVISION: u32 = 50331648;
+pub const _LINUX_CAPABILITY_VERSION: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S: u32 = 1;
+pub const CAP_CHOWN: u32 = 0;
+pub const CAP_DAC_OVERRIDE: u32 = 1;
+pub const CAP_DAC_READ_SEARCH: u32 = 2;
+pub const CAP_FOWNER: u32 = 3;
+pub const CAP_FSETID: u32 = 4;
+pub const CAP_KILL: u32 = 5;
+pub const CAP_SETGID: u32 = 6;
+pub const CAP_SETUID: u32 = 7;
+pub const CAP_SETPCAP: u32 = 8;
+pub const CAP_LINUX_IMMUTABLE: u32 = 9;
+pub const CAP_NET_BIND_SERVICE: u32 = 10;
+pub const CAP_NET_BROADCAST: u32 = 11;
+pub const CAP_NET_ADMIN: u32 = 12;
+pub const CAP_NET_RAW: u32 = 13;
+pub const CAP_IPC_LOCK: u32 = 14;
+pub const CAP_IPC_OWNER: u32 = 15;
+pub const CAP_SYS_MODULE: u32 = 16;
+pub const CAP_SYS_RAWIO: u32 = 17;
+pub const CAP_SYS_CHROOT: u32 = 18;
+pub const CAP_SYS_PTRACE: u32 = 19;
+pub const CAP_SYS_PACCT: u32 = 20;
+pub const CAP_SYS_ADMIN: u32 = 21;
+pub const CAP_SYS_BOOT: u32 = 22;
+pub const CAP_SYS_NICE: u32 = 23;
+pub const CAP_SYS_RESOURCE: u32 = 24;
+pub const CAP_SYS_TIME: u32 = 25;
+pub const CAP_SYS_TTY_CONFIG: u32 = 26;
+pub const CAP_MKNOD: u32 = 27;
+pub const CAP_LEASE: u32 = 28;
+pub const CAP_AUDIT_WRITE: u32 = 29;
+pub const CAP_AUDIT_CONTROL: u32 = 30;
+pub const CAP_SETFCAP: u32 = 31;
+pub const CAP_MAC_OVERRIDE: u32 = 32;
+pub const CAP_MAC_ADMIN: u32 = 33;
+pub const CAP_SYSLOG: u32 = 34;
+pub const CAP_WAKE_ALARM: u32 = 35;
+pub const CAP_BLOCK_SUSPEND: u32 = 36;
+pub const CAP_AUDIT_READ: u32 = 37;
+pub const CAP_PERFMON: u32 = 38;
+pub const CAP_BPF: u32 = 39;
+pub const CAP_CHECKPOINT_RESTORE: u32 = 40;
+pub const CAP_LAST_CAP: u32 = 40;
 pub const O_APPEND: u32 = 8;
 pub const FASYNC: u32 = 64;
 pub const O_CREAT: u32 = 512;
@@ -195,8 +259,6 @@ pub const F_SETLKW: u32 = 9;
 pub const F_RDLCK: u32 = 1;
 pub const F_WRLCK: u32 = 2;
 pub const F_UNLCK: u32 = 3;
-pub const __BITS_PER_LONG: u32 = 32;
-pub const __FD_SETSIZE: u32 = 1024;
 pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
@@ -2833,6 +2895,46 @@ pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_header_struct {
+pub version: __u32,
+pub pid: crate::ctypes::c_int,
+}
+pub type cap_user_header_t = *mut __user_cap_header_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_data_struct {
+pub effective: __u32,
+pub permitted: __u32,
+pub inheritable: __u32,
+}
+pub type cap_user_data_t = *mut __user_cap_data_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_cap_data__bindgen_ty_1; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_ns_cap_data__bindgen_ty_1; 2usize],
+pub rootid: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {

--- a/src/sparc64/general.rs
+++ b/src/sparc64/general.rs
@@ -170,6 +170,70 @@ pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_EXECFN: u32 = 31;
 pub const AT_MINSIGSTKSZ: u32 = 51;
+pub const __BITS_PER_LONG: u32 = 64;
+pub const __FD_SETSIZE: u32 = 1024;
+pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
+pub const _LINUX_CAPABILITY_VERSION_2: u32 = 537333798;
+pub const _LINUX_CAPABILITY_U32S_2: u32 = 2;
+pub const _LINUX_CAPABILITY_VERSION_3: u32 = 537396514;
+pub const _LINUX_CAPABILITY_U32S_3: u32 = 2;
+pub const VFS_CAP_REVISION_MASK: u32 = 4278190080;
+pub const VFS_CAP_REVISION_SHIFT: u32 = 24;
+pub const VFS_CAP_FLAGS_MASK: i64 = -4278190081;
+pub const VFS_CAP_FLAGS_EFFECTIVE: u32 = 1;
+pub const VFS_CAP_REVISION_1: u32 = 16777216;
+pub const VFS_CAP_U32_1: u32 = 1;
+pub const VFS_CAP_REVISION_2: u32 = 33554432;
+pub const VFS_CAP_U32_2: u32 = 2;
+pub const VFS_CAP_REVISION_3: u32 = 50331648;
+pub const VFS_CAP_U32_3: u32 = 2;
+pub const VFS_CAP_U32: u32 = 2;
+pub const VFS_CAP_REVISION: u32 = 50331648;
+pub const _LINUX_CAPABILITY_VERSION: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S: u32 = 1;
+pub const CAP_CHOWN: u32 = 0;
+pub const CAP_DAC_OVERRIDE: u32 = 1;
+pub const CAP_DAC_READ_SEARCH: u32 = 2;
+pub const CAP_FOWNER: u32 = 3;
+pub const CAP_FSETID: u32 = 4;
+pub const CAP_KILL: u32 = 5;
+pub const CAP_SETGID: u32 = 6;
+pub const CAP_SETUID: u32 = 7;
+pub const CAP_SETPCAP: u32 = 8;
+pub const CAP_LINUX_IMMUTABLE: u32 = 9;
+pub const CAP_NET_BIND_SERVICE: u32 = 10;
+pub const CAP_NET_BROADCAST: u32 = 11;
+pub const CAP_NET_ADMIN: u32 = 12;
+pub const CAP_NET_RAW: u32 = 13;
+pub const CAP_IPC_LOCK: u32 = 14;
+pub const CAP_IPC_OWNER: u32 = 15;
+pub const CAP_SYS_MODULE: u32 = 16;
+pub const CAP_SYS_RAWIO: u32 = 17;
+pub const CAP_SYS_CHROOT: u32 = 18;
+pub const CAP_SYS_PTRACE: u32 = 19;
+pub const CAP_SYS_PACCT: u32 = 20;
+pub const CAP_SYS_ADMIN: u32 = 21;
+pub const CAP_SYS_BOOT: u32 = 22;
+pub const CAP_SYS_NICE: u32 = 23;
+pub const CAP_SYS_RESOURCE: u32 = 24;
+pub const CAP_SYS_TIME: u32 = 25;
+pub const CAP_SYS_TTY_CONFIG: u32 = 26;
+pub const CAP_MKNOD: u32 = 27;
+pub const CAP_LEASE: u32 = 28;
+pub const CAP_AUDIT_WRITE: u32 = 29;
+pub const CAP_AUDIT_CONTROL: u32 = 30;
+pub const CAP_SETFCAP: u32 = 31;
+pub const CAP_MAC_OVERRIDE: u32 = 32;
+pub const CAP_MAC_ADMIN: u32 = 33;
+pub const CAP_SYSLOG: u32 = 34;
+pub const CAP_WAKE_ALARM: u32 = 35;
+pub const CAP_BLOCK_SUSPEND: u32 = 36;
+pub const CAP_AUDIT_READ: u32 = 37;
+pub const CAP_PERFMON: u32 = 38;
+pub const CAP_BPF: u32 = 39;
+pub const CAP_CHECKPOINT_RESTORE: u32 = 40;
+pub const CAP_LAST_CAP: u32 = 40;
 pub const O_APPEND: u32 = 8;
 pub const FASYNC: u32 = 64;
 pub const O_CREAT: u32 = 512;
@@ -195,8 +259,6 @@ pub const F_SETLKW: u32 = 9;
 pub const F_RDLCK: u32 = 1;
 pub const F_WRLCK: u32 = 2;
 pub const F_UNLCK: u32 = 3;
-pub const __BITS_PER_LONG: u32 = 64;
-pub const __FD_SETSIZE: u32 = 1024;
 pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
@@ -2806,6 +2868,46 @@ pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_header_struct {
+pub version: __u32,
+pub pid: crate::ctypes::c_int,
+}
+pub type cap_user_header_t = *mut __user_cap_header_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_data_struct {
+pub effective: __u32,
+pub permitted: __u32,
+pub inheritable: __u32,
+}
+pub type cap_user_data_t = *mut __user_cap_data_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_cap_data__bindgen_ty_1; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_ns_cap_data__bindgen_ty_1; 2usize],
+pub rootid: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {

--- a/src/x32/general.rs
+++ b/src/x32/general.rs
@@ -169,6 +169,68 @@ pub const AT_EXECFN: u32 = 31;
 pub const AT_MINSIGSTKSZ: u32 = 51;
 pub const __BITS_PER_LONG: u32 = 32;
 pub const __FD_SETSIZE: u32 = 1024;
+pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
+pub const _LINUX_CAPABILITY_VERSION_2: u32 = 537333798;
+pub const _LINUX_CAPABILITY_U32S_2: u32 = 2;
+pub const _LINUX_CAPABILITY_VERSION_3: u32 = 537396514;
+pub const _LINUX_CAPABILITY_U32S_3: u32 = 2;
+pub const VFS_CAP_REVISION_MASK: u32 = 4278190080;
+pub const VFS_CAP_REVISION_SHIFT: u32 = 24;
+pub const VFS_CAP_FLAGS_MASK: i64 = -4278190081;
+pub const VFS_CAP_FLAGS_EFFECTIVE: u32 = 1;
+pub const VFS_CAP_REVISION_1: u32 = 16777216;
+pub const VFS_CAP_U32_1: u32 = 1;
+pub const VFS_CAP_REVISION_2: u32 = 33554432;
+pub const VFS_CAP_U32_2: u32 = 2;
+pub const VFS_CAP_REVISION_3: u32 = 50331648;
+pub const VFS_CAP_U32_3: u32 = 2;
+pub const VFS_CAP_U32: u32 = 2;
+pub const VFS_CAP_REVISION: u32 = 50331648;
+pub const _LINUX_CAPABILITY_VERSION: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S: u32 = 1;
+pub const CAP_CHOWN: u32 = 0;
+pub const CAP_DAC_OVERRIDE: u32 = 1;
+pub const CAP_DAC_READ_SEARCH: u32 = 2;
+pub const CAP_FOWNER: u32 = 3;
+pub const CAP_FSETID: u32 = 4;
+pub const CAP_KILL: u32 = 5;
+pub const CAP_SETGID: u32 = 6;
+pub const CAP_SETUID: u32 = 7;
+pub const CAP_SETPCAP: u32 = 8;
+pub const CAP_LINUX_IMMUTABLE: u32 = 9;
+pub const CAP_NET_BIND_SERVICE: u32 = 10;
+pub const CAP_NET_BROADCAST: u32 = 11;
+pub const CAP_NET_ADMIN: u32 = 12;
+pub const CAP_NET_RAW: u32 = 13;
+pub const CAP_IPC_LOCK: u32 = 14;
+pub const CAP_IPC_OWNER: u32 = 15;
+pub const CAP_SYS_MODULE: u32 = 16;
+pub const CAP_SYS_RAWIO: u32 = 17;
+pub const CAP_SYS_CHROOT: u32 = 18;
+pub const CAP_SYS_PTRACE: u32 = 19;
+pub const CAP_SYS_PACCT: u32 = 20;
+pub const CAP_SYS_ADMIN: u32 = 21;
+pub const CAP_SYS_BOOT: u32 = 22;
+pub const CAP_SYS_NICE: u32 = 23;
+pub const CAP_SYS_RESOURCE: u32 = 24;
+pub const CAP_SYS_TIME: u32 = 25;
+pub const CAP_SYS_TTY_CONFIG: u32 = 26;
+pub const CAP_MKNOD: u32 = 27;
+pub const CAP_LEASE: u32 = 28;
+pub const CAP_AUDIT_WRITE: u32 = 29;
+pub const CAP_AUDIT_CONTROL: u32 = 30;
+pub const CAP_SETFCAP: u32 = 31;
+pub const CAP_MAC_OVERRIDE: u32 = 32;
+pub const CAP_MAC_ADMIN: u32 = 33;
+pub const CAP_SYSLOG: u32 = 34;
+pub const CAP_WAKE_ALARM: u32 = 35;
+pub const CAP_BLOCK_SUSPEND: u32 = 36;
+pub const CAP_AUDIT_READ: u32 = 37;
+pub const CAP_PERFMON: u32 = 38;
+pub const CAP_BPF: u32 = 39;
+pub const CAP_CHECKPOINT_RESTORE: u32 = 40;
+pub const CAP_LAST_CAP: u32 = 40;
 pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
@@ -2517,6 +2579,46 @@ pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_header_struct {
+pub version: __u32,
+pub pid: crate::ctypes::c_int,
+}
+pub type cap_user_header_t = *mut __user_cap_header_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_data_struct {
+pub effective: __u32,
+pub permitted: __u32,
+pub inheritable: __u32,
+}
+pub type cap_user_data_t = *mut __user_cap_data_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_cap_data__bindgen_ty_1; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_ns_cap_data__bindgen_ty_1; 2usize],
+pub rootid: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {

--- a/src/x86/general.rs
+++ b/src/x86/general.rs
@@ -170,6 +170,68 @@ pub const AT_EXECFN: u32 = 31;
 pub const AT_MINSIGSTKSZ: u32 = 51;
 pub const __BITS_PER_LONG: u32 = 32;
 pub const __FD_SETSIZE: u32 = 1024;
+pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
+pub const _LINUX_CAPABILITY_VERSION_2: u32 = 537333798;
+pub const _LINUX_CAPABILITY_U32S_2: u32 = 2;
+pub const _LINUX_CAPABILITY_VERSION_3: u32 = 537396514;
+pub const _LINUX_CAPABILITY_U32S_3: u32 = 2;
+pub const VFS_CAP_REVISION_MASK: u32 = 4278190080;
+pub const VFS_CAP_REVISION_SHIFT: u32 = 24;
+pub const VFS_CAP_FLAGS_MASK: i64 = -4278190081;
+pub const VFS_CAP_FLAGS_EFFECTIVE: u32 = 1;
+pub const VFS_CAP_REVISION_1: u32 = 16777216;
+pub const VFS_CAP_U32_1: u32 = 1;
+pub const VFS_CAP_REVISION_2: u32 = 33554432;
+pub const VFS_CAP_U32_2: u32 = 2;
+pub const VFS_CAP_REVISION_3: u32 = 50331648;
+pub const VFS_CAP_U32_3: u32 = 2;
+pub const VFS_CAP_U32: u32 = 2;
+pub const VFS_CAP_REVISION: u32 = 50331648;
+pub const _LINUX_CAPABILITY_VERSION: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S: u32 = 1;
+pub const CAP_CHOWN: u32 = 0;
+pub const CAP_DAC_OVERRIDE: u32 = 1;
+pub const CAP_DAC_READ_SEARCH: u32 = 2;
+pub const CAP_FOWNER: u32 = 3;
+pub const CAP_FSETID: u32 = 4;
+pub const CAP_KILL: u32 = 5;
+pub const CAP_SETGID: u32 = 6;
+pub const CAP_SETUID: u32 = 7;
+pub const CAP_SETPCAP: u32 = 8;
+pub const CAP_LINUX_IMMUTABLE: u32 = 9;
+pub const CAP_NET_BIND_SERVICE: u32 = 10;
+pub const CAP_NET_BROADCAST: u32 = 11;
+pub const CAP_NET_ADMIN: u32 = 12;
+pub const CAP_NET_RAW: u32 = 13;
+pub const CAP_IPC_LOCK: u32 = 14;
+pub const CAP_IPC_OWNER: u32 = 15;
+pub const CAP_SYS_MODULE: u32 = 16;
+pub const CAP_SYS_RAWIO: u32 = 17;
+pub const CAP_SYS_CHROOT: u32 = 18;
+pub const CAP_SYS_PTRACE: u32 = 19;
+pub const CAP_SYS_PACCT: u32 = 20;
+pub const CAP_SYS_ADMIN: u32 = 21;
+pub const CAP_SYS_BOOT: u32 = 22;
+pub const CAP_SYS_NICE: u32 = 23;
+pub const CAP_SYS_RESOURCE: u32 = 24;
+pub const CAP_SYS_TIME: u32 = 25;
+pub const CAP_SYS_TTY_CONFIG: u32 = 26;
+pub const CAP_MKNOD: u32 = 27;
+pub const CAP_LEASE: u32 = 28;
+pub const CAP_AUDIT_WRITE: u32 = 29;
+pub const CAP_AUDIT_CONTROL: u32 = 30;
+pub const CAP_SETFCAP: u32 = 31;
+pub const CAP_MAC_OVERRIDE: u32 = 32;
+pub const CAP_MAC_ADMIN: u32 = 33;
+pub const CAP_SYSLOG: u32 = 34;
+pub const CAP_WAKE_ALARM: u32 = 35;
+pub const CAP_BLOCK_SUSPEND: u32 = 36;
+pub const CAP_AUDIT_READ: u32 = 37;
+pub const CAP_PERFMON: u32 = 38;
+pub const CAP_BPF: u32 = 39;
+pub const CAP_CHECKPOINT_RESTORE: u32 = 40;
+pub const CAP_LAST_CAP: u32 = 40;
 pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
@@ -2600,6 +2662,46 @@ pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_header_struct {
+pub version: __u32,
+pub pid: crate::ctypes::c_int,
+}
+pub type cap_user_header_t = *mut __user_cap_header_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_data_struct {
+pub effective: __u32,
+pub permitted: __u32,
+pub inheritable: __u32,
+}
+pub type cap_user_data_t = *mut __user_cap_data_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_cap_data__bindgen_ty_1; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_ns_cap_data__bindgen_ty_1; 2usize],
+pub rootid: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {

--- a/src/x86_64/general.rs
+++ b/src/x86_64/general.rs
@@ -169,6 +169,68 @@ pub const AT_EXECFN: u32 = 31;
 pub const AT_MINSIGSTKSZ: u32 = 51;
 pub const __BITS_PER_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
+pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
+pub const _LINUX_CAPABILITY_VERSION_2: u32 = 537333798;
+pub const _LINUX_CAPABILITY_U32S_2: u32 = 2;
+pub const _LINUX_CAPABILITY_VERSION_3: u32 = 537396514;
+pub const _LINUX_CAPABILITY_U32S_3: u32 = 2;
+pub const VFS_CAP_REVISION_MASK: u32 = 4278190080;
+pub const VFS_CAP_REVISION_SHIFT: u32 = 24;
+pub const VFS_CAP_FLAGS_MASK: i64 = -4278190081;
+pub const VFS_CAP_FLAGS_EFFECTIVE: u32 = 1;
+pub const VFS_CAP_REVISION_1: u32 = 16777216;
+pub const VFS_CAP_U32_1: u32 = 1;
+pub const VFS_CAP_REVISION_2: u32 = 33554432;
+pub const VFS_CAP_U32_2: u32 = 2;
+pub const VFS_CAP_REVISION_3: u32 = 50331648;
+pub const VFS_CAP_U32_3: u32 = 2;
+pub const VFS_CAP_U32: u32 = 2;
+pub const VFS_CAP_REVISION: u32 = 50331648;
+pub const _LINUX_CAPABILITY_VERSION: u32 = 429392688;
+pub const _LINUX_CAPABILITY_U32S: u32 = 1;
+pub const CAP_CHOWN: u32 = 0;
+pub const CAP_DAC_OVERRIDE: u32 = 1;
+pub const CAP_DAC_READ_SEARCH: u32 = 2;
+pub const CAP_FOWNER: u32 = 3;
+pub const CAP_FSETID: u32 = 4;
+pub const CAP_KILL: u32 = 5;
+pub const CAP_SETGID: u32 = 6;
+pub const CAP_SETUID: u32 = 7;
+pub const CAP_SETPCAP: u32 = 8;
+pub const CAP_LINUX_IMMUTABLE: u32 = 9;
+pub const CAP_NET_BIND_SERVICE: u32 = 10;
+pub const CAP_NET_BROADCAST: u32 = 11;
+pub const CAP_NET_ADMIN: u32 = 12;
+pub const CAP_NET_RAW: u32 = 13;
+pub const CAP_IPC_LOCK: u32 = 14;
+pub const CAP_IPC_OWNER: u32 = 15;
+pub const CAP_SYS_MODULE: u32 = 16;
+pub const CAP_SYS_RAWIO: u32 = 17;
+pub const CAP_SYS_CHROOT: u32 = 18;
+pub const CAP_SYS_PTRACE: u32 = 19;
+pub const CAP_SYS_PACCT: u32 = 20;
+pub const CAP_SYS_ADMIN: u32 = 21;
+pub const CAP_SYS_BOOT: u32 = 22;
+pub const CAP_SYS_NICE: u32 = 23;
+pub const CAP_SYS_RESOURCE: u32 = 24;
+pub const CAP_SYS_TIME: u32 = 25;
+pub const CAP_SYS_TTY_CONFIG: u32 = 26;
+pub const CAP_MKNOD: u32 = 27;
+pub const CAP_LEASE: u32 = 28;
+pub const CAP_AUDIT_WRITE: u32 = 29;
+pub const CAP_AUDIT_CONTROL: u32 = 30;
+pub const CAP_SETFCAP: u32 = 31;
+pub const CAP_MAC_OVERRIDE: u32 = 32;
+pub const CAP_MAC_ADMIN: u32 = 33;
+pub const CAP_SYSLOG: u32 = 34;
+pub const CAP_WAKE_ALARM: u32 = 35;
+pub const CAP_BLOCK_SUSPEND: u32 = 36;
+pub const CAP_AUDIT_READ: u32 = 37;
+pub const CAP_PERFMON: u32 = 38;
+pub const CAP_BPF: u32 = 39;
+pub const CAP_CHECKPOINT_RESTORE: u32 = 40;
+pub const CAP_LAST_CAP: u32 = 40;
 pub const O_ACCMODE: u32 = 3;
 pub const O_RDONLY: u32 = 0;
 pub const O_WRONLY: u32 = 1;
@@ -2525,6 +2587,46 @@ pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_header_struct {
+pub version: __u32,
+pub pid: crate::ctypes::c_int,
+}
+pub type cap_user_header_t = *mut __user_cap_header_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __user_cap_data_struct {
+pub effective: __u32,
+pub permitted: __u32,
+pub inheritable: __u32,
+}
+pub type cap_user_data_t = *mut __user_cap_data_struct;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_cap_data__bindgen_ty_1; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data {
+pub magic_etc: __le32,
+pub data: [vfs_ns_cap_data__bindgen_ty_1; 2usize],
+pub rootid: __le32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vfs_ns_cap_data__bindgen_ty_1 {
+pub permitted: __le32,
+pub inheritable: __le32,
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct f_owner_ex {


### PR DESCRIPTION
This includes the `CAP_*` constants.

Fixes #41.