### PR TITLE
Provide `_NSIG`, `kernel_sigset_t`, and `kernel_sigaction`

### DIFF
--- a/src/aarch64/general.rs
+++ b/src/aarch64/general.rs
@@ -5254,3 +5254,16 @@ pub struct mmsghdr {
 pub msg_hdr: msghdr,
 pub msg_len: crate::ctypes::c_uint,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigset_t {
+pub sig: [crate::ctypes::c_ulong; 1usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigaction {
+pub sa_handler_kernel: __kernel_sighandler_t,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: __sigrestore_t,
+pub sa_mask: kernel_sigset_t,
+}

--- a/src/arm/general.rs
+++ b/src/arm/general.rs
@@ -2614,6 +2614,7 @@ pub const MNT_DETACH: u32 = 2;
 pub const MNT_EXPIRE: u32 = 4;
 pub const UMOUNT_NOFOLLOW: u32 = 8;
 pub const UMOUNT_UNUSED: u32 = 2147483648;
+pub const _NSIG: u32 = 64;
 pub type size_t = crate::ctypes::c_uint;
 pub type ssize_t = crate::ctypes::c_int;
 pub type __s8 = crate::ctypes::c_schar;
@@ -5376,4 +5377,17 @@ pub gid: __u32,
 pub struct mmsghdr {
 pub msg_hdr: msghdr,
 pub msg_len: crate::ctypes::c_uint,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigset_t {
+pub sig: [crate::ctypes::c_ulong; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigaction {
+pub sa_handler_kernel: __kernel_sighandler_t,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: __sigrestore_t,
+pub sa_mask: kernel_sigset_t,
 }

--- a/src/mips/general.rs
+++ b/src/mips/general.rs
@@ -5542,3 +5542,16 @@ pub struct mmsghdr {
 pub msg_hdr: msghdr,
 pub msg_len: crate::ctypes::c_uint,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigset_t {
+pub sig: [crate::ctypes::c_ulong; 4usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigaction {
+pub sa_handler_kernel: __kernel_sighandler_t,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: __sigrestore_t,
+pub sa_mask: kernel_sigset_t,
+}

--- a/src/mips64/general.rs
+++ b/src/mips64/general.rs
@@ -5467,3 +5467,16 @@ pub struct mmsghdr {
 pub msg_hdr: msghdr,
 pub msg_len: crate::ctypes::c_uint,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigset_t {
+pub sig: [crate::ctypes::c_ulong; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigaction {
+pub sa_handler_kernel: __kernel_sighandler_t,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: __sigrestore_t,
+pub sa_mask: kernel_sigset_t,
+}

--- a/src/powerpc/general.rs
+++ b/src/powerpc/general.rs
@@ -5463,3 +5463,16 @@ pub struct mmsghdr {
 pub msg_hdr: msghdr,
 pub msg_len: crate::ctypes::c_uint,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigset_t {
+pub sig: [crate::ctypes::c_ulong; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigaction {
+pub sa_handler_kernel: __kernel_sighandler_t,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: __sigrestore_t,
+pub sa_mask: kernel_sigset_t,
+}

--- a/src/powerpc64/general.rs
+++ b/src/powerpc64/general.rs
@@ -5418,3 +5418,16 @@ pub struct mmsghdr {
 pub msg_hdr: msghdr,
 pub msg_len: crate::ctypes::c_uint,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigset_t {
+pub sig: [crate::ctypes::c_ulong; 1usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigaction {
+pub sa_handler_kernel: __kernel_sighandler_t,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: __sigrestore_t,
+pub sa_mask: kernel_sigset_t,
+}

--- a/src/riscv32/general.rs
+++ b/src/riscv32/general.rs
@@ -5262,3 +5262,16 @@ pub struct mmsghdr {
 pub msg_hdr: msghdr,
 pub msg_len: crate::ctypes::c_uint,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigset_t {
+pub sig: [crate::ctypes::c_ulong; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigaction {
+pub sa_handler_kernel: __kernel_sighandler_t,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: __sigrestore_t,
+pub sa_mask: kernel_sigset_t,
+}

--- a/src/riscv64/general.rs
+++ b/src/riscv64/general.rs
@@ -5255,3 +5255,16 @@ pub struct mmsghdr {
 pub msg_hdr: msghdr,
 pub msg_len: crate::ctypes::c_uint,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigset_t {
+pub sig: [crate::ctypes::c_ulong; 1usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigaction {
+pub sa_handler_kernel: __kernel_sighandler_t,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: __sigrestore_t,
+pub sa_mask: kernel_sigset_t,
+}

--- a/src/s390x/general.rs
+++ b/src/s390x/general.rs
@@ -2572,6 +2572,7 @@ pub const MNT_DETACH: u32 = 2;
 pub const MNT_EXPIRE: u32 = 4;
 pub const UMOUNT_NOFOLLOW: u32 = 8;
 pub const UMOUNT_UNUSED: u32 = 2147483648;
+pub const _NSIG: u32 = 64;
 pub type size_t = crate::ctypes::c_ulong;
 pub type ssize_t = crate::ctypes::c_long;
 pub type __s8 = crate::ctypes::c_schar;
@@ -5294,4 +5295,17 @@ pub gid: __u32,
 pub struct mmsghdr {
 pub msg_hdr: msghdr,
 pub msg_len: crate::ctypes::c_uint,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigset_t {
+pub sig: [crate::ctypes::c_ulong; 1usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigaction {
+pub sa_handler_kernel: __kernel_sighandler_t,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: __sigrestore_t,
+pub sa_mask: kernel_sigset_t,
 }

--- a/src/sparc/general.rs
+++ b/src/sparc/general.rs
@@ -5640,3 +5640,16 @@ pub struct mmsghdr {
 pub msg_hdr: msghdr,
 pub msg_len: crate::ctypes::c_uint,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigset_t {
+pub sig: [crate::ctypes::c_ulong; 1usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigaction {
+pub sa_handler_kernel: __kernel_sighandler_t,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: __sigrestore_t,
+pub sa_mask: kernel_sigset_t,
+}

--- a/src/sparc64/general.rs
+++ b/src/sparc64/general.rs
@@ -5602,3 +5602,16 @@ pub struct mmsghdr {
 pub msg_hdr: msghdr,
 pub msg_len: crate::ctypes::c_uint,
 }
+#[repr(C)]
+#[derive(Debug)]
+pub struct kernel_sigset_t {
+pub sig: __IncompleteArrayField<crate::ctypes::c_ulong>,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct kernel_sigaction {
+pub sa_handler_kernel: __kernel_sighandler_t,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: __sigrestore_t,
+pub sa_mask: kernel_sigset_t,
+}

--- a/src/x32/general.rs
+++ b/src/x32/general.rs
@@ -2561,6 +2561,7 @@ pub const MNT_DETACH: u32 = 2;
 pub const MNT_EXPIRE: u32 = 4;
 pub const UMOUNT_NOFOLLOW: u32 = 8;
 pub const UMOUNT_UNUSED: u32 = 2147483648;
+pub const _NSIG: u32 = 64;
 pub type size_t = crate::ctypes::c_uint;
 pub type ssize_t = crate::ctypes::c_int;
 pub type __s8 = crate::ctypes::c_schar;
@@ -5311,4 +5312,17 @@ pub gid: __u32,
 pub struct mmsghdr {
 pub msg_hdr: msghdr,
 pub msg_len: crate::ctypes::c_uint,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigset_t {
+pub sig: [crate::ctypes::c_ulong; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigaction {
+pub sa_handler_kernel: __kernel_sighandler_t,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: __sigrestore_t,
+pub sa_mask: kernel_sigset_t,
 }

--- a/src/x86/general.rs
+++ b/src/x86/general.rs
@@ -2644,6 +2644,7 @@ pub const MNT_DETACH: u32 = 2;
 pub const MNT_EXPIRE: u32 = 4;
 pub const UMOUNT_NOFOLLOW: u32 = 8;
 pub const UMOUNT_UNUSED: u32 = 2147483648;
+pub const _NSIG: u32 = 64;
 pub type size_t = crate::ctypes::c_uint;
 pub type ssize_t = crate::ctypes::c_int;
 pub type __s8 = crate::ctypes::c_schar;
@@ -5411,4 +5412,17 @@ pub gid: __u32,
 pub struct mmsghdr {
 pub msg_hdr: msghdr,
 pub msg_len: crate::ctypes::c_uint,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigset_t {
+pub sig: [crate::ctypes::c_ulong; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigaction {
+pub sa_handler_kernel: __kernel_sighandler_t,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: __sigrestore_t,
+pub sa_mask: kernel_sigset_t,
 }

--- a/src/x86_64/general.rs
+++ b/src/x86_64/general.rs
@@ -2569,6 +2569,7 @@ pub const MNT_DETACH: u32 = 2;
 pub const MNT_EXPIRE: u32 = 4;
 pub const UMOUNT_NOFOLLOW: u32 = 8;
 pub const UMOUNT_UNUSED: u32 = 2147483648;
+pub const _NSIG: u32 = 64;
 pub type size_t = crate::ctypes::c_ulong;
 pub type ssize_t = crate::ctypes::c_long;
 pub type __s8 = crate::ctypes::c_schar;
@@ -5317,4 +5318,17 @@ pub gid: __u32,
 pub struct mmsghdr {
 pub msg_hdr: msghdr,
 pub msg_len: crate::ctypes::c_uint,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigset_t {
+pub sig: [crate::ctypes::c_ulong; 1usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct kernel_sigaction {
+pub sa_handler_kernel: __kernel_sighandler_t,
+pub sa_flags: crate::ctypes::c_ulong,
+pub sa_restorer: __sigrestore_t,
+pub sa_mask: kernel_sigset_t,
 }


### PR DESCRIPTION
See the comments in gen/modules/general.h for details, but in short, the definitions of `NSIG`, `sigset_t`, and `sigaction` provided by the Linux headers don't match what's used by the `rt_sigaction` system call, so define versions that do.