### PR TITLE
Don't define the `sa_restorer` field on platforms which lack it.

### DIFF
--- a/gen/modules/general.h
+++ b/gen/modules/general.h
@@ -376,6 +376,8 @@ struct kernel_sigaction {
     // Some platforms make `sa_handler` a macro, so use a different name.
     __kernel_sighandler_t sa_handler_kernel;
     unsigned long sa_flags;
+#ifdef SA_RESTORER
     __sigrestore_t sa_restorer;
+#endif
     kernel_sigset_t sa_mask;
 };

--- a/src/mips/general.rs
+++ b/src/mips/general.rs
@@ -5552,6 +5552,5 @@ pub sig: [crate::ctypes::c_ulong; 4usize],
 pub struct kernel_sigaction {
 pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
-pub sa_restorer: __sigrestore_t,
 pub sa_mask: kernel_sigset_t,
 }

--- a/src/mips64/general.rs
+++ b/src/mips64/general.rs
@@ -5477,6 +5477,5 @@ pub sig: [crate::ctypes::c_ulong; 2usize],
 pub struct kernel_sigaction {
 pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
-pub sa_restorer: __sigrestore_t,
 pub sa_mask: kernel_sigset_t,
 }

--- a/src/riscv32/general.rs
+++ b/src/riscv32/general.rs
@@ -5272,6 +5272,5 @@ pub sig: [crate::ctypes::c_ulong; 2usize],
 pub struct kernel_sigaction {
 pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
-pub sa_restorer: __sigrestore_t,
 pub sa_mask: kernel_sigset_t,
 }

--- a/src/riscv64/general.rs
+++ b/src/riscv64/general.rs
@@ -5265,6 +5265,5 @@ pub sig: [crate::ctypes::c_ulong; 1usize],
 pub struct kernel_sigaction {
 pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
-pub sa_restorer: __sigrestore_t,
 pub sa_mask: kernel_sigset_t,
 }

--- a/src/sparc/general.rs
+++ b/src/sparc/general.rs
@@ -5650,6 +5650,5 @@ pub sig: [crate::ctypes::c_ulong; 1usize],
 pub struct kernel_sigaction {
 pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
-pub sa_restorer: __sigrestore_t,
 pub sa_mask: kernel_sigset_t,
 }

--- a/src/sparc64/general.rs
+++ b/src/sparc64/general.rs
@@ -5612,6 +5612,5 @@ pub sig: __IncompleteArrayField<crate::ctypes::c_ulong>,
 pub struct kernel_sigaction {
 pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
-pub sa_restorer: __sigrestore_t,
 pub sa_mask: kernel_sigset_t,
 }


### PR DESCRIPTION
riscv and others don't define `SA_RESTORER` and don't have a `sa_restorer` field.