### PR TITLE
Add padding to `sigaction` for non-`SA_RESTORER` platforms.

### DIFF
--- a/gen/modules/general.h
+++ b/gen/modules/general.h
@@ -380,4 +380,7 @@ struct kernel_sigaction {
     __sigrestore_t sa_restorer;
 #endif
     kernel_sigset_t sa_mask;
+#ifndef SA_RESTORER
+    void *padding;
+#endif
 };

--- a/src/mips/general.rs
+++ b/src/mips/general.rs
@@ -5553,4 +5553,5 @@ pub struct kernel_sigaction {
 pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
+pub padding: *mut crate::ctypes::c_void,
 }

--- a/src/mips64/general.rs
+++ b/src/mips64/general.rs
@@ -5478,4 +5478,5 @@ pub struct kernel_sigaction {
 pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
+pub padding: *mut crate::ctypes::c_void,
 }

--- a/src/riscv32/general.rs
+++ b/src/riscv32/general.rs
@@ -5273,4 +5273,5 @@ pub struct kernel_sigaction {
 pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
+pub padding: *mut crate::ctypes::c_void,
 }

--- a/src/riscv64/general.rs
+++ b/src/riscv64/general.rs
@@ -5266,4 +5266,5 @@ pub struct kernel_sigaction {
 pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
+pub padding: *mut crate::ctypes::c_void,
 }

--- a/src/sparc/general.rs
+++ b/src/sparc/general.rs
@@ -5651,4 +5651,5 @@ pub struct kernel_sigaction {
 pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
+pub padding: *mut crate::ctypes::c_void,
 }

--- a/src/sparc64/general.rs
+++ b/src/sparc64/general.rs
@@ -5613,4 +5613,5 @@ pub struct kernel_sigaction {
 pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
+pub padding: *mut crate::ctypes::c_void,
 }


### PR DESCRIPTION
When `SA_RESTORER` isn't defined, `sigaction` has a padding field at the end.