### PR TITLE
Enable the `size_t_is_usize` option in bindgen.

### DIFF
--- a/gen/src/main.rs
+++ b/gen/src/main.rs
@@ -336,7 +336,6 @@ fn run_bindgen(
         })
         .array_pointers_in_arguments(true)
         .derive_debug(true)
-        .size_t_is_usize(false)
         .clang_arg(&format!("--target={}", clang_target))
         .clang_arg("-DBITS_PER_LONG=(__SIZEOF_LONG__*__CHAR_BIT__)")
         .clang_arg("-nostdinc")

--- a/src/aarch64/general.rs
+++ b/src/aarch64/general.rs
@@ -2539,8 +2539,6 @@ pub const MNT_DETACH: u32 = 2;
 pub const MNT_EXPIRE: u32 = 4;
 pub const UMOUNT_NOFOLLOW: u32 = 8;
 pub const UMOUNT_UNUSED: u32 = 2147483648;
-pub type size_t = crate::ctypes::c_ulong;
-pub type ssize_t = crate::ctypes::c_long;
 pub type __s8 = crate::ctypes::c_schar;
 pub type __u8 = crate::ctypes::c_uchar;
 pub type __s16 = crate::ctypes::c_short;
@@ -5252,15 +5250,15 @@ pub struct msghdr {
 pub msg_name: *mut crate::ctypes::c_void,
 pub msg_namelen: crate::ctypes::c_int,
 pub msg_iov: *mut iovec,
-pub msg_iovlen: size_t,
+pub msg_iovlen: usize,
 pub msg_control: *mut crate::ctypes::c_void,
-pub msg_controllen: size_t,
+pub msg_controllen: usize,
 pub msg_flags: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cmsghdr {
-pub cmsg_len: size_t,
+pub cmsg_len: usize,
 pub cmsg_level: crate::ctypes::c_int,
 pub cmsg_type: crate::ctypes::c_int,
 }

--- a/src/aarch64/netlink.rs
+++ b/src/aarch64/netlink.rs
@@ -247,8 +247,6 @@ pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
 pub const RTEXT_FILTER_MST: u32 = 128;
-pub type size_t = crate::ctypes::c_ulong;
-pub type ssize_t = crate::ctypes::c_long;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/src/arm/general.rs
+++ b/src/arm/general.rs
@@ -2626,8 +2626,6 @@ pub const MNT_EXPIRE: u32 = 4;
 pub const UMOUNT_NOFOLLOW: u32 = 8;
 pub const UMOUNT_UNUSED: u32 = 2147483648;
 pub const _NSIG: u32 = 64;
-pub type size_t = crate::ctypes::c_uint;
-pub type ssize_t = crate::ctypes::c_int;
 pub type __s8 = crate::ctypes::c_schar;
 pub type __u8 = crate::ctypes::c_uchar;
 pub type __s16 = crate::ctypes::c_short;
@@ -5376,15 +5374,15 @@ pub struct msghdr {
 pub msg_name: *mut crate::ctypes::c_void,
 pub msg_namelen: crate::ctypes::c_int,
 pub msg_iov: *mut iovec,
-pub msg_iovlen: size_t,
+pub msg_iovlen: usize,
 pub msg_control: *mut crate::ctypes::c_void,
-pub msg_controllen: size_t,
+pub msg_controllen: usize,
 pub msg_flags: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cmsghdr {
-pub cmsg_len: size_t,
+pub cmsg_len: usize,
 pub cmsg_level: crate::ctypes::c_int,
 pub cmsg_type: crate::ctypes::c_int,
 }

--- a/src/arm/netlink.rs
+++ b/src/arm/netlink.rs
@@ -247,8 +247,6 @@ pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
 pub const RTEXT_FILTER_MST: u32 = 128;
-pub type size_t = crate::ctypes::c_uint;
-pub type ssize_t = crate::ctypes::c_int;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/src/mips/general.rs
+++ b/src/mips/general.rs
@@ -2788,8 +2788,6 @@ pub const MNT_DETACH: u32 = 2;
 pub const MNT_EXPIRE: u32 = 4;
 pub const UMOUNT_NOFOLLOW: u32 = 8;
 pub const UMOUNT_UNUSED: u32 = 2147483648;
-pub type size_t = crate::ctypes::c_uint;
-pub type ssize_t = crate::ctypes::c_int;
 pub type __s8 = crate::ctypes::c_schar;
 pub type __u8 = crate::ctypes::c_uchar;
 pub type __s16 = crate::ctypes::c_short;
@@ -5540,15 +5538,15 @@ pub struct msghdr {
 pub msg_name: *mut crate::ctypes::c_void,
 pub msg_namelen: crate::ctypes::c_int,
 pub msg_iov: *mut iovec,
-pub msg_iovlen: size_t,
+pub msg_iovlen: usize,
 pub msg_control: *mut crate::ctypes::c_void,
-pub msg_controllen: size_t,
+pub msg_controllen: usize,
 pub msg_flags: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cmsghdr {
-pub cmsg_len: size_t,
+pub cmsg_len: usize,
 pub cmsg_level: crate::ctypes::c_int,
 pub cmsg_type: crate::ctypes::c_int,
 }

--- a/src/mips/netlink.rs
+++ b/src/mips/netlink.rs
@@ -256,8 +256,6 @@ pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
 pub const RTEXT_FILTER_MST: u32 = 128;
-pub type size_t = crate::ctypes::c_uint;
-pub type ssize_t = crate::ctypes::c_int;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/src/mips64/general.rs
+++ b/src/mips64/general.rs
@@ -2723,8 +2723,6 @@ pub const MNT_DETACH: u32 = 2;
 pub const MNT_EXPIRE: u32 = 4;
 pub const UMOUNT_NOFOLLOW: u32 = 8;
 pub const UMOUNT_UNUSED: u32 = 2147483648;
-pub type size_t = crate::ctypes::c_ulong;
-pub type ssize_t = crate::ctypes::c_long;
 pub type __s8 = crate::ctypes::c_schar;
 pub type __u8 = crate::ctypes::c_uchar;
 pub type __s16 = crate::ctypes::c_short;
@@ -5465,15 +5463,15 @@ pub struct msghdr {
 pub msg_name: *mut crate::ctypes::c_void,
 pub msg_namelen: crate::ctypes::c_int,
 pub msg_iov: *mut iovec,
-pub msg_iovlen: size_t,
+pub msg_iovlen: usize,
 pub msg_control: *mut crate::ctypes::c_void,
-pub msg_controllen: size_t,
+pub msg_controllen: usize,
 pub msg_flags: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cmsghdr {
-pub cmsg_len: size_t,
+pub cmsg_len: usize,
 pub cmsg_level: crate::ctypes::c_int,
 pub cmsg_type: crate::ctypes::c_int,
 }

--- a/src/mips64/netlink.rs
+++ b/src/mips64/netlink.rs
@@ -256,8 +256,6 @@ pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
 pub const RTEXT_FILTER_MST: u32 = 128;
-pub type size_t = crate::ctypes::c_ulong;
-pub type ssize_t = crate::ctypes::c_long;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/src/powerpc/general.rs
+++ b/src/powerpc/general.rs
@@ -2673,8 +2673,6 @@ pub const MNT_DETACH: u32 = 2;
 pub const MNT_EXPIRE: u32 = 4;
 pub const UMOUNT_NOFOLLOW: u32 = 8;
 pub const UMOUNT_UNUSED: u32 = 2147483648;
-pub type size_t = crate::ctypes::c_uint;
-pub type ssize_t = crate::ctypes::c_int;
 pub type __s8 = crate::ctypes::c_schar;
 pub type __u8 = crate::ctypes::c_uchar;
 pub type __s16 = crate::ctypes::c_short;
@@ -5461,15 +5459,15 @@ pub struct msghdr {
 pub msg_name: *mut crate::ctypes::c_void,
 pub msg_namelen: crate::ctypes::c_int,
 pub msg_iov: *mut iovec,
-pub msg_iovlen: size_t,
+pub msg_iovlen: usize,
 pub msg_control: *mut crate::ctypes::c_void,
-pub msg_controllen: size_t,
+pub msg_controllen: usize,
 pub msg_flags: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cmsghdr {
-pub cmsg_len: size_t,
+pub cmsg_len: usize,
 pub cmsg_level: crate::ctypes::c_int,
 pub cmsg_type: crate::ctypes::c_int,
 }

--- a/src/powerpc/netlink.rs
+++ b/src/powerpc/netlink.rs
@@ -247,8 +247,6 @@ pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
 pub const RTEXT_FILTER_MST: u32 = 128;
-pub type size_t = crate::ctypes::c_uint;
-pub type ssize_t = crate::ctypes::c_int;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/src/powerpc64/general.rs
+++ b/src/powerpc64/general.rs
@@ -2648,8 +2648,6 @@ pub const MNT_DETACH: u32 = 2;
 pub const MNT_EXPIRE: u32 = 4;
 pub const UMOUNT_NOFOLLOW: u32 = 8;
 pub const UMOUNT_UNUSED: u32 = 2147483648;
-pub type size_t = crate::ctypes::c_ulong;
-pub type ssize_t = crate::ctypes::c_long;
 pub type __s8 = crate::ctypes::c_schar;
 pub type __u8 = crate::ctypes::c_uchar;
 pub type __s16 = crate::ctypes::c_short;
@@ -5416,15 +5414,15 @@ pub struct msghdr {
 pub msg_name: *mut crate::ctypes::c_void,
 pub msg_namelen: crate::ctypes::c_int,
 pub msg_iov: *mut iovec,
-pub msg_iovlen: size_t,
+pub msg_iovlen: usize,
 pub msg_control: *mut crate::ctypes::c_void,
-pub msg_controllen: size_t,
+pub msg_controllen: usize,
 pub msg_flags: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cmsghdr {
-pub cmsg_len: size_t,
+pub cmsg_len: usize,
 pub cmsg_level: crate::ctypes::c_int,
 pub cmsg_type: crate::ctypes::c_int,
 }

--- a/src/powerpc64/netlink.rs
+++ b/src/powerpc64/netlink.rs
@@ -247,8 +247,6 @@ pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
 pub const RTEXT_FILTER_MST: u32 = 128;
-pub type size_t = crate::ctypes::c_ulong;
-pub type ssize_t = crate::ctypes::c_long;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/src/riscv32/general.rs
+++ b/src/riscv32/general.rs
@@ -2524,8 +2524,6 @@ pub const MNT_DETACH: u32 = 2;
 pub const MNT_EXPIRE: u32 = 4;
 pub const UMOUNT_NOFOLLOW: u32 = 8;
 pub const UMOUNT_UNUSED: u32 = 2147483648;
-pub type size_t = crate::ctypes::c_uint;
-pub type ssize_t = crate::ctypes::c_int;
 pub type __s8 = crate::ctypes::c_schar;
 pub type __u8 = crate::ctypes::c_uchar;
 pub type __s16 = crate::ctypes::c_short;
@@ -5260,15 +5258,15 @@ pub struct msghdr {
 pub msg_name: *mut crate::ctypes::c_void,
 pub msg_namelen: crate::ctypes::c_int,
 pub msg_iov: *mut iovec,
-pub msg_iovlen: size_t,
+pub msg_iovlen: usize,
 pub msg_control: *mut crate::ctypes::c_void,
-pub msg_controllen: size_t,
+pub msg_controllen: usize,
 pub msg_flags: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cmsghdr {
-pub cmsg_len: size_t,
+pub cmsg_len: usize,
 pub cmsg_level: crate::ctypes::c_int,
 pub cmsg_type: crate::ctypes::c_int,
 }

--- a/src/riscv32/netlink.rs
+++ b/src/riscv32/netlink.rs
@@ -246,8 +246,6 @@ pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
 pub const RTEXT_FILTER_MST: u32 = 128;
-pub type size_t = crate::ctypes::c_uint;
-pub type ssize_t = crate::ctypes::c_int;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/src/riscv64/general.rs
+++ b/src/riscv64/general.rs
@@ -2541,8 +2541,6 @@ pub const MNT_DETACH: u32 = 2;
 pub const MNT_EXPIRE: u32 = 4;
 pub const UMOUNT_NOFOLLOW: u32 = 8;
 pub const UMOUNT_UNUSED: u32 = 2147483648;
-pub type size_t = crate::ctypes::c_ulong;
-pub type ssize_t = crate::ctypes::c_long;
 pub type __s8 = crate::ctypes::c_schar;
 pub type __u8 = crate::ctypes::c_uchar;
 pub type __s16 = crate::ctypes::c_short;
@@ -5253,15 +5251,15 @@ pub struct msghdr {
 pub msg_name: *mut crate::ctypes::c_void,
 pub msg_namelen: crate::ctypes::c_int,
 pub msg_iov: *mut iovec,
-pub msg_iovlen: size_t,
+pub msg_iovlen: usize,
 pub msg_control: *mut crate::ctypes::c_void,
-pub msg_controllen: size_t,
+pub msg_controllen: usize,
 pub msg_flags: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cmsghdr {
-pub cmsg_len: size_t,
+pub cmsg_len: usize,
 pub cmsg_level: crate::ctypes::c_int,
 pub cmsg_type: crate::ctypes::c_int,
 }

--- a/src/riscv64/netlink.rs
+++ b/src/riscv64/netlink.rs
@@ -246,8 +246,6 @@ pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
 pub const RTEXT_FILTER_MST: u32 = 128;
-pub type size_t = crate::ctypes::c_ulong;
-pub type ssize_t = crate::ctypes::c_long;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/src/s390x/general.rs
+++ b/src/s390x/general.rs
@@ -2584,8 +2584,6 @@ pub const MNT_EXPIRE: u32 = 4;
 pub const UMOUNT_NOFOLLOW: u32 = 8;
 pub const UMOUNT_UNUSED: u32 = 2147483648;
 pub const _NSIG: u32 = 64;
-pub type size_t = crate::ctypes::c_ulong;
-pub type ssize_t = crate::ctypes::c_long;
 pub type __s8 = crate::ctypes::c_schar;
 pub type __u8 = crate::ctypes::c_uchar;
 pub type __s16 = crate::ctypes::c_short;
@@ -5306,15 +5304,15 @@ pub struct msghdr {
 pub msg_name: *mut crate::ctypes::c_void,
 pub msg_namelen: crate::ctypes::c_int,
 pub msg_iov: *mut iovec,
-pub msg_iovlen: size_t,
+pub msg_iovlen: usize,
 pub msg_control: *mut crate::ctypes::c_void,
-pub msg_controllen: size_t,
+pub msg_controllen: usize,
 pub msg_flags: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cmsghdr {
-pub cmsg_len: size_t,
+pub cmsg_len: usize,
 pub cmsg_level: crate::ctypes::c_int,
 pub cmsg_type: crate::ctypes::c_int,
 }

--- a/src/s390x/netlink.rs
+++ b/src/s390x/netlink.rs
@@ -247,8 +247,6 @@ pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
 pub const RTEXT_FILTER_MST: u32 = 128;
-pub type size_t = crate::ctypes::c_ulong;
-pub type ssize_t = crate::ctypes::c_long;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/src/sparc/general.rs
+++ b/src/sparc/general.rs
@@ -2888,8 +2888,6 @@ pub const MNT_DETACH: u32 = 2;
 pub const MNT_EXPIRE: u32 = 4;
 pub const UMOUNT_NOFOLLOW: u32 = 8;
 pub const UMOUNT_UNUSED: u32 = 2147483648;
-pub type size_t = crate::ctypes::c_uint;
-pub type ssize_t = crate::ctypes::c_int;
 pub type __s8 = crate::ctypes::c_schar;
 pub type __u8 = crate::ctypes::c_uchar;
 pub type __s16 = crate::ctypes::c_short;
@@ -5638,15 +5636,15 @@ pub struct msghdr {
 pub msg_name: *mut crate::ctypes::c_void,
 pub msg_namelen: crate::ctypes::c_int,
 pub msg_iov: *mut iovec,
-pub msg_iovlen: size_t,
+pub msg_iovlen: usize,
 pub msg_control: *mut crate::ctypes::c_void,
-pub msg_controllen: size_t,
+pub msg_controllen: usize,
 pub msg_flags: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cmsghdr {
-pub cmsg_len: size_t,
+pub cmsg_len: usize,
 pub cmsg_level: crate::ctypes::c_int,
 pub cmsg_type: crate::ctypes::c_int,
 }

--- a/src/sparc/netlink.rs
+++ b/src/sparc/netlink.rs
@@ -247,8 +247,6 @@ pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
 pub const RTEXT_FILTER_MST: u32 = 128;
-pub type size_t = crate::ctypes::c_uint;
-pub type ssize_t = crate::ctypes::c_int;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/src/sparc64/general.rs
+++ b/src/sparc64/general.rs
@@ -2855,8 +2855,6 @@ pub const MNT_DETACH: u32 = 2;
 pub const MNT_EXPIRE: u32 = 4;
 pub const UMOUNT_NOFOLLOW: u32 = 8;
 pub const UMOUNT_UNUSED: u32 = 2147483648;
-pub type size_t = crate::ctypes::c_ulong;
-pub type ssize_t = crate::ctypes::c_long;
 pub type __s8 = crate::ctypes::c_schar;
 pub type __u8 = crate::ctypes::c_uchar;
 pub type __s16 = crate::ctypes::c_short;
@@ -5600,15 +5598,15 @@ pub struct msghdr {
 pub msg_name: *mut crate::ctypes::c_void,
 pub msg_namelen: crate::ctypes::c_int,
 pub msg_iov: *mut iovec,
-pub msg_iovlen: size_t,
+pub msg_iovlen: usize,
 pub msg_control: *mut crate::ctypes::c_void,
-pub msg_controllen: size_t,
+pub msg_controllen: usize,
 pub msg_flags: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cmsghdr {
-pub cmsg_len: size_t,
+pub cmsg_len: usize,
 pub cmsg_level: crate::ctypes::c_int,
 pub cmsg_type: crate::ctypes::c_int,
 }

--- a/src/sparc64/netlink.rs
+++ b/src/sparc64/netlink.rs
@@ -247,8 +247,6 @@ pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
 pub const RTEXT_FILTER_MST: u32 = 128;
-pub type size_t = crate::ctypes::c_ulong;
-pub type ssize_t = crate::ctypes::c_long;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/src/x32/general.rs
+++ b/src/x32/general.rs
@@ -2573,8 +2573,6 @@ pub const MNT_EXPIRE: u32 = 4;
 pub const UMOUNT_NOFOLLOW: u32 = 8;
 pub const UMOUNT_UNUSED: u32 = 2147483648;
 pub const _NSIG: u32 = 64;
-pub type size_t = crate::ctypes::c_uint;
-pub type ssize_t = crate::ctypes::c_int;
 pub type __s8 = crate::ctypes::c_schar;
 pub type __u8 = crate::ctypes::c_uchar;
 pub type __s16 = crate::ctypes::c_short;
@@ -5311,15 +5309,15 @@ pub struct msghdr {
 pub msg_name: *mut crate::ctypes::c_void,
 pub msg_namelen: crate::ctypes::c_int,
 pub msg_iov: *mut iovec,
-pub msg_iovlen: size_t,
+pub msg_iovlen: usize,
 pub msg_control: *mut crate::ctypes::c_void,
-pub msg_controllen: size_t,
+pub msg_controllen: usize,
 pub msg_flags: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cmsghdr {
-pub cmsg_len: size_t,
+pub cmsg_len: usize,
 pub cmsg_level: crate::ctypes::c_int,
 pub cmsg_type: crate::ctypes::c_int,
 }

--- a/src/x32/netlink.rs
+++ b/src/x32/netlink.rs
@@ -247,8 +247,6 @@ pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
 pub const RTEXT_FILTER_MST: u32 = 128;
-pub type size_t = crate::ctypes::c_uint;
-pub type ssize_t = crate::ctypes::c_int;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/src/x86/general.rs
+++ b/src/x86/general.rs
@@ -2656,8 +2656,6 @@ pub const MNT_EXPIRE: u32 = 4;
 pub const UMOUNT_NOFOLLOW: u32 = 8;
 pub const UMOUNT_UNUSED: u32 = 2147483648;
 pub const _NSIG: u32 = 64;
-pub type size_t = crate::ctypes::c_uint;
-pub type ssize_t = crate::ctypes::c_int;
 pub type __s8 = crate::ctypes::c_schar;
 pub type __u8 = crate::ctypes::c_uchar;
 pub type __s16 = crate::ctypes::c_short;
@@ -5411,15 +5409,15 @@ pub struct msghdr {
 pub msg_name: *mut crate::ctypes::c_void,
 pub msg_namelen: crate::ctypes::c_int,
 pub msg_iov: *mut iovec,
-pub msg_iovlen: size_t,
+pub msg_iovlen: usize,
 pub msg_control: *mut crate::ctypes::c_void,
-pub msg_controllen: size_t,
+pub msg_controllen: usize,
 pub msg_flags: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cmsghdr {
-pub cmsg_len: size_t,
+pub cmsg_len: usize,
 pub cmsg_level: crate::ctypes::c_int,
 pub cmsg_type: crate::ctypes::c_int,
 }

--- a/src/x86/netlink.rs
+++ b/src/x86/netlink.rs
@@ -247,8 +247,6 @@ pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
 pub const RTEXT_FILTER_MST: u32 = 128;
-pub type size_t = crate::ctypes::c_uint;
-pub type ssize_t = crate::ctypes::c_int;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/src/x86_64/general.rs
+++ b/src/x86_64/general.rs
@@ -2581,8 +2581,6 @@ pub const MNT_EXPIRE: u32 = 4;
 pub const UMOUNT_NOFOLLOW: u32 = 8;
 pub const UMOUNT_UNUSED: u32 = 2147483648;
 pub const _NSIG: u32 = 64;
-pub type size_t = crate::ctypes::c_ulong;
-pub type ssize_t = crate::ctypes::c_long;
 pub type __s8 = crate::ctypes::c_schar;
 pub type __u8 = crate::ctypes::c_uchar;
 pub type __s16 = crate::ctypes::c_short;
@@ -5317,15 +5315,15 @@ pub struct msghdr {
 pub msg_name: *mut crate::ctypes::c_void,
 pub msg_namelen: crate::ctypes::c_int,
 pub msg_iov: *mut iovec,
-pub msg_iovlen: size_t,
+pub msg_iovlen: usize,
 pub msg_control: *mut crate::ctypes::c_void,
-pub msg_controllen: size_t,
+pub msg_controllen: usize,
 pub msg_flags: crate::ctypes::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cmsghdr {
-pub cmsg_len: size_t,
+pub cmsg_len: usize,
 pub cmsg_level: crate::ctypes::c_int,
 pub cmsg_type: crate::ctypes::c_int,
 }

--- a/src/x86_64/netlink.rs
+++ b/src/x86_64/netlink.rs
@@ -247,8 +247,6 @@ pub const RTEXT_FILTER_MRP: u32 = 16;
 pub const RTEXT_FILTER_CFM_CONFIG: u32 = 32;
 pub const RTEXT_FILTER_CFM_STATUS: u32 = 64;
 pub const RTEXT_FILTER_MST: u32 = 128;
-pub type size_t = crate::ctypes::c_ulong;
-pub type ssize_t = crate::ctypes::c_long;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Copy, Clone)]


### PR DESCRIPTION
This eliminates the `size_t` and `ssize_t` types, and uses `usize` and `isize` in their place. This will reduce the amount of casting needed when working with the bindings.