### PR TITLE
Update the MSRV to Rust 1.63.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, nightly, 1.48]
+        rust: [stable, nightly, 1.63]
 
     env:
       RUSTFLAGS: -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ description = "Generated bindings for Linux's userspace API"
 documentation = "https://docs.rs/linux-raw-sys"
 license = "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
 repository = "https://github.com/sunfishcode/linux-raw-sys"
-edition = "2018"
+edition = "2021"
 keywords = ["linux", "uapi", "ffi"]
 categories = ["external-ffi-bindings"]
 exclude = ["/gen", "/.*"]
-rust-version = "1.48"
+rust-version = "1.63"
 
 [dependencies]
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ exported by Linux's headers but nonetheless needed by userspace.
 # Minimum Supported Rust Version (MSRV)
 
 This crate currently works on the version of [Rust on Debian stable], which is
-currently Rust 1.48. This policy may change in the future, in minor version
+currently Rust 1.63. This policy may change in the future, in minor version
 releases, so users using a fixed version of Rust should pin to a specific
 version of this crate.
 

--- a/gen/Cargo.toml
+++ b/gen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gen"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,8 +90,7 @@ pub mod cmsg_macros {
         (len + c_long_size - 1) & !(c_long_size - 1)
     }
 
-    // TODO: In Rust 1.63 we can make this a `const fn`.
-    pub unsafe fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
+    pub const unsafe fn CMSG_DATA(cmsg: *const cmsghdr) -> *mut c_uchar {
         (cmsg as *mut c_uchar).add(size_of::<cmsghdr>())
     }
 
@@ -103,8 +102,7 @@ pub mod cmsg_macros {
         size_of::<cmsghdr>() as c_uint + len
     }
 
-    // TODO: In Rust 1.63 we can make this a `const fn`.
-    pub unsafe fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
+    pub const unsafe fn CMSG_FIRSTHDR(mhdr: *const msghdr) -> *mut cmsghdr {
         if (*mhdr).msg_controllen < size_of::<cmsghdr>() as _ {
             return ptr::null_mut();
         }
@@ -178,9 +176,8 @@ pub mod signal_macros {
     /// `SIG_IGN` value into a function pointer in a `const` initializer, so
     /// we make it a function instead.
     ///
-    // TODO: In Rust 1.56 we can make this a `const fn`.
     #[inline]
-    pub fn sig_ign() -> super::general::__kernel_sighandler_t {
+    pub const fn sig_ign() -> super::general::__kernel_sighandler_t {
         // Safety: This creates an invalid pointer, but the pointer type
         // includes `unsafe`, which covers the safety of calling it.
         Some(unsafe {


### PR DESCRIPTION
This allows us to make a few more functions `const`.