### PR TITLE
Make `a_type` and `a_val` public fields.

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -247,10 +247,10 @@ pub const R_RELATIVE: u32 = 23; // `R_ARM_RELATIVE`
 #[repr(C)]
 #[derive(Clone)]
 pub struct Elf_auxv_t {
-    a_type: usize,
+    pub a_type: usize,
 
     // Some of the values in the auxv array are pointers, so we make `a_val` a
     // pointer, in order to preserve their provenance. For the values which are
     // integers, we cast this to `usize`.
-    a_val: *mut crate::ctypes::c_void,
+    pub a_val: *mut crate::ctypes::c_void,
 }


### PR DESCRIPTION
Following up on #78, make the fields of `Elf_auxv_t` public.