### PR TITLE
Arrange for `net::iovec` to have a full definition.

### DIFF
--- a/gen/modules/net.h
+++ b/gen/modules/net.h
@@ -12,6 +12,7 @@
 #include <linux/net.h>
 #include <linux/socket.h>
 #include <linux/tcp.h>
+#include <linux/uio.h>
 #include <linux/un.h>
 #include <linux/netfilter_ipv6/ip6_tables.h>
 #include <linux/netfilter_ipv4.h>

--- a/src/aarch64/net.rs
+++ b/src/aarch64/net.rs
@@ -467,6 +467,12 @@ pub reserved: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct iovec {
+pub iov_base: *mut crate::ctypes::c_void,
+pub iov_len: __kernel_size_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
 pub sun_path: [crate::ctypes::c_char; 108usize],
@@ -770,11 +776,6 @@ pub _address: u8,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct xt_target {
-pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct iovec {
 pub _address: u8,
 }
 pub const _K_SS_MAXSIZE: u32 = 128;
@@ -1198,6 +1199,8 @@ pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
+pub const UIO_FASTIOV: u32 = 8;
+pub const UIO_MAXIOV: u32 = 1024;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
 pub const IFALIASZ: u32 = 256;

--- a/src/arm/net.rs
+++ b/src/arm/net.rs
@@ -465,6 +465,12 @@ pub reserved: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct iovec {
+pub iov_base: *mut crate::ctypes::c_void,
+pub iov_len: __kernel_size_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
 pub sun_path: [crate::ctypes::c_char; 108usize],
@@ -768,11 +774,6 @@ pub _address: u8,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct xt_target {
-pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct iovec {
 pub _address: u8,
 }
 pub const _K_SS_MAXSIZE: u32 = 128;
@@ -1188,6 +1189,8 @@ pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
+pub const UIO_FASTIOV: u32 = 8;
+pub const UIO_MAXIOV: u32 = 1024;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
 pub const IFALIASZ: u32 = 256;

--- a/src/csky/net.rs
+++ b/src/csky/net.rs
@@ -465,6 +465,12 @@ pub reserved: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct iovec {
+pub iov_base: *mut crate::ctypes::c_void,
+pub iov_len: __kernel_size_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
 pub sun_path: [crate::ctypes::c_char; 108usize],
@@ -768,11 +774,6 @@ pub _address: u8,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct xt_target {
-pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct iovec {
 pub _address: u8,
 }
 pub const _K_SS_MAXSIZE: u32 = 128;
@@ -1188,6 +1189,8 @@ pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
+pub const UIO_FASTIOV: u32 = 8;
+pub const UIO_MAXIOV: u32 = 1024;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
 pub const IFALIASZ: u32 = 256;

--- a/src/loongarch64/net.rs
+++ b/src/loongarch64/net.rs
@@ -467,6 +467,12 @@ pub reserved: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct iovec {
+pub iov_base: *mut crate::ctypes::c_void,
+pub iov_len: __kernel_size_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
 pub sun_path: [crate::ctypes::c_char; 108usize],
@@ -770,11 +776,6 @@ pub _address: u8,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct xt_target {
-pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct iovec {
 pub _address: u8,
 }
 pub const _K_SS_MAXSIZE: u32 = 128;
@@ -1198,6 +1199,8 @@ pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
+pub const UIO_FASTIOV: u32 = 8;
+pub const UIO_MAXIOV: u32 = 1024;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
 pub const IFALIASZ: u32 = 256;

--- a/src/mips/net.rs
+++ b/src/mips/net.rs
@@ -465,6 +465,12 @@ pub reserved: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct iovec {
+pub iov_base: *mut crate::ctypes::c_void,
+pub iov_len: __kernel_size_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
 pub sun_path: [crate::ctypes::c_char; 108usize],
@@ -768,11 +774,6 @@ pub _address: u8,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct xt_target {
-pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct iovec {
 pub _address: u8,
 }
 pub const _MIPS_ISA_MIPS1: u32 = 1;
@@ -1219,6 +1220,8 @@ pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
+pub const UIO_FASTIOV: u32 = 8;
+pub const UIO_MAXIOV: u32 = 1024;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
 pub const IFALIASZ: u32 = 256;

--- a/src/mips32r6/net.rs
+++ b/src/mips32r6/net.rs
@@ -465,6 +465,12 @@ pub reserved: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct iovec {
+pub iov_base: *mut crate::ctypes::c_void,
+pub iov_len: __kernel_size_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
 pub sun_path: [crate::ctypes::c_char; 108usize],
@@ -768,11 +774,6 @@ pub _address: u8,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct xt_target {
-pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct iovec {
 pub _address: u8,
 }
 pub const _MIPS_ISA_MIPS1: u32 = 1;
@@ -1219,6 +1220,8 @@ pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
+pub const UIO_FASTIOV: u32 = 8;
+pub const UIO_MAXIOV: u32 = 1024;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
 pub const IFALIASZ: u32 = 256;

--- a/src/mips64/net.rs
+++ b/src/mips64/net.rs
@@ -467,6 +467,12 @@ pub reserved: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct iovec {
+pub iov_base: *mut crate::ctypes::c_void,
+pub iov_len: __kernel_size_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
 pub sun_path: [crate::ctypes::c_char; 108usize],
@@ -770,11 +776,6 @@ pub _address: u8,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct xt_target {
-pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct iovec {
 pub _address: u8,
 }
 pub const _MIPS_ISA_MIPS1: u32 = 1;
@@ -1229,6 +1230,8 @@ pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
+pub const UIO_FASTIOV: u32 = 8;
+pub const UIO_MAXIOV: u32 = 1024;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
 pub const IFALIASZ: u32 = 256;

--- a/src/mips64r6/net.rs
+++ b/src/mips64r6/net.rs
@@ -467,6 +467,12 @@ pub reserved: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct iovec {
+pub iov_base: *mut crate::ctypes::c_void,
+pub iov_len: __kernel_size_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
 pub sun_path: [crate::ctypes::c_char; 108usize],
@@ -770,11 +776,6 @@ pub _address: u8,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct xt_target {
-pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct iovec {
 pub _address: u8,
 }
 pub const _MIPS_ISA_MIPS1: u32 = 1;
@@ -1229,6 +1230,8 @@ pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
+pub const UIO_FASTIOV: u32 = 8;
+pub const UIO_MAXIOV: u32 = 1024;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
 pub const IFALIASZ: u32 = 256;

--- a/src/powerpc/net.rs
+++ b/src/powerpc/net.rs
@@ -471,6 +471,12 @@ pub reserved: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct iovec {
+pub iov_base: *mut crate::ctypes::c_void,
+pub iov_len: __kernel_size_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
 pub sun_path: [crate::ctypes::c_char; 108usize],
@@ -774,11 +780,6 @@ pub _address: u8,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct xt_target {
-pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct iovec {
 pub _address: u8,
 }
 pub const _K_SS_MAXSIZE: u32 = 128;
@@ -1194,6 +1195,8 @@ pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
+pub const UIO_FASTIOV: u32 = 8;
+pub const UIO_MAXIOV: u32 = 1024;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
 pub const IFALIASZ: u32 = 256;

--- a/src/powerpc64/net.rs
+++ b/src/powerpc64/net.rs
@@ -473,6 +473,12 @@ pub reserved: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct iovec {
+pub iov_base: *mut crate::ctypes::c_void,
+pub iov_len: __kernel_size_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
 pub sun_path: [crate::ctypes::c_char; 108usize],
@@ -776,11 +782,6 @@ pub _address: u8,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct xt_target {
-pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct iovec {
 pub _address: u8,
 }
 pub const _K_SS_MAXSIZE: u32 = 128;
@@ -1204,6 +1205,8 @@ pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
+pub const UIO_FASTIOV: u32 = 8;
+pub const UIO_MAXIOV: u32 = 1024;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
 pub const IFALIASZ: u32 = 256;

--- a/src/riscv32/net.rs
+++ b/src/riscv32/net.rs
@@ -465,6 +465,12 @@ pub reserved: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct iovec {
+pub iov_base: *mut crate::ctypes::c_void,
+pub iov_len: __kernel_size_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
 pub sun_path: [crate::ctypes::c_char; 108usize],
@@ -768,11 +774,6 @@ pub _address: u8,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct xt_target {
-pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct iovec {
 pub _address: u8,
 }
 pub const _K_SS_MAXSIZE: u32 = 128;
@@ -1188,6 +1189,8 @@ pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
+pub const UIO_FASTIOV: u32 = 8;
+pub const UIO_MAXIOV: u32 = 1024;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
 pub const IFALIASZ: u32 = 256;

--- a/src/riscv64/net.rs
+++ b/src/riscv64/net.rs
@@ -467,6 +467,12 @@ pub reserved: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct iovec {
+pub iov_base: *mut crate::ctypes::c_void,
+pub iov_len: __kernel_size_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
 pub sun_path: [crate::ctypes::c_char; 108usize],
@@ -770,11 +776,6 @@ pub _address: u8,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct xt_target {
-pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct iovec {
 pub _address: u8,
 }
 pub const _K_SS_MAXSIZE: u32 = 128;
@@ -1198,6 +1199,8 @@ pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
+pub const UIO_FASTIOV: u32 = 8;
+pub const UIO_MAXIOV: u32 = 1024;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
 pub const IFALIASZ: u32 = 256;

--- a/src/s390x/net.rs
+++ b/src/s390x/net.rs
@@ -481,6 +481,12 @@ pub reserved: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct iovec {
+pub iov_base: *mut crate::ctypes::c_void,
+pub iov_len: __kernel_size_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
 pub sun_path: [crate::ctypes::c_char; 108usize],
@@ -784,11 +790,6 @@ pub _address: u8,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct xt_target {
-pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct iovec {
 pub _address: u8,
 }
 pub const _K_SS_MAXSIZE: u32 = 128;
@@ -1212,6 +1213,8 @@ pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
+pub const UIO_FASTIOV: u32 = 8;
+pub const UIO_MAXIOV: u32 = 1024;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
 pub const IFALIASZ: u32 = 256;

--- a/src/sparc/net.rs
+++ b/src/sparc/net.rs
@@ -465,6 +465,12 @@ pub reserved: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct iovec {
+pub iov_base: *mut crate::ctypes::c_void,
+pub iov_len: __kernel_size_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
 pub sun_path: [crate::ctypes::c_char; 108usize],
@@ -768,11 +774,6 @@ pub _address: u8,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct xt_target {
-pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct iovec {
 pub _address: u8,
 }
 pub const _K_SS_MAXSIZE: u32 = 128;
@@ -1404,6 +1405,8 @@ pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
+pub const UIO_FASTIOV: u32 = 8;
+pub const UIO_MAXIOV: u32 = 1024;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
 pub const IFALIASZ: u32 = 256;

--- a/src/sparc64/net.rs
+++ b/src/sparc64/net.rs
@@ -473,6 +473,12 @@ pub reserved: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct iovec {
+pub iov_base: *mut crate::ctypes::c_void,
+pub iov_len: __kernel_size_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
 pub sun_path: [crate::ctypes::c_char; 108usize],
@@ -776,11 +782,6 @@ pub _address: u8,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct xt_target {
-pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct iovec {
 pub _address: u8,
 }
 pub const _K_SS_MAXSIZE: u32 = 128;
@@ -1420,6 +1421,8 @@ pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
+pub const UIO_FASTIOV: u32 = 8;
+pub const UIO_MAXIOV: u32 = 1024;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
 pub const IFALIASZ: u32 = 256;

--- a/src/x32/net.rs
+++ b/src/x32/net.rs
@@ -467,6 +467,12 @@ pub reserved: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct iovec {
+pub iov_base: *mut crate::ctypes::c_void,
+pub iov_len: __kernel_size_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
 pub sun_path: [crate::ctypes::c_char; 108usize],
@@ -770,11 +776,6 @@ pub _address: u8,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct xt_target {
-pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct iovec {
 pub _address: u8,
 }
 pub const _K_SS_MAXSIZE: u32 = 128;
@@ -1198,6 +1199,8 @@ pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
+pub const UIO_FASTIOV: u32 = 8;
+pub const UIO_MAXIOV: u32 = 1024;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
 pub const IFALIASZ: u32 = 256;

--- a/src/x86/net.rs
+++ b/src/x86/net.rs
@@ -465,6 +465,12 @@ pub reserved: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct iovec {
+pub iov_base: *mut crate::ctypes::c_void,
+pub iov_len: __kernel_size_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
 pub sun_path: [crate::ctypes::c_char; 108usize],
@@ -768,11 +774,6 @@ pub _address: u8,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct xt_target {
-pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct iovec {
 pub _address: u8,
 }
 pub const _K_SS_MAXSIZE: u32 = 128;
@@ -1188,6 +1189,8 @@ pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
+pub const UIO_FASTIOV: u32 = 8;
+pub const UIO_MAXIOV: u32 = 1024;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
 pub const IFALIASZ: u32 = 256;

--- a/src/x86_64/net.rs
+++ b/src/x86_64/net.rs
@@ -467,6 +467,12 @@ pub reserved: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct iovec {
+pub iov_base: *mut crate::ctypes::c_void,
+pub iov_len: __kernel_size_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_un {
 pub sun_family: __kernel_sa_family_t,
 pub sun_path: [crate::ctypes::c_char; 108usize],
@@ -770,11 +776,6 @@ pub _address: u8,
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct xt_target {
-pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct iovec {
 pub _address: u8,
 }
 pub const _K_SS_MAXSIZE: u32 = 128;
@@ -1198,6 +1199,8 @@ pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
+pub const UIO_FASTIOV: u32 = 8;
+pub const UIO_MAXIOV: u32 = 1024;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
 pub const IFALIASZ: u32 = 256;


### PR DESCRIPTION
Add uio.h to the net module so that the `iovec` type is defined rather than forward-declared, so that we get a useful definition.