### PR TITLE
Fix the definition of `CMSG_NXTHDR`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@ pub mod cmsg_macros {
         }
 
         if next_cmsg.add(1) as usize > max
-            || next_cmsg as usize + CMSG_ALIGN(cmsg_len as _) as usize > max
+            || next_cmsg as usize + CMSG_ALIGN((*next_cmsg).cmsg_len as _) as usize > max
         {
             return ptr::null_mut();
         }


### PR DESCRIPTION
Use the correct `cmsg_len` value when testing for the end of the iteration sequence.