### PR TITLE
Add missing features to docs.rs metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ static_assertions = "1.1.0"
 libc = "0.2.100"
 
 [package.metadata.docs.rs]
-features = ["default", "ioctl", "netlink", "io_uring", "if_ether", "net", "prctl", "elf"]
+features = ["default", "ioctl", "netlink", "io_uring", "if_ether", "net", "prctl", "elf", "xdp", "mempolicy", "system"]
 targets = ["x86_64-unknown-linux-gnu", "i686-unknown-linux-gnu"]
 
 # The rest of this file is auto-generated!


### PR DESCRIPTION
Adds missing features to the docs.rs metadata entry in Cargo.toml.