### PR TITLE
Update to linux 6.8

### DIFF
--- a/gen/src/main.rs
+++ b/gen/src/main.rs
@@ -10,7 +10,7 @@ use std::process::Command;
 use std::{env, fs};
 
 #[allow(unused_doc_comments)]
-const LINUX_VERSION: &str = "v6.5";
+const LINUX_VERSION: &str = "v6.8";
 
 /// Some commonly used features.
 const DEFAULT_FEATURES: &str = "\"general\", \"errno\"";

--- a/src/aarch64/general.rs
+++ b/src/aarch64/general.rs
@@ -183,7 +183,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -238,6 +239,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -296,6 +330,29 @@ pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
 pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -390,36 +447,6 @@ pub it_value: __kernel_old_timeval,
 pub struct __kernel_sock_timeval {
 pub tv_sec: __s64,
 pub tv_usec: __s64,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timespec {
-pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: crate::ctypes::c_long,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timeval {
-pub tv_sec: __kernel_old_time_t,
-pub tv_usec: __kernel_suseconds_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerspec {
-pub it_interval: timespec,
-pub it_value: timespec,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerval {
-pub it_interval: timeval,
-pub it_value: timeval,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timezone {
-pub tz_minuteswest: crate::ctypes::c_int,
-pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -673,6 +700,36 @@ pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct timespec {
+pub tv_sec: __kernel_old_time_t,
+pub tv_nsec: crate::ctypes::c_long,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timeval {
+pub tv_sec: __kernel_old_time_t,
+pub tv_usec: __kernel_suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerspec {
+pub it_interval: timespec,
+pub it_value: timespec,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerval {
+pub it_interval: timeval,
+pub it_value: timeval,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timezone {
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct iovec {
 pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
@@ -766,6 +823,22 @@ pub struct uffdio_continue {
 pub range: uffdio_range,
 pub mode: __u64,
 pub mapped: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_poison {
+pub range: uffdio_range,
+pub mode: __u64,
+pub updated: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_move {
+pub dst: __u64,
+pub src: __u64,
+pub len: __u64,
+pub mode: __u64,
+pub move_: __s64,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -871,9 +944,9 @@ pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 394496;
+pub const LINUX_VERSION_CODE: u32 = 395264;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 5;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_MINSIGSTKSZ: u32 = 51;
@@ -1242,6 +1315,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1313,6 +1394,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const FUTEX_WAIT: u32 = 0;
 pub const FUTEX_WAKE: u32 = 1;
 pub const FUTEX_FD: u32 = 2;
@@ -1343,6 +1434,13 @@ pub const FUTEX_WAIT_BITSET_PRIVATE: u32 = 137;
 pub const FUTEX_WAKE_BITSET_PRIVATE: u32 = 138;
 pub const FUTEX_WAIT_REQUEUE_PI_PRIVATE: u32 = 139;
 pub const FUTEX_CMP_REQUEUE_PI_PRIVATE: u32 = 140;
+pub const FUTEX2_SIZE_U8: u32 = 0;
+pub const FUTEX2_SIZE_U16: u32 = 1;
+pub const FUTEX2_SIZE_U32: u32 = 2;
+pub const FUTEX2_SIZE_U64: u32 = 3;
+pub const FUTEX2_NUMA: u32 = 4;
+pub const FUTEX2_PRIVATE: u32 = 128;
+pub const FUTEX2_SIZE_MASK: u32 = 3;
 pub const FUTEX_32: u32 = 2;
 pub const FUTEX_WAITV_MAX: u32 = 128;
 pub const FUTEX_WAITERS: u32 = 2147483648;
@@ -1601,25 +1699,6 @@ pub const LINUX_REBOOT_CMD_POWER_OFF: u32 = 1126301404;
 pub const LINUX_REBOOT_CMD_RESTART2: u32 = 2712847316;
 pub const LINUX_REBOOT_CMD_SW_SUSPEND: u32 = 3489725666;
 pub const LINUX_REBOOT_CMD_KEXEC: u32 = 1163412803;
-pub const ITIMER_REAL: u32 = 0;
-pub const ITIMER_VIRTUAL: u32 = 1;
-pub const ITIMER_PROF: u32 = 2;
-pub const CLOCK_REALTIME: u32 = 0;
-pub const CLOCK_MONOTONIC: u32 = 1;
-pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
-pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
-pub const CLOCK_MONOTONIC_RAW: u32 = 4;
-pub const CLOCK_REALTIME_COARSE: u32 = 5;
-pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
-pub const CLOCK_BOOTTIME: u32 = 7;
-pub const CLOCK_REALTIME_ALARM: u32 = 8;
-pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
-pub const CLOCK_SGI_CYCLE: u32 = 10;
-pub const CLOCK_TAI: u32 = 11;
-pub const MAX_CLOCKS: u32 = 16;
-pub const CLOCKS_MASK: u32 = 1;
-pub const CLOCKS_MONO: u32 = 1;
-pub const TIMER_ABSTIME: u32 = 1;
 pub const RUSAGE_SELF: u32 = 0;
 pub const RUSAGE_CHILDREN: i32 = -1;
 pub const RUSAGE_BOTH: i32 = -2;
@@ -1802,7 +1881,8 @@ pub const SEGV_ADIDERR: u32 = 6;
 pub const SEGV_ADIPERR: u32 = 7;
 pub const SEGV_MTEAERR: u32 = 8;
 pub const SEGV_MTESERR: u32 = 9;
-pub const NSIGSEGV: u32 = 9;
+pub const SEGV_CPERR: u32 = 10;
+pub const NSIGSEGV: u32 = 10;
 pub const BUS_ADRALN: u32 = 1;
 pub const BUS_ADRERR: u32 = 2;
 pub const BUS_OBJERR: u32 = 3;
@@ -1883,6 +1963,7 @@ pub const STATX_BASIC_STATS: u32 = 2047;
 pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
+pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2060,6 +2141,25 @@ pub const TIOCM_RI: u32 = 128;
 pub const TIOCM_OUT1: u32 = 8192;
 pub const TIOCM_OUT2: u32 = 16384;
 pub const TIOCM_LOOP: u32 = 32768;
+pub const ITIMER_REAL: u32 = 0;
+pub const ITIMER_VIRTUAL: u32 = 1;
+pub const ITIMER_PROF: u32 = 2;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_SGI_CYCLE: u32 = 10;
+pub const CLOCK_TAI: u32 = 11;
+pub const MAX_CLOCKS: u32 = 16;
+pub const CLOCKS_MASK: u32 = 1;
+pub const CLOCKS_MONO: u32 = 1;
+pub const TIMER_ABSTIME: u32 = 1;
 pub const UIO_FASTIOV: u32 = 8;
 pub const UIO_MAXIOV: u32 = 1024;
 pub const __NR_io_setup: u32 = 0;
@@ -2370,7 +2470,17 @@ pub const __NR_process_mrelease: u32 = 448;
 pub const __NR_futex_waitv: u32 = 449;
 pub const __NR_set_mempolicy_home_node: u32 = 450;
 pub const __NR_cachestat: u32 = 451;
-pub const __NR_syscalls: u32 = 452;
+pub const __NR_fchmodat2: u32 = 452;
+pub const __NR_map_shadow_stack: u32 = 453;
+pub const __NR_futex_wake: u32 = 454;
+pub const __NR_futex_wait: u32 = 455;
+pub const __NR_futex_requeue: u32 = 456;
+pub const __NR_statmount: u32 = 457;
+pub const __NR_listmount: u32 = 458;
+pub const __NR_lsm_get_self_attr: u32 = 459;
+pub const __NR_lsm_set_self_attr: u32 = 460;
+pub const __NR_lsm_list_modules: u32 = 461;
+pub const __NR_syscalls: u32 = 462;
 pub const __NR_fcntl: u32 = 25;
 pub const __NR_statfs: u32 = 43;
 pub const __NR_fstatfs: u32 = 44;
@@ -2460,8 +2570,10 @@ pub const _UFFDIO_UNREGISTER: u32 = 1;
 pub const _UFFDIO_WAKE: u32 = 2;
 pub const _UFFDIO_COPY: u32 = 3;
 pub const _UFFDIO_ZEROPAGE: u32 = 4;
+pub const _UFFDIO_MOVE: u32 = 5;
 pub const _UFFDIO_WRITEPROTECT: u32 = 6;
 pub const _UFFDIO_CONTINUE: u32 = 7;
+pub const _UFFDIO_POISON: u32 = 8;
 pub const _UFFDIO_API: u32 = 63;
 pub const UFFDIO: u32 = 170;
 pub const UFFD_EVENT_PAGEFAULT: u32 = 18;
@@ -2486,6 +2598,9 @@ pub const UFFD_FEATURE_MINOR_SHMEM: u32 = 1024;
 pub const UFFD_FEATURE_EXACT_ADDRESS: u32 = 2048;
 pub const UFFD_FEATURE_WP_HUGETLBFS_SHMEM: u32 = 4096;
 pub const UFFD_FEATURE_WP_UNPOPULATED: u32 = 8192;
+pub const UFFD_FEATURE_POISON: u32 = 16384;
+pub const UFFD_FEATURE_WP_ASYNC: u32 = 32768;
+pub const UFFD_FEATURE_MOVE: u32 = 65536;
 pub const UFFD_USER_MODE_ONLY: u32 = 1;
 pub const DT_UNKNOWN: u32 = 0;
 pub const DT_FIFO: u32 = 1;
@@ -2560,6 +2675,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/aarch64/if_arp.rs
+++ b/src/aarch64/if_arp.rs
@@ -52,11 +52,6 @@ pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
@@ -175,6 +170,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -182,23 +178,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -1126,6 +1107,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_4 = _bindgen_ty_4::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_4 = _bindgen_ty_4::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_MASK;
@@ -1194,6 +1176,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_HAIRPIN;
@@ -1241,6 +1225,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_10 = _bindgen_ty_10::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_KIND;
@@ -1302,301 +1287,310 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_19 = _bindgen_ty_19::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_40 = _bindgen_ty_40::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_46 = _bindgen_ty_46::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_DSA_MAX;
-pub const IF_PORT_UNKNOWN: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_UNKNOWN;
-pub const IF_PORT_10BASE2: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASE2;
-pub const IF_PORT_10BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASET;
-pub const IF_PORT_AUI: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_AUI;
-pub const IF_PORT_100BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASET;
-pub const IF_PORT_100BASETX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASETX;
-pub const IF_PORT_100BASEFX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASEFX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_20 = _bindgen_ty_20::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_23 = _bindgen_ty_23::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_47 = _bindgen_ty_47::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__IFLA_DSA_MAX;
+pub const IF_PORT_UNKNOWN: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_UNKNOWN;
+pub const IF_PORT_10BASE2: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASE2;
+pub const IF_PORT_10BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASET;
+pub const IF_PORT_AUI: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_AUI;
+pub const IF_PORT_100BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASET;
+pub const IF_PORT_100BASETX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASETX;
+pub const IF_PORT_100BASEFX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASEFX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1699,6 +1693,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1788,7 +1784,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1884,7 +1881,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1941,7 +1940,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2094,10 +2094,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_20 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_21 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -2113,7 +2141,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -2125,7 +2153,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum _bindgen_ty_23 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -2133,7 +2161,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2166,7 +2194,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2180,7 +2209,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_25 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2210,7 +2247,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2221,7 +2258,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2236,7 +2273,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2249,7 +2286,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2287,7 +2324,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2299,7 +2336,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2315,7 +2352,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2323,7 +2360,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2343,7 +2380,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2351,7 +2388,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2360,7 +2397,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2375,7 +2412,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2383,7 +2420,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2397,7 +2434,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2406,7 +2443,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2424,7 +2461,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2434,14 +2471,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2449,7 +2486,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2463,7 +2500,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2475,7 +2512,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2484,7 +2521,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2493,7 +2530,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2503,7 +2540,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2512,7 +2549,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2522,7 +2559,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2537,7 +2574,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2549,7 +2586,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2565,7 +2602,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2574,7 +2611,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2582,15 +2619,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 IF_PORT_UNKNOWN = 0,
 IF_PORT_10BASE2 = 1,
 IF_PORT_10BASET = 2,
@@ -2673,74 +2710,6 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 impl nlmsgerr_attrs {
 pub const NLMSGERR_ATTR_MAX: nlmsgerr_attrs = nlmsgerr_attrs::NLMSGERR_ATTR_MISS_NEST;
 }
@@ -2755,6 +2724,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/aarch64/if_packet.rs
+++ b/src/aarch64/if_packet.rs
@@ -51,11 +51,6 @@ pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_pkt {
 pub spkt_family: crate::ctypes::c_ushort,
@@ -63,6 +58,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -70,23 +66,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -327,71 +308,3 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}

--- a/src/aarch64/io_uring.rs
+++ b/src/aarch64/io_uring.rs
@@ -79,7 +79,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -134,6 +135,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -195,6 +229,29 @@ pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
 pub tv_nsec: crate::ctypes::c_longlong,
@@ -253,6 +310,12 @@ pub __pad1: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_sqe__bindgen_ty_2__bindgen_ty_1 {
+pub level: __u32,
+pub optname: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_sqe__bindgen_ty_5__bindgen_ty_1 {
 pub addr_len: __u16,
 pub __pad3: [__u16; 1usize],
@@ -260,6 +323,7 @@ pub __pad3: [__u16; 1usize],
 #[repr(C)]
 pub struct io_uring_sqe__bindgen_ty_6 {
 pub __bindgen_anon_1: __BindgenUnionField<io_uring_sqe__bindgen_ty_6__bindgen_ty_1>,
+pub optval: __BindgenUnionField<__u64>,
 pub cmd: __BindgenUnionField<[__u8; 0usize]>,
 pub bindgen_union_field: [u64; 2usize],
 }
@@ -421,6 +485,13 @@ pub resv: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_buf_status {
+pub buf_group: __u32,
+pub head: __u32,
+pub resv: [__u32; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -434,7 +505,9 @@ pub addr: __u64,
 pub fd: __s32,
 pub flags: __u32,
 pub timeout: __kernel_timespec,
-pub pad: [__u64; 4usize],
+pub opcode: __u8,
+pub pad: [__u8; 7usize],
+pub pad2: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -597,6 +670,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -668,6 +749,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const IORING_FILE_INDEX_ALLOC: i32 = -1;
 pub const IORING_SETUP_IOPOLL: u32 = 1;
 pub const IORING_SETUP_SQPOLL: u32 = 2;
@@ -685,8 +776,9 @@ pub const IORING_SETUP_SINGLE_ISSUER: u32 = 4096;
 pub const IORING_SETUP_DEFER_TASKRUN: u32 = 8192;
 pub const IORING_SETUP_NO_MMAP: u32 = 16384;
 pub const IORING_SETUP_REGISTERED_FD_ONLY: u32 = 32768;
+pub const IORING_SETUP_NO_SQARRAY: u32 = 65536;
 pub const IORING_URING_CMD_FIXED: u32 = 1;
-pub const IORING_URING_CMD_POLLED: u32 = 2147483648;
+pub const IORING_URING_CMD_MASK: u32 = 1;
 pub const IORING_FSYNC_DATASYNC: u32 = 1;
 pub const IORING_TIMEOUT_ABS: u32 = 1;
 pub const IORING_TIMEOUT_UPDATE: u32 = 2;
@@ -706,6 +798,8 @@ pub const IORING_ASYNC_CANCEL_ALL: u32 = 1;
 pub const IORING_ASYNC_CANCEL_FD: u32 = 2;
 pub const IORING_ASYNC_CANCEL_ANY: u32 = 4;
 pub const IORING_ASYNC_CANCEL_FD_FIXED: u32 = 8;
+pub const IORING_ASYNC_CANCEL_USERDATA: u32 = 16;
+pub const IORING_ASYNC_CANCEL_OP: u32 = 32;
 pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
@@ -714,6 +808,7 @@ pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
+pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
@@ -786,6 +881,7 @@ pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGIS
 pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
 pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
 pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
+pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
 pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
 pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
 pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
@@ -796,6 +892,10 @@ pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTR
 pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
 pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
 pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
+pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
+pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
+pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
+pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -808,6 +908,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -874,7 +975,13 @@ IORING_OP_SOCKET = 45,
 IORING_OP_URING_CMD = 46,
 IORING_OP_SEND_ZC = 47,
 IORING_OP_SENDMSG_ZC = 48,
-IORING_OP_LAST = 49,
+IORING_OP_READ_MULTISHOT = 49,
+IORING_OP_WAITID = 50,
+IORING_OP_FUTEX_WAIT = 51,
+IORING_OP_FUTEX_WAKE = 52,
+IORING_OP_FUTEX_WAITV = 53,
+IORING_OP_FIXED_FD_INSTALL = 54,
+IORING_OP_LAST = 55,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -919,7 +1026,8 @@ IORING_REGISTER_PBUF_RING = 22,
 IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
-IORING_REGISTER_LAST = 26,
+IORING_REGISTER_PBUF_STATUS = 26,
+IORING_REGISTER_LAST = 27,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
@@ -944,6 +1052,15 @@ IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
 IORING_RESTRICTION_SQE_FLAGS_REQUIRED = 3,
 IORING_RESTRICTION_LAST = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_8 {
+SOCKET_URING_OP_SIOCINQ = 0,
+SOCKET_URING_OP_SIOCOUTQ = 1,
+SOCKET_URING_OP_GETSOCKOPT = 2,
+SOCKET_URING_OP_SETSOCKOPT = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -971,6 +1088,7 @@ pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_1__bindgen_ty_1,
 pub union io_uring_sqe__bindgen_ty_2 {
 pub addr: __u64,
 pub splice_off_in: __u64,
+pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_2__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -994,6 +1112,9 @@ pub hardlink_flags: __u32,
 pub xattr_flags: __u32,
 pub msg_ring_flags: __u32,
 pub uring_cmd_flags: __u32,
+pub waitid_flags: __u32,
+pub futex_flags: __u32,
+pub install_fd_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]
@@ -1006,6 +1127,7 @@ pub buf_group: __u16,
 pub union io_uring_sqe__bindgen_ty_5 {
 pub splice_fd_in: __s32,
 pub file_index: __u32,
+pub optlen: __u32,
 pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]

--- a/src/aarch64/net.rs
+++ b/src/aarch64/net.rs
@@ -429,6 +429,9 @@ pub tcpi_rcv_ooopack: __u32,
 pub tcpi_snd_wnd: __u32,
 pub tcpi_rcv_wnd: __u32,
 pub tcpi_rehash: __u32,
+pub tcpi_total_rto: __u16,
+pub tcpi_total_rto_recoveries: __u16,
+pub tcpi_total_rto_time: __u32,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -448,6 +451,80 @@ pub tcpm_prefixlen: __u8,
 pub tcpm_keylen: __u16,
 pub tcpm_addr: [__be32; 4usize],
 pub tcpm_key: [__u8; 80usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_add {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub key: [__u8; 80usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_del {
+pub addr: __kernel_sockaddr_storage,
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub current_key: __u8,
+pub rnext: __u8,
+pub keyflags: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_info_opt {
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub current_key: __u8,
+pub rnext: __u8,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+pub pkt_key_not_found: __u64,
+pub pkt_ao_required: __u64,
+pub pkt_dropped_icmp: __u64,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_getsockopt {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub key: [__u8; 80usize],
+pub nkeys: __u32,
+pub _bitfield_align_1: [u16; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub prefix: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub ifindex: __s32,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_repair {
+pub snt_isn: __be32,
+pub rcv_isn: __be32,
+pub snd_sne: __u32,
+pub rcv_sne: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1185,6 +1262,11 @@ pub const TCP_ZEROCOPY_RECEIVE: u32 = 35;
 pub const TCP_INQ: u32 = 36;
 pub const TCP_CM_INQ: u32 = 36;
 pub const TCP_TX_DELAY: u32 = 37;
+pub const TCP_AO_ADD_KEY: u32 = 38;
+pub const TCP_AO_DEL_KEY: u32 = 39;
+pub const TCP_AO_INFO: u32 = 40;
+pub const TCP_AO_GET_KEYS: u32 = 41;
+pub const TCP_AO_REPAIR: u32 = 42;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1194,9 +1276,13 @@ pub const TCPI_OPT_WSCALE: u32 = 4;
 pub const TCPI_OPT_ECN: u32 = 8;
 pub const TCPI_OPT_ECN_SEEN: u32 = 16;
 pub const TCPI_OPT_SYN_DATA: u32 = 32;
+pub const TCPI_OPT_USEC_TS: u32 = 64;
 pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
+pub const TCP_AO_MAXKEYLEN: u32 = 80;
+pub const TCP_AO_KEYF_IFINDEX: u32 = 1;
+pub const TCP_AO_KEYF_EXCLUDE_OPT: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
@@ -1561,6 +1647,7 @@ pub const DEVCONF_IOAM6_ID: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID;
 pub const DEVCONF_IOAM6_ID_WIDE: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID_WIDE;
 pub const DEVCONF_NDISC_EVICT_NOCARRIER: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_NDISC_EVICT_NOCARRIER;
 pub const DEVCONF_ACCEPT_UNTRACKED_NA: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_UNTRACKED_NA;
+pub const DEVCONF_ACCEPT_RA_MIN_LFT: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_RA_MIN_LFT;
 pub const DEVCONF_MAX: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_MAX;
 pub const TCP_FLAG_CWR: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_CWR;
 pub const TCP_FLAG_ECE: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_ECE;
@@ -1758,7 +1845,8 @@ DEVCONF_IOAM6_ID = 54,
 DEVCONF_IOAM6_ID_WIDE = 55,
 DEVCONF_NDISC_EVICT_NOCARRIER = 56,
 DEVCONF_ACCEPT_UNTRACKED_NA = 57,
-DEVCONF_MAX = 58,
+DEVCONF_ACCEPT_RA_MIN_LFT = 58,
+DEVCONF_MAX = 59,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2476,6 +2564,289 @@ tcpi_delivery_rate_app_limited as u64
 __bindgen_bitfield_unit.set(9usize, 2u8, {
 let tcpi_fastopen_client_fail: u8 = unsafe { ::core::mem::transmute(tcpi_fastopen_client_fail) };
 tcpi_fastopen_client_fail as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_add {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 30u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 30u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_del {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn del_async(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_del_async(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 29u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 29u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, del_async: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let del_async: u32 = unsafe { ::core::mem::transmute(del_async) };
+del_async as u64
+});
+__bindgen_bitfield_unit.set(3usize, 29u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_info_opt {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn ao_required(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_ao_required(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_counters(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_counters(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn accept_icmps(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_accept_icmps(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(4usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(5usize, 27u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(5usize, 27u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, ao_required: __u32, set_counters: __u32, accept_icmps: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let ao_required: u32 = unsafe { ::core::mem::transmute(ao_required) };
+ao_required as u64
+});
+__bindgen_bitfield_unit.set(3usize, 1u8, {
+let set_counters: u32 = unsafe { ::core::mem::transmute(set_counters) };
+set_counters as u64
+});
+__bindgen_bitfield_unit.set(4usize, 1u8, {
+let accept_icmps: u32 = unsafe { ::core::mem::transmute(accept_icmps) };
+accept_icmps as u64
+});
+__bindgen_bitfield_unit.set(5usize, 27u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_getsockopt {
+#[inline]
+pub fn is_current(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_current(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn is_rnext(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_rnext(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn get_all(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_get_all(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 13u8) as u16) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 13u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(is_current: __u16, is_rnext: __u16, get_all: __u16, reserved: __u16) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let is_current: u16 = unsafe { ::core::mem::transmute(is_current) };
+is_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let is_rnext: u16 = unsafe { ::core::mem::transmute(is_rnext) };
+is_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let get_all: u16 = unsafe { ::core::mem::transmute(get_all) };
+get_all as u64
+});
+__bindgen_bitfield_unit.set(3usize, 13u8, {
+let reserved: u16 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
 });
 __bindgen_bitfield_unit
 }

--- a/src/aarch64/netlink.rs
+++ b/src/aarch64/netlink.rs
@@ -724,7 +724,8 @@ pub const RTAX_FEATURE_ECN: u32 = 1;
 pub const RTAX_FEATURE_SACK: u32 = 2;
 pub const RTAX_FEATURE_TIMESTAMP: u32 = 4;
 pub const RTAX_FEATURE_ALLFRAG: u32 = 8;
-pub const RTAX_FEATURE_MASK: u32 = 15;
+pub const RTAX_FEATURE_TCP_USEC_TS: u32 = 16;
+pub const RTAX_FEATURE_MASK: u32 = 31;
 pub const TCM_IFINDEX_MAGIC_BLOCK: u32 = 4294967295;
 pub const TCA_DUMP_FLAGS_TERSE: u32 = 1;
 pub const RTMGRP_LINK: u32 = 1;
@@ -821,6 +822,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_2 = _bindgen_ty_2::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_2 = _bindgen_ty_2::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_MASK;
@@ -889,6 +891,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_6 = _bindgen_ty_6::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_HAIRPIN;
@@ -936,6 +940,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_KIND;
@@ -997,501 +1002,510 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_17 = _bindgen_ty_17::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_18 = _bindgen_ty_18::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_21 = _bindgen_ty_21::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_44 = _bindgen_ty_44::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_DSA_MAX;
-pub const IFA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFA_UNSPEC;
-pub const IFA_ADDRESS: _bindgen_ty_54 = _bindgen_ty_54::IFA_ADDRESS;
-pub const IFA_LOCAL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LOCAL;
-pub const IFA_LABEL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LABEL;
-pub const IFA_BROADCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_BROADCAST;
-pub const IFA_ANYCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_ANYCAST;
-pub const IFA_CACHEINFO: _bindgen_ty_54 = _bindgen_ty_54::IFA_CACHEINFO;
-pub const IFA_MULTICAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_MULTICAST;
-pub const IFA_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFA_FLAGS;
-pub const IFA_RT_PRIORITY: _bindgen_ty_54 = _bindgen_ty_54::IFA_RT_PRIORITY;
-pub const IFA_TARGET_NETNSID: _bindgen_ty_54 = _bindgen_ty_54::IFA_TARGET_NETNSID;
-pub const IFA_PROTO: _bindgen_ty_54 = _bindgen_ty_54::IFA_PROTO;
-pub const __IFA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFA_MAX;
-pub const NDA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::NDA_UNSPEC;
-pub const NDA_DST: _bindgen_ty_55 = _bindgen_ty_55::NDA_DST;
-pub const NDA_LLADDR: _bindgen_ty_55 = _bindgen_ty_55::NDA_LLADDR;
-pub const NDA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::NDA_CACHEINFO;
-pub const NDA_PROBES: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROBES;
-pub const NDA_VLAN: _bindgen_ty_55 = _bindgen_ty_55::NDA_VLAN;
-pub const NDA_PORT: _bindgen_ty_55 = _bindgen_ty_55::NDA_PORT;
-pub const NDA_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_VNI;
-pub const NDA_IFINDEX: _bindgen_ty_55 = _bindgen_ty_55::NDA_IFINDEX;
-pub const NDA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::NDA_MASTER;
-pub const NDA_LINK_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::NDA_LINK_NETNSID;
-pub const NDA_SRC_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_SRC_VNI;
-pub const NDA_PROTOCOL: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROTOCOL;
-pub const NDA_NH_ID: _bindgen_ty_55 = _bindgen_ty_55::NDA_NH_ID;
-pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_55 = _bindgen_ty_55::NDA_FDB_EXT_ATTRS;
-pub const NDA_FLAGS_EXT: _bindgen_ty_55 = _bindgen_ty_55::NDA_FLAGS_EXT;
-pub const NDA_NDM_STATE_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_STATE_MASK;
-pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_FLAGS_MASK;
-pub const __NDA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__NDA_MAX;
-pub const NDTPA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UNSPEC;
-pub const NDTPA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_IFINDEX;
-pub const NDTPA_REFCNT: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REFCNT;
-pub const NDTPA_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REACHABLE_TIME;
-pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_BASE_REACHABLE_TIME;
-pub const NDTPA_RETRANS_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_RETRANS_TIME;
-pub const NDTPA_GC_STALETIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_GC_STALETIME;
-pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_DELAY_PROBE_TIME;
-pub const NDTPA_QUEUE_LEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LEN;
-pub const NDTPA_APP_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_APP_PROBES;
-pub const NDTPA_UCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UCAST_PROBES;
-pub const NDTPA_MCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_PROBES;
-pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_ANYCAST_DELAY;
-pub const NDTPA_PROXY_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_DELAY;
-pub const NDTPA_PROXY_QLEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_QLEN;
-pub const NDTPA_LOCKTIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_LOCKTIME;
-pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LENBYTES;
-pub const NDTPA_MCAST_REPROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_REPROBES;
-pub const NDTPA_PAD: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PAD;
-pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_INTERVAL_PROBE_TIME_MS;
-pub const __NDTPA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDTPA_MAX;
-pub const NDTA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTA_UNSPEC;
-pub const NDTA_NAME: _bindgen_ty_57 = _bindgen_ty_57::NDTA_NAME;
-pub const NDTA_THRESH1: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH1;
-pub const NDTA_THRESH2: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH2;
-pub const NDTA_THRESH3: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH3;
-pub const NDTA_CONFIG: _bindgen_ty_57 = _bindgen_ty_57::NDTA_CONFIG;
-pub const NDTA_PARMS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PARMS;
-pub const NDTA_STATS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_STATS;
-pub const NDTA_GC_INTERVAL: _bindgen_ty_57 = _bindgen_ty_57::NDTA_GC_INTERVAL;
-pub const NDTA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PAD;
-pub const __NDTA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTA_MAX;
-pub const FDB_NOTIFY_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_BIT;
-pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_INACTIVE_BIT;
-pub const NFEA_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::NFEA_UNSPEC;
-pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_59 = _bindgen_ty_59::NFEA_ACTIVITY_NOTIFY;
-pub const NFEA_DONT_REFRESH: _bindgen_ty_59 = _bindgen_ty_59::NFEA_DONT_REFRESH;
-pub const __NFEA_MAX: _bindgen_ty_59 = _bindgen_ty_59::__NFEA_MAX;
-pub const RTM_BASE: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_NEWLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_DELLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINK;
-pub const RTM_GETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINK;
-pub const RTM_SETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETLINK;
-pub const RTM_NEWADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDR;
-pub const RTM_DELADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDR;
-pub const RTM_GETADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDR;
-pub const RTM_NEWROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWROUTE;
-pub const RTM_DELROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELROUTE;
-pub const RTM_GETROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETROUTE;
-pub const RTM_NEWNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGH;
-pub const RTM_DELNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEIGH;
-pub const RTM_GETNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGH;
-pub const RTM_NEWRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWRULE;
-pub const RTM_DELRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELRULE;
-pub const RTM_GETRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETRULE;
-pub const RTM_NEWQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWQDISC;
-pub const RTM_DELQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELQDISC;
-pub const RTM_GETQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETQDISC;
-pub const RTM_NEWTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTCLASS;
-pub const RTM_DELTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTCLASS;
-pub const RTM_GETTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTCLASS;
-pub const RTM_NEWTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTFILTER;
-pub const RTM_DELTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTFILTER;
-pub const RTM_GETTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTFILTER;
-pub const RTM_NEWACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWACTION;
-pub const RTM_DELACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELACTION;
-pub const RTM_GETACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETACTION;
-pub const RTM_NEWPREFIX: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWPREFIX;
-pub const RTM_GETMULTICAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMULTICAST;
-pub const RTM_GETANYCAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETANYCAST;
-pub const RTM_NEWNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGHTBL;
-pub const RTM_GETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGHTBL;
-pub const RTM_SETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETNEIGHTBL;
-pub const RTM_NEWNDUSEROPT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNDUSEROPT;
-pub const RTM_NEWADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDRLABEL;
-pub const RTM_DELADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDRLABEL;
-pub const RTM_GETADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDRLABEL;
-pub const RTM_GETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETDCB;
-pub const RTM_SETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETDCB;
-pub const RTM_NEWNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNETCONF;
-pub const RTM_DELNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNETCONF;
-pub const RTM_GETNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNETCONF;
-pub const RTM_NEWMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWMDB;
-pub const RTM_DELMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELMDB;
-pub const RTM_GETMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMDB;
-pub const RTM_NEWNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNSID;
-pub const RTM_DELNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNSID;
-pub const RTM_GETNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNSID;
-pub const RTM_NEWSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWSTATS;
-pub const RTM_GETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETSTATS;
-pub const RTM_SETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETSTATS;
-pub const RTM_NEWCACHEREPORT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCACHEREPORT;
-pub const RTM_NEWCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCHAIN;
-pub const RTM_DELCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELCHAIN;
-pub const RTM_GETCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETCHAIN;
-pub const RTM_NEWNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOP;
-pub const RTM_DELNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOP;
-pub const RTM_GETNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOP;
-pub const RTM_NEWLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWLINKPROP;
-pub const RTM_DELLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINKPROP;
-pub const RTM_GETLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINKPROP;
-pub const RTM_NEWVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWVLAN;
-pub const RTM_DELVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELVLAN;
-pub const RTM_GETVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETVLAN;
-pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOPBUCKET;
-pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOPBUCKET;
-pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOPBUCKET;
-pub const RTM_NEWTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTUNNEL;
-pub const RTM_DELTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTUNNEL;
-pub const RTM_GETTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTUNNEL;
-pub const __RTM_MAX: _bindgen_ty_60 = _bindgen_ty_60::__RTM_MAX;
-pub const RTN_UNSPEC: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNSPEC;
-pub const RTN_UNICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNICAST;
-pub const RTN_LOCAL: _bindgen_ty_61 = _bindgen_ty_61::RTN_LOCAL;
-pub const RTN_BROADCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_BROADCAST;
-pub const RTN_ANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_ANYCAST;
-pub const RTN_MULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_MULTICAST;
-pub const RTN_BLACKHOLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_BLACKHOLE;
-pub const RTN_UNREACHABLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNREACHABLE;
-pub const RTN_PROHIBIT: _bindgen_ty_61 = _bindgen_ty_61::RTN_PROHIBIT;
-pub const RTN_THROW: _bindgen_ty_61 = _bindgen_ty_61::RTN_THROW;
-pub const RTN_NAT: _bindgen_ty_61 = _bindgen_ty_61::RTN_NAT;
-pub const RTN_XRESOLVE: _bindgen_ty_61 = _bindgen_ty_61::RTN_XRESOLVE;
-pub const __RTN_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTN_MAX;
-pub const RTAX_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTAX_UNSPEC;
-pub const RTAX_LOCK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_LOCK;
-pub const RTAX_MTU: _bindgen_ty_62 = _bindgen_ty_62::RTAX_MTU;
-pub const RTAX_WINDOW: _bindgen_ty_62 = _bindgen_ty_62::RTAX_WINDOW;
-pub const RTAX_RTT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTT;
-pub const RTAX_RTTVAR: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTTVAR;
-pub const RTAX_SSTHRESH: _bindgen_ty_62 = _bindgen_ty_62::RTAX_SSTHRESH;
-pub const RTAX_CWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CWND;
-pub const RTAX_ADVMSS: _bindgen_ty_62 = _bindgen_ty_62::RTAX_ADVMSS;
-pub const RTAX_REORDERING: _bindgen_ty_62 = _bindgen_ty_62::RTAX_REORDERING;
-pub const RTAX_HOPLIMIT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_HOPLIMIT;
-pub const RTAX_INITCWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITCWND;
-pub const RTAX_FEATURES: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FEATURES;
-pub const RTAX_RTO_MIN: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTO_MIN;
-pub const RTAX_INITRWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITRWND;
-pub const RTAX_QUICKACK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_QUICKACK;
-pub const RTAX_CC_ALGO: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CC_ALGO;
-pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FASTOPEN_NO_COOKIE;
-pub const __RTAX_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTAX_MAX;
-pub const PREFIX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_UNSPEC;
-pub const PREFIX_ADDRESS: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_ADDRESS;
-pub const PREFIX_CACHEINFO: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_CACHEINFO;
-pub const __PREFIX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__PREFIX_MAX;
-pub const TCA_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::TCA_UNSPEC;
-pub const TCA_KIND: _bindgen_ty_64 = _bindgen_ty_64::TCA_KIND;
-pub const TCA_OPTIONS: _bindgen_ty_64 = _bindgen_ty_64::TCA_OPTIONS;
-pub const TCA_STATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS;
-pub const TCA_XSTATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_XSTATS;
-pub const TCA_RATE: _bindgen_ty_64 = _bindgen_ty_64::TCA_RATE;
-pub const TCA_FCNT: _bindgen_ty_64 = _bindgen_ty_64::TCA_FCNT;
-pub const TCA_STATS2: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS2;
-pub const TCA_STAB: _bindgen_ty_64 = _bindgen_ty_64::TCA_STAB;
-pub const TCA_PAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_PAD;
-pub const TCA_DUMP_INVISIBLE: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_INVISIBLE;
-pub const TCA_CHAIN: _bindgen_ty_64 = _bindgen_ty_64::TCA_CHAIN;
-pub const TCA_HW_OFFLOAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_HW_OFFLOAD;
-pub const TCA_INGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_INGRESS_BLOCK;
-pub const TCA_EGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_EGRESS_BLOCK;
-pub const TCA_DUMP_FLAGS: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_FLAGS;
-pub const TCA_EXT_WARN_MSG: _bindgen_ty_64 = _bindgen_ty_64::TCA_EXT_WARN_MSG;
-pub const __TCA_MAX: _bindgen_ty_64 = _bindgen_ty_64::__TCA_MAX;
-pub const NDUSEROPT_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_UNSPEC;
-pub const NDUSEROPT_SRCADDR: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_SRCADDR;
-pub const __NDUSEROPT_MAX: _bindgen_ty_65 = _bindgen_ty_65::__NDUSEROPT_MAX;
-pub const TCA_ROOT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_UNSPEC;
-pub const TCA_ROOT_TAB: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TAB;
-pub const TCA_ROOT_FLAGS: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_FLAGS;
-pub const TCA_ROOT_COUNT: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_COUNT;
-pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TIME_DELTA;
-pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_EXT_WARN_MSG;
-pub const __TCA_ROOT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__TCA_ROOT_MAX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_18 = _bindgen_ty_18::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_39 = _bindgen_ty_39::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_45 = _bindgen_ty_45::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_DSA_MAX;
+pub const IFA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFA_UNSPEC;
+pub const IFA_ADDRESS: _bindgen_ty_55 = _bindgen_ty_55::IFA_ADDRESS;
+pub const IFA_LOCAL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LOCAL;
+pub const IFA_LABEL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LABEL;
+pub const IFA_BROADCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_BROADCAST;
+pub const IFA_ANYCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_ANYCAST;
+pub const IFA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::IFA_CACHEINFO;
+pub const IFA_MULTICAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_MULTICAST;
+pub const IFA_FLAGS: _bindgen_ty_55 = _bindgen_ty_55::IFA_FLAGS;
+pub const IFA_RT_PRIORITY: _bindgen_ty_55 = _bindgen_ty_55::IFA_RT_PRIORITY;
+pub const IFA_TARGET_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::IFA_TARGET_NETNSID;
+pub const IFA_PROTO: _bindgen_ty_55 = _bindgen_ty_55::IFA_PROTO;
+pub const __IFA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFA_MAX;
+pub const NDA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDA_UNSPEC;
+pub const NDA_DST: _bindgen_ty_56 = _bindgen_ty_56::NDA_DST;
+pub const NDA_LLADDR: _bindgen_ty_56 = _bindgen_ty_56::NDA_LLADDR;
+pub const NDA_CACHEINFO: _bindgen_ty_56 = _bindgen_ty_56::NDA_CACHEINFO;
+pub const NDA_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROBES;
+pub const NDA_VLAN: _bindgen_ty_56 = _bindgen_ty_56::NDA_VLAN;
+pub const NDA_PORT: _bindgen_ty_56 = _bindgen_ty_56::NDA_PORT;
+pub const NDA_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_VNI;
+pub const NDA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDA_IFINDEX;
+pub const NDA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::NDA_MASTER;
+pub const NDA_LINK_NETNSID: _bindgen_ty_56 = _bindgen_ty_56::NDA_LINK_NETNSID;
+pub const NDA_SRC_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_SRC_VNI;
+pub const NDA_PROTOCOL: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROTOCOL;
+pub const NDA_NH_ID: _bindgen_ty_56 = _bindgen_ty_56::NDA_NH_ID;
+pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_56 = _bindgen_ty_56::NDA_FDB_EXT_ATTRS;
+pub const NDA_FLAGS_EXT: _bindgen_ty_56 = _bindgen_ty_56::NDA_FLAGS_EXT;
+pub const NDA_NDM_STATE_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_STATE_MASK;
+pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_FLAGS_MASK;
+pub const __NDA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDA_MAX;
+pub const NDTPA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UNSPEC;
+pub const NDTPA_IFINDEX: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_IFINDEX;
+pub const NDTPA_REFCNT: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REFCNT;
+pub const NDTPA_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REACHABLE_TIME;
+pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_BASE_REACHABLE_TIME;
+pub const NDTPA_RETRANS_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_RETRANS_TIME;
+pub const NDTPA_GC_STALETIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_GC_STALETIME;
+pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_DELAY_PROBE_TIME;
+pub const NDTPA_QUEUE_LEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LEN;
+pub const NDTPA_APP_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_APP_PROBES;
+pub const NDTPA_UCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UCAST_PROBES;
+pub const NDTPA_MCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_PROBES;
+pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_ANYCAST_DELAY;
+pub const NDTPA_PROXY_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_DELAY;
+pub const NDTPA_PROXY_QLEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_QLEN;
+pub const NDTPA_LOCKTIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_LOCKTIME;
+pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LENBYTES;
+pub const NDTPA_MCAST_REPROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_REPROBES;
+pub const NDTPA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PAD;
+pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_INTERVAL_PROBE_TIME_MS;
+pub const __NDTPA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTPA_MAX;
+pub const NDTA_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDTA_UNSPEC;
+pub const NDTA_NAME: _bindgen_ty_58 = _bindgen_ty_58::NDTA_NAME;
+pub const NDTA_THRESH1: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH1;
+pub const NDTA_THRESH2: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH2;
+pub const NDTA_THRESH3: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH3;
+pub const NDTA_CONFIG: _bindgen_ty_58 = _bindgen_ty_58::NDTA_CONFIG;
+pub const NDTA_PARMS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PARMS;
+pub const NDTA_STATS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_STATS;
+pub const NDTA_GC_INTERVAL: _bindgen_ty_58 = _bindgen_ty_58::NDTA_GC_INTERVAL;
+pub const NDTA_PAD: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PAD;
+pub const __NDTA_MAX: _bindgen_ty_58 = _bindgen_ty_58::__NDTA_MAX;
+pub const FDB_NOTIFY_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_BIT;
+pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_INACTIVE_BIT;
+pub const NFEA_UNSPEC: _bindgen_ty_60 = _bindgen_ty_60::NFEA_UNSPEC;
+pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_60 = _bindgen_ty_60::NFEA_ACTIVITY_NOTIFY;
+pub const NFEA_DONT_REFRESH: _bindgen_ty_60 = _bindgen_ty_60::NFEA_DONT_REFRESH;
+pub const __NFEA_MAX: _bindgen_ty_60 = _bindgen_ty_60::__NFEA_MAX;
+pub const RTM_BASE: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_NEWLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_DELLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINK;
+pub const RTM_GETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINK;
+pub const RTM_SETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETLINK;
+pub const RTM_NEWADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDR;
+pub const RTM_DELADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDR;
+pub const RTM_GETADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDR;
+pub const RTM_NEWROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWROUTE;
+pub const RTM_DELROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELROUTE;
+pub const RTM_GETROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETROUTE;
+pub const RTM_NEWNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGH;
+pub const RTM_DELNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEIGH;
+pub const RTM_GETNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGH;
+pub const RTM_NEWRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWRULE;
+pub const RTM_DELRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELRULE;
+pub const RTM_GETRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETRULE;
+pub const RTM_NEWQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWQDISC;
+pub const RTM_DELQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELQDISC;
+pub const RTM_GETQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETQDISC;
+pub const RTM_NEWTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTCLASS;
+pub const RTM_DELTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTCLASS;
+pub const RTM_GETTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTCLASS;
+pub const RTM_NEWTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTFILTER;
+pub const RTM_DELTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTFILTER;
+pub const RTM_GETTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTFILTER;
+pub const RTM_NEWACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWACTION;
+pub const RTM_DELACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELACTION;
+pub const RTM_GETACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETACTION;
+pub const RTM_NEWPREFIX: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWPREFIX;
+pub const RTM_GETMULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMULTICAST;
+pub const RTM_GETANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETANYCAST;
+pub const RTM_NEWNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGHTBL;
+pub const RTM_GETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGHTBL;
+pub const RTM_SETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETNEIGHTBL;
+pub const RTM_NEWNDUSEROPT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNDUSEROPT;
+pub const RTM_NEWADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDRLABEL;
+pub const RTM_DELADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDRLABEL;
+pub const RTM_GETADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDRLABEL;
+pub const RTM_GETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETDCB;
+pub const RTM_SETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETDCB;
+pub const RTM_NEWNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNETCONF;
+pub const RTM_DELNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNETCONF;
+pub const RTM_GETNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNETCONF;
+pub const RTM_NEWMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWMDB;
+pub const RTM_DELMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELMDB;
+pub const RTM_GETMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMDB;
+pub const RTM_NEWNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNSID;
+pub const RTM_DELNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNSID;
+pub const RTM_GETNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNSID;
+pub const RTM_NEWSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWSTATS;
+pub const RTM_GETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETSTATS;
+pub const RTM_SETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETSTATS;
+pub const RTM_NEWCACHEREPORT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCACHEREPORT;
+pub const RTM_NEWCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCHAIN;
+pub const RTM_DELCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELCHAIN;
+pub const RTM_GETCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETCHAIN;
+pub const RTM_NEWNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOP;
+pub const RTM_DELNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOP;
+pub const RTM_GETNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOP;
+pub const RTM_NEWLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWLINKPROP;
+pub const RTM_DELLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINKPROP;
+pub const RTM_GETLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINKPROP;
+pub const RTM_NEWVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWVLAN;
+pub const RTM_DELVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELVLAN;
+pub const RTM_GETVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETVLAN;
+pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOPBUCKET;
+pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOPBUCKET;
+pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOPBUCKET;
+pub const RTM_NEWTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTUNNEL;
+pub const RTM_DELTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTUNNEL;
+pub const RTM_GETTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTUNNEL;
+pub const __RTM_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTM_MAX;
+pub const RTN_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNSPEC;
+pub const RTN_UNICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNICAST;
+pub const RTN_LOCAL: _bindgen_ty_62 = _bindgen_ty_62::RTN_LOCAL;
+pub const RTN_BROADCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_BROADCAST;
+pub const RTN_ANYCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_ANYCAST;
+pub const RTN_MULTICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_MULTICAST;
+pub const RTN_BLACKHOLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_BLACKHOLE;
+pub const RTN_UNREACHABLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNREACHABLE;
+pub const RTN_PROHIBIT: _bindgen_ty_62 = _bindgen_ty_62::RTN_PROHIBIT;
+pub const RTN_THROW: _bindgen_ty_62 = _bindgen_ty_62::RTN_THROW;
+pub const RTN_NAT: _bindgen_ty_62 = _bindgen_ty_62::RTN_NAT;
+pub const RTN_XRESOLVE: _bindgen_ty_62 = _bindgen_ty_62::RTN_XRESOLVE;
+pub const __RTN_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTN_MAX;
+pub const RTAX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::RTAX_UNSPEC;
+pub const RTAX_LOCK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_LOCK;
+pub const RTAX_MTU: _bindgen_ty_63 = _bindgen_ty_63::RTAX_MTU;
+pub const RTAX_WINDOW: _bindgen_ty_63 = _bindgen_ty_63::RTAX_WINDOW;
+pub const RTAX_RTT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTT;
+pub const RTAX_RTTVAR: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTTVAR;
+pub const RTAX_SSTHRESH: _bindgen_ty_63 = _bindgen_ty_63::RTAX_SSTHRESH;
+pub const RTAX_CWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CWND;
+pub const RTAX_ADVMSS: _bindgen_ty_63 = _bindgen_ty_63::RTAX_ADVMSS;
+pub const RTAX_REORDERING: _bindgen_ty_63 = _bindgen_ty_63::RTAX_REORDERING;
+pub const RTAX_HOPLIMIT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_HOPLIMIT;
+pub const RTAX_INITCWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITCWND;
+pub const RTAX_FEATURES: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FEATURES;
+pub const RTAX_RTO_MIN: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTO_MIN;
+pub const RTAX_INITRWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITRWND;
+pub const RTAX_QUICKACK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_QUICKACK;
+pub const RTAX_CC_ALGO: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CC_ALGO;
+pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FASTOPEN_NO_COOKIE;
+pub const __RTAX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__RTAX_MAX;
+pub const PREFIX_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_UNSPEC;
+pub const PREFIX_ADDRESS: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_ADDRESS;
+pub const PREFIX_CACHEINFO: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_CACHEINFO;
+pub const __PREFIX_MAX: _bindgen_ty_64 = _bindgen_ty_64::__PREFIX_MAX;
+pub const TCA_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::TCA_UNSPEC;
+pub const TCA_KIND: _bindgen_ty_65 = _bindgen_ty_65::TCA_KIND;
+pub const TCA_OPTIONS: _bindgen_ty_65 = _bindgen_ty_65::TCA_OPTIONS;
+pub const TCA_STATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS;
+pub const TCA_XSTATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_XSTATS;
+pub const TCA_RATE: _bindgen_ty_65 = _bindgen_ty_65::TCA_RATE;
+pub const TCA_FCNT: _bindgen_ty_65 = _bindgen_ty_65::TCA_FCNT;
+pub const TCA_STATS2: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS2;
+pub const TCA_STAB: _bindgen_ty_65 = _bindgen_ty_65::TCA_STAB;
+pub const TCA_PAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_PAD;
+pub const TCA_DUMP_INVISIBLE: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_INVISIBLE;
+pub const TCA_CHAIN: _bindgen_ty_65 = _bindgen_ty_65::TCA_CHAIN;
+pub const TCA_HW_OFFLOAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_HW_OFFLOAD;
+pub const TCA_INGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_INGRESS_BLOCK;
+pub const TCA_EGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_EGRESS_BLOCK;
+pub const TCA_DUMP_FLAGS: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_FLAGS;
+pub const TCA_EXT_WARN_MSG: _bindgen_ty_65 = _bindgen_ty_65::TCA_EXT_WARN_MSG;
+pub const __TCA_MAX: _bindgen_ty_65 = _bindgen_ty_65::__TCA_MAX;
+pub const NDUSEROPT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_UNSPEC;
+pub const NDUSEROPT_SRCADDR: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_SRCADDR;
+pub const __NDUSEROPT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__NDUSEROPT_MAX;
+pub const TCA_ROOT_UNSPEC: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_UNSPEC;
+pub const TCA_ROOT_TAB: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TAB;
+pub const TCA_ROOT_FLAGS: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_FLAGS;
+pub const TCA_ROOT_COUNT: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_COUNT;
+pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TIME_DELTA;
+pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_EXT_WARN_MSG;
+pub const __TCA_ROOT_MAX: _bindgen_ty_67 = _bindgen_ty_67::__TCA_ROOT_MAX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1542,6 +1556,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1631,7 +1647,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1727,7 +1744,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1784,7 +1803,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1937,10 +1957,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_18 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_19 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -1956,7 +2004,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_19 {
+pub enum _bindgen_ty_20 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -1968,7 +2016,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_20 {
+pub enum _bindgen_ty_21 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -1976,7 +2024,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2009,7 +2057,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2023,7 +2072,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_23 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2053,7 +2110,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2064,7 +2121,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum _bindgen_ty_25 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2079,7 +2136,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2092,7 +2149,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2130,7 +2187,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2142,7 +2199,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2158,7 +2215,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2166,7 +2223,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2186,7 +2243,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2194,7 +2251,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2203,7 +2260,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2218,7 +2275,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2226,7 +2283,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2240,7 +2297,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2249,7 +2306,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2267,7 +2324,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2277,14 +2334,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2292,7 +2349,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2306,7 +2363,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2318,7 +2375,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2327,7 +2384,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2336,7 +2393,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2346,7 +2403,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2355,7 +2412,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2365,7 +2422,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2380,7 +2437,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2392,7 +2449,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2408,7 +2465,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2417,7 +2474,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2425,15 +2482,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFA_UNSPEC = 0,
 IFA_ADDRESS = 1,
 IFA_LOCAL = 2,
@@ -2451,7 +2508,7 @@ __IFA_MAX = 12,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 NDA_UNSPEC = 0,
 NDA_DST = 1,
 NDA_LLADDR = 2,
@@ -2475,7 +2532,7 @@ __NDA_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 NDTPA_UNSPEC = 0,
 NDTPA_IFINDEX = 1,
 NDTPA_REFCNT = 2,
@@ -2501,7 +2558,7 @@ __NDTPA_MAX = 20,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_57 {
+pub enum _bindgen_ty_58 {
 NDTA_UNSPEC = 0,
 NDTA_NAME = 1,
 NDTA_THRESH1 = 2,
@@ -2517,14 +2574,14 @@ __NDTA_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_58 {
+pub enum _bindgen_ty_59 {
 FDB_NOTIFY_BIT = 1,
 FDB_NOTIFY_INACTIVE_BIT = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_59 {
+pub enum _bindgen_ty_60 {
 NFEA_UNSPEC = 0,
 NFEA_ACTIVITY_NOTIFY = 1,
 NFEA_DONT_REFRESH = 2,
@@ -2533,7 +2590,7 @@ __NFEA_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_60 {
+pub enum _bindgen_ty_61 {
 RTM_BASE = 16,
 RTM_DELLINK = 17,
 RTM_GETLINK = 18,
@@ -2610,7 +2667,7 @@ __RTM_MAX = 123,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_61 {
+pub enum _bindgen_ty_62 {
 RTN_UNSPEC = 0,
 RTN_UNICAST = 1,
 RTN_LOCAL = 2,
@@ -2686,7 +2743,7 @@ __RTA_MAX = 31,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_62 {
+pub enum _bindgen_ty_63 {
 RTAX_UNSPEC = 0,
 RTAX_LOCK = 1,
 RTAX_MTU = 2,
@@ -2710,7 +2767,7 @@ __RTAX_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_63 {
+pub enum _bindgen_ty_64 {
 PREFIX_UNSPEC = 0,
 PREFIX_ADDRESS = 1,
 PREFIX_CACHEINFO = 2,
@@ -2719,7 +2776,7 @@ __PREFIX_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_64 {
+pub enum _bindgen_ty_65 {
 TCA_UNSPEC = 0,
 TCA_KIND = 1,
 TCA_OPTIONS = 2,
@@ -2742,7 +2799,7 @@ __TCA_MAX = 17,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_65 {
+pub enum _bindgen_ty_66 {
 NDUSEROPT_UNSPEC = 0,
 NDUSEROPT_SRCADDR = 1,
 __NDUSEROPT_MAX = 2,
@@ -2793,7 +2850,7 @@ __RTNLGRP_MAX = 37,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_66 {
+pub enum _bindgen_ty_67 {
 TCA_ROOT_UNSPEC = 0,
 TCA_ROOT_TAB = 1,
 TCA_ROOT_FLAGS = 2,
@@ -2856,6 +2913,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/aarch64/prctl.rs
+++ b/src/aarch64/prctl.rs
@@ -218,6 +218,7 @@ pub const PR_SME_VL_LEN_MASK: u32 = 65535;
 pub const PR_SME_VL_INHERIT: u32 = 131072;
 pub const PR_SET_MDWE: u32 = 65;
 pub const PR_MDWE_REFUSE_EXEC_GAIN: u32 = 1;
+pub const PR_MDWE_NO_INHERIT: u32 = 2;
 pub const PR_GET_MDWE: u32 = 66;
 pub const PR_SET_VMA: u32 = 1398164801;
 pub const PR_SET_VMA_ANON_NAME: u32 = 0;

--- a/src/aarch64/xdp.rs
+++ b/src/aarch64/xdp.rs
@@ -83,6 +83,7 @@ pub len: __u64,
 pub chunk_size: __u32,
 pub headroom: __u32,
 pub flags: __u32,
+pub tx_metadata_len: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -98,6 +99,23 @@ pub tx_ring_empty_descs: __u64,
 #[derive(Debug, Copy, Clone)]
 pub struct xdp_options {
 pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct xsk_tx_metadata {
+pub flags: __u64,
+pub __bindgen_anon_1: xsk_tx_metadata__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1 {
+pub csum_start: __u16,
+pub csum_offset: __u16,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2 {
+pub tx_timestamp: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -140,7 +158,9 @@ pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
 pub const XDP_USE_NEED_WAKEUP: u32 = 8;
+pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
+pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;
@@ -157,5 +177,13 @@ pub const XDP_UMEM_PGOFF_FILL_RING: u64 = 4294967296;
 pub const XDP_UMEM_PGOFF_COMPLETION_RING: u64 = 6442450944;
 pub const XSK_UNALIGNED_BUF_OFFSET_SHIFT: u32 = 48;
 pub const XSK_UNALIGNED_BUF_ADDR_MASK: u64 = 281474976710655;
-pub const XDP_USE_SG: u32 = 16;
+pub const XDP_TXMD_FLAGS_TIMESTAMP: u32 = 1;
+pub const XDP_TXMD_FLAGS_CHECKSUM: u32 = 2;
 pub const XDP_PKT_CONTD: u32 = 1;
+pub const XDP_TX_METADATA: u32 = 2;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union xsk_tx_metadata__bindgen_ty_1 {
+pub request: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1,
+pub completion: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2,
+}

--- a/src/arm/general.rs
+++ b/src/arm/general.rs
@@ -181,7 +181,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -236,6 +237,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -294,6 +328,29 @@ pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
 pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -388,36 +445,6 @@ pub it_value: __kernel_old_timeval,
 pub struct __kernel_sock_timeval {
 pub tv_sec: __s64,
 pub tv_usec: __s64,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timespec {
-pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: crate::ctypes::c_long,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timeval {
-pub tv_sec: __kernel_old_time_t,
-pub tv_usec: __kernel_suseconds_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerspec {
-pub it_interval: timespec,
-pub it_value: timespec,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerval {
-pub it_interval: timeval,
-pub it_value: timeval,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timezone {
-pub tz_minuteswest: crate::ctypes::c_int,
-pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -666,6 +693,36 @@ pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct timespec {
+pub tv_sec: __kernel_old_time_t,
+pub tv_nsec: crate::ctypes::c_long,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timeval {
+pub tv_sec: __kernel_old_time_t,
+pub tv_usec: __kernel_suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerspec {
+pub it_interval: timespec,
+pub it_value: timespec,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerval {
+pub it_interval: timeval,
+pub it_value: timeval,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timezone {
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct iovec {
 pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
@@ -759,6 +816,22 @@ pub struct uffdio_continue {
 pub range: uffdio_range,
 pub mode: __u64,
 pub mapped: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_poison {
+pub range: uffdio_range,
+pub mode: __u64,
+pub updated: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_move {
+pub dst: __u64,
+pub src: __u64,
+pub len: __u64,
+pub mode: __u64,
+pub move_: __s64,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -900,9 +973,9 @@ pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 394496;
+pub const LINUX_VERSION_CODE: u32 = 395264;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 5;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_NULL: u32 = 0;
@@ -1273,6 +1346,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1344,6 +1425,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const FUTEX_WAIT: u32 = 0;
 pub const FUTEX_WAKE: u32 = 1;
 pub const FUTEX_FD: u32 = 2;
@@ -1374,6 +1465,13 @@ pub const FUTEX_WAIT_BITSET_PRIVATE: u32 = 137;
 pub const FUTEX_WAKE_BITSET_PRIVATE: u32 = 138;
 pub const FUTEX_WAIT_REQUEUE_PI_PRIVATE: u32 = 139;
 pub const FUTEX_CMP_REQUEUE_PI_PRIVATE: u32 = 140;
+pub const FUTEX2_SIZE_U8: u32 = 0;
+pub const FUTEX2_SIZE_U16: u32 = 1;
+pub const FUTEX2_SIZE_U32: u32 = 2;
+pub const FUTEX2_SIZE_U64: u32 = 3;
+pub const FUTEX2_NUMA: u32 = 4;
+pub const FUTEX2_PRIVATE: u32 = 128;
+pub const FUTEX2_SIZE_MASK: u32 = 3;
 pub const FUTEX_32: u32 = 2;
 pub const FUTEX_WAITV_MAX: u32 = 128;
 pub const FUTEX_WAITERS: u32 = 2147483648;
@@ -1630,25 +1728,6 @@ pub const LINUX_REBOOT_CMD_POWER_OFF: u32 = 1126301404;
 pub const LINUX_REBOOT_CMD_RESTART2: u32 = 2712847316;
 pub const LINUX_REBOOT_CMD_SW_SUSPEND: u32 = 3489725666;
 pub const LINUX_REBOOT_CMD_KEXEC: u32 = 1163412803;
-pub const ITIMER_REAL: u32 = 0;
-pub const ITIMER_VIRTUAL: u32 = 1;
-pub const ITIMER_PROF: u32 = 2;
-pub const CLOCK_REALTIME: u32 = 0;
-pub const CLOCK_MONOTONIC: u32 = 1;
-pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
-pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
-pub const CLOCK_MONOTONIC_RAW: u32 = 4;
-pub const CLOCK_REALTIME_COARSE: u32 = 5;
-pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
-pub const CLOCK_BOOTTIME: u32 = 7;
-pub const CLOCK_REALTIME_ALARM: u32 = 8;
-pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
-pub const CLOCK_SGI_CYCLE: u32 = 10;
-pub const CLOCK_TAI: u32 = 11;
-pub const MAX_CLOCKS: u32 = 16;
-pub const CLOCKS_MASK: u32 = 1;
-pub const CLOCKS_MONO: u32 = 1;
-pub const TIMER_ABSTIME: u32 = 1;
 pub const RUSAGE_SELF: u32 = 0;
 pub const RUSAGE_CHILDREN: i32 = -1;
 pub const RUSAGE_BOTH: i32 = -2;
@@ -1830,7 +1909,8 @@ pub const SEGV_ADIDERR: u32 = 6;
 pub const SEGV_ADIPERR: u32 = 7;
 pub const SEGV_MTEAERR: u32 = 8;
 pub const SEGV_MTESERR: u32 = 9;
-pub const NSIGSEGV: u32 = 9;
+pub const SEGV_CPERR: u32 = 10;
+pub const NSIGSEGV: u32 = 10;
 pub const BUS_ADRALN: u32 = 1;
 pub const BUS_ADRERR: u32 = 2;
 pub const BUS_OBJERR: u32 = 3;
@@ -1911,6 +1991,7 @@ pub const STATX_BASIC_STATS: u32 = 2047;
 pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
+pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2088,6 +2169,25 @@ pub const TIOCM_RI: u32 = 128;
 pub const TIOCM_OUT1: u32 = 8192;
 pub const TIOCM_OUT2: u32 = 16384;
 pub const TIOCM_LOOP: u32 = 32768;
+pub const ITIMER_REAL: u32 = 0;
+pub const ITIMER_VIRTUAL: u32 = 1;
+pub const ITIMER_PROF: u32 = 2;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_SGI_CYCLE: u32 = 10;
+pub const CLOCK_TAI: u32 = 11;
+pub const MAX_CLOCKS: u32 = 16;
+pub const CLOCKS_MASK: u32 = 1;
+pub const CLOCKS_MONO: u32 = 1;
+pub const TIMER_ABSTIME: u32 = 1;
 pub const UIO_FASTIOV: u32 = 8;
 pub const UIO_MAXIOV: u32 = 1024;
 pub const __NR_OABI_SYSCALL_BASE: u32 = 9437184;
@@ -2497,6 +2597,16 @@ pub const __NR_process_mrelease: u32 = 448;
 pub const __NR_futex_waitv: u32 = 449;
 pub const __NR_set_mempolicy_home_node: u32 = 450;
 pub const __NR_cachestat: u32 = 451;
+pub const __NR_fchmodat2: u32 = 452;
+pub const __NR_map_shadow_stack: u32 = 453;
+pub const __NR_futex_wake: u32 = 454;
+pub const __NR_futex_wait: u32 = 455;
+pub const __NR_futex_requeue: u32 = 456;
+pub const __NR_statmount: u32 = 457;
+pub const __NR_listmount: u32 = 458;
+pub const __NR_lsm_get_self_attr: u32 = 459;
+pub const __NR_lsm_set_self_attr: u32 = 460;
+pub const __NR_lsm_list_modules: u32 = 461;
 pub const __NR_sync_file_range2: u32 = 341;
 pub const __ARM_NR_BASE: u32 = 983040;
 pub const __ARM_NR_breakpoint: u32 = 983041;
@@ -2583,8 +2693,10 @@ pub const _UFFDIO_UNREGISTER: u32 = 1;
 pub const _UFFDIO_WAKE: u32 = 2;
 pub const _UFFDIO_COPY: u32 = 3;
 pub const _UFFDIO_ZEROPAGE: u32 = 4;
+pub const _UFFDIO_MOVE: u32 = 5;
 pub const _UFFDIO_WRITEPROTECT: u32 = 6;
 pub const _UFFDIO_CONTINUE: u32 = 7;
+pub const _UFFDIO_POISON: u32 = 8;
 pub const _UFFDIO_API: u32 = 63;
 pub const UFFDIO: u32 = 170;
 pub const UFFD_EVENT_PAGEFAULT: u32 = 18;
@@ -2609,6 +2721,9 @@ pub const UFFD_FEATURE_MINOR_SHMEM: u32 = 1024;
 pub const UFFD_FEATURE_EXACT_ADDRESS: u32 = 2048;
 pub const UFFD_FEATURE_WP_HUGETLBFS_SHMEM: u32 = 4096;
 pub const UFFD_FEATURE_WP_UNPOPULATED: u32 = 8192;
+pub const UFFD_FEATURE_POISON: u32 = 16384;
+pub const UFFD_FEATURE_WP_ASYNC: u32 = 32768;
+pub const UFFD_FEATURE_MOVE: u32 = 65536;
 pub const UFFD_USER_MODE_ONLY: u32 = 1;
 pub const DT_UNKNOWN: u32 = 0;
 pub const DT_FIFO: u32 = 1;
@@ -2684,6 +2799,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/arm/if_arp.rs
+++ b/src/arm/if_arp.rs
@@ -50,11 +50,6 @@ pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
@@ -173,6 +168,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -180,23 +176,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -1124,6 +1105,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_4 = _bindgen_ty_4::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_4 = _bindgen_ty_4::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_MASK;
@@ -1192,6 +1174,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_HAIRPIN;
@@ -1239,6 +1223,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_10 = _bindgen_ty_10::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_KIND;
@@ -1300,301 +1285,310 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_19 = _bindgen_ty_19::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_40 = _bindgen_ty_40::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_46 = _bindgen_ty_46::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_DSA_MAX;
-pub const IF_PORT_UNKNOWN: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_UNKNOWN;
-pub const IF_PORT_10BASE2: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASE2;
-pub const IF_PORT_10BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASET;
-pub const IF_PORT_AUI: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_AUI;
-pub const IF_PORT_100BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASET;
-pub const IF_PORT_100BASETX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASETX;
-pub const IF_PORT_100BASEFX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASEFX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_20 = _bindgen_ty_20::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_23 = _bindgen_ty_23::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_47 = _bindgen_ty_47::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__IFLA_DSA_MAX;
+pub const IF_PORT_UNKNOWN: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_UNKNOWN;
+pub const IF_PORT_10BASE2: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASE2;
+pub const IF_PORT_10BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASET;
+pub const IF_PORT_AUI: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_AUI;
+pub const IF_PORT_100BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASET;
+pub const IF_PORT_100BASETX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASETX;
+pub const IF_PORT_100BASEFX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASEFX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1697,6 +1691,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1786,7 +1782,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1882,7 +1879,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1939,7 +1938,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2092,10 +2092,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_20 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_21 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -2111,7 +2139,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -2123,7 +2151,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum _bindgen_ty_23 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -2131,7 +2159,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2164,7 +2192,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2178,7 +2207,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_25 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2208,7 +2245,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2219,7 +2256,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2234,7 +2271,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2247,7 +2284,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2285,7 +2322,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2297,7 +2334,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2313,7 +2350,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2321,7 +2358,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2341,7 +2378,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2349,7 +2386,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2358,7 +2395,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2373,7 +2410,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2381,7 +2418,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2395,7 +2432,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2404,7 +2441,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2422,7 +2459,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2432,14 +2469,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2447,7 +2484,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2461,7 +2498,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2473,7 +2510,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2482,7 +2519,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2491,7 +2528,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2501,7 +2538,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2510,7 +2547,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2520,7 +2557,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2535,7 +2572,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2547,7 +2584,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2563,7 +2600,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2572,7 +2609,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2580,15 +2617,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 IF_PORT_UNKNOWN = 0,
 IF_PORT_10BASE2 = 1,
 IF_PORT_10BASET = 2,
@@ -2671,74 +2708,6 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 impl nlmsgerr_attrs {
 pub const NLMSGERR_ATTR_MAX: nlmsgerr_attrs = nlmsgerr_attrs::NLMSGERR_ATTR_MISS_NEST;
 }
@@ -2753,6 +2722,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/arm/if_packet.rs
+++ b/src/arm/if_packet.rs
@@ -49,11 +49,6 @@ pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_pkt {
 pub spkt_family: crate::ctypes::c_ushort,
@@ -61,6 +56,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -68,23 +64,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -325,71 +306,3 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}

--- a/src/arm/io_uring.rs
+++ b/src/arm/io_uring.rs
@@ -77,7 +77,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -132,6 +133,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -193,6 +227,29 @@ pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
 pub tv_nsec: crate::ctypes::c_longlong,
@@ -251,6 +308,12 @@ pub __pad1: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_sqe__bindgen_ty_2__bindgen_ty_1 {
+pub level: __u32,
+pub optname: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_sqe__bindgen_ty_5__bindgen_ty_1 {
 pub addr_len: __u16,
 pub __pad3: [__u16; 1usize],
@@ -258,6 +321,7 @@ pub __pad3: [__u16; 1usize],
 #[repr(C)]
 pub struct io_uring_sqe__bindgen_ty_6 {
 pub __bindgen_anon_1: __BindgenUnionField<io_uring_sqe__bindgen_ty_6__bindgen_ty_1>,
+pub optval: __BindgenUnionField<__u64>,
 pub cmd: __BindgenUnionField<[__u8; 0usize]>,
 pub bindgen_union_field: [u64; 2usize],
 }
@@ -419,6 +483,13 @@ pub resv: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_buf_status {
+pub buf_group: __u32,
+pub head: __u32,
+pub resv: [__u32; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -432,7 +503,9 @@ pub addr: __u64,
 pub fd: __s32,
 pub flags: __u32,
 pub timeout: __kernel_timespec,
-pub pad: [__u64; 4usize],
+pub opcode: __u8,
+pub pad: [__u8; 7usize],
+pub pad2: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -595,6 +668,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -666,6 +747,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const IORING_FILE_INDEX_ALLOC: i32 = -1;
 pub const IORING_SETUP_IOPOLL: u32 = 1;
 pub const IORING_SETUP_SQPOLL: u32 = 2;
@@ -683,8 +774,9 @@ pub const IORING_SETUP_SINGLE_ISSUER: u32 = 4096;
 pub const IORING_SETUP_DEFER_TASKRUN: u32 = 8192;
 pub const IORING_SETUP_NO_MMAP: u32 = 16384;
 pub const IORING_SETUP_REGISTERED_FD_ONLY: u32 = 32768;
+pub const IORING_SETUP_NO_SQARRAY: u32 = 65536;
 pub const IORING_URING_CMD_FIXED: u32 = 1;
-pub const IORING_URING_CMD_POLLED: u32 = 2147483648;
+pub const IORING_URING_CMD_MASK: u32 = 1;
 pub const IORING_FSYNC_DATASYNC: u32 = 1;
 pub const IORING_TIMEOUT_ABS: u32 = 1;
 pub const IORING_TIMEOUT_UPDATE: u32 = 2;
@@ -704,6 +796,8 @@ pub const IORING_ASYNC_CANCEL_ALL: u32 = 1;
 pub const IORING_ASYNC_CANCEL_FD: u32 = 2;
 pub const IORING_ASYNC_CANCEL_ANY: u32 = 4;
 pub const IORING_ASYNC_CANCEL_FD_FIXED: u32 = 8;
+pub const IORING_ASYNC_CANCEL_USERDATA: u32 = 16;
+pub const IORING_ASYNC_CANCEL_OP: u32 = 32;
 pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
@@ -712,6 +806,7 @@ pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
+pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
@@ -784,6 +879,7 @@ pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGIS
 pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
 pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
 pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
+pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
 pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
 pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
 pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
@@ -794,6 +890,10 @@ pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTR
 pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
 pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
 pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
+pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
+pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
+pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
+pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -806,6 +906,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -872,7 +973,13 @@ IORING_OP_SOCKET = 45,
 IORING_OP_URING_CMD = 46,
 IORING_OP_SEND_ZC = 47,
 IORING_OP_SENDMSG_ZC = 48,
-IORING_OP_LAST = 49,
+IORING_OP_READ_MULTISHOT = 49,
+IORING_OP_WAITID = 50,
+IORING_OP_FUTEX_WAIT = 51,
+IORING_OP_FUTEX_WAKE = 52,
+IORING_OP_FUTEX_WAITV = 53,
+IORING_OP_FIXED_FD_INSTALL = 54,
+IORING_OP_LAST = 55,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -917,7 +1024,8 @@ IORING_REGISTER_PBUF_RING = 22,
 IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
-IORING_REGISTER_LAST = 26,
+IORING_REGISTER_PBUF_STATUS = 26,
+IORING_REGISTER_LAST = 27,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
@@ -942,6 +1050,15 @@ IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
 IORING_RESTRICTION_SQE_FLAGS_REQUIRED = 3,
 IORING_RESTRICTION_LAST = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_8 {
+SOCKET_URING_OP_SIOCINQ = 0,
+SOCKET_URING_OP_SIOCOUTQ = 1,
+SOCKET_URING_OP_GETSOCKOPT = 2,
+SOCKET_URING_OP_SETSOCKOPT = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -969,6 +1086,7 @@ pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_1__bindgen_ty_1,
 pub union io_uring_sqe__bindgen_ty_2 {
 pub addr: __u64,
 pub splice_off_in: __u64,
+pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_2__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -992,6 +1110,9 @@ pub hardlink_flags: __u32,
 pub xattr_flags: __u32,
 pub msg_ring_flags: __u32,
 pub uring_cmd_flags: __u32,
+pub waitid_flags: __u32,
+pub futex_flags: __u32,
+pub install_fd_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]
@@ -1004,6 +1125,7 @@ pub buf_group: __u16,
 pub union io_uring_sqe__bindgen_ty_5 {
 pub splice_fd_in: __s32,
 pub file_index: __u32,
+pub optlen: __u32,
 pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]

--- a/src/arm/net.rs
+++ b/src/arm/net.rs
@@ -427,6 +427,9 @@ pub tcpi_rcv_ooopack: __u32,
 pub tcpi_snd_wnd: __u32,
 pub tcpi_rcv_wnd: __u32,
 pub tcpi_rehash: __u32,
+pub tcpi_total_rto: __u16,
+pub tcpi_total_rto_recoveries: __u16,
+pub tcpi_total_rto_time: __u32,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -446,6 +449,82 @@ pub tcpm_prefixlen: __u8,
 pub tcpm_keylen: __u16,
 pub tcpm_addr: [__be32; 4usize],
 pub tcpm_key: [__u8; 80usize],
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_add {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub key: [__u8; 80usize],
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_del {
+pub addr: __kernel_sockaddr_storage,
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub current_key: __u8,
+pub rnext: __u8,
+pub keyflags: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_info_opt {
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub current_key: __u8,
+pub rnext: __u8,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+pub pkt_key_not_found: __u64,
+pub pkt_ao_required: __u64,
+pub pkt_dropped_icmp: __u64,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_getsockopt {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub key: [__u8; 80usize],
+pub nkeys: __u32,
+pub _bitfield_align_1: [u16; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub prefix: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub ifindex: __s32,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_repair {
+pub snt_isn: __be32,
+pub rcv_isn: __be32,
+pub snd_sne: __u32,
+pub rcv_sne: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1175,6 +1254,11 @@ pub const TCP_ZEROCOPY_RECEIVE: u32 = 35;
 pub const TCP_INQ: u32 = 36;
 pub const TCP_CM_INQ: u32 = 36;
 pub const TCP_TX_DELAY: u32 = 37;
+pub const TCP_AO_ADD_KEY: u32 = 38;
+pub const TCP_AO_DEL_KEY: u32 = 39;
+pub const TCP_AO_INFO: u32 = 40;
+pub const TCP_AO_GET_KEYS: u32 = 41;
+pub const TCP_AO_REPAIR: u32 = 42;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1184,9 +1268,13 @@ pub const TCPI_OPT_WSCALE: u32 = 4;
 pub const TCPI_OPT_ECN: u32 = 8;
 pub const TCPI_OPT_ECN_SEEN: u32 = 16;
 pub const TCPI_OPT_SYN_DATA: u32 = 32;
+pub const TCPI_OPT_USEC_TS: u32 = 64;
 pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
+pub const TCP_AO_MAXKEYLEN: u32 = 80;
+pub const TCP_AO_KEYF_IFINDEX: u32 = 1;
+pub const TCP_AO_KEYF_EXCLUDE_OPT: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
@@ -1551,6 +1639,7 @@ pub const DEVCONF_IOAM6_ID: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID;
 pub const DEVCONF_IOAM6_ID_WIDE: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID_WIDE;
 pub const DEVCONF_NDISC_EVICT_NOCARRIER: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_NDISC_EVICT_NOCARRIER;
 pub const DEVCONF_ACCEPT_UNTRACKED_NA: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_UNTRACKED_NA;
+pub const DEVCONF_ACCEPT_RA_MIN_LFT: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_RA_MIN_LFT;
 pub const DEVCONF_MAX: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_MAX;
 pub const TCP_FLAG_CWR: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_CWR;
 pub const TCP_FLAG_ECE: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_ECE;
@@ -1748,7 +1837,8 @@ DEVCONF_IOAM6_ID = 54,
 DEVCONF_IOAM6_ID_WIDE = 55,
 DEVCONF_NDISC_EVICT_NOCARRIER = 56,
 DEVCONF_ACCEPT_UNTRACKED_NA = 57,
-DEVCONF_MAX = 58,
+DEVCONF_ACCEPT_RA_MIN_LFT = 58,
+DEVCONF_MAX = 59,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2466,6 +2556,289 @@ tcpi_delivery_rate_app_limited as u64
 __bindgen_bitfield_unit.set(9usize, 2u8, {
 let tcpi_fastopen_client_fail: u8 = unsafe { ::core::mem::transmute(tcpi_fastopen_client_fail) };
 tcpi_fastopen_client_fail as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_add {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 30u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 30u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_del {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn del_async(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_del_async(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 29u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 29u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, del_async: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let del_async: u32 = unsafe { ::core::mem::transmute(del_async) };
+del_async as u64
+});
+__bindgen_bitfield_unit.set(3usize, 29u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_info_opt {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn ao_required(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_ao_required(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_counters(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_counters(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn accept_icmps(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_accept_icmps(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(4usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(5usize, 27u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(5usize, 27u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, ao_required: __u32, set_counters: __u32, accept_icmps: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let ao_required: u32 = unsafe { ::core::mem::transmute(ao_required) };
+ao_required as u64
+});
+__bindgen_bitfield_unit.set(3usize, 1u8, {
+let set_counters: u32 = unsafe { ::core::mem::transmute(set_counters) };
+set_counters as u64
+});
+__bindgen_bitfield_unit.set(4usize, 1u8, {
+let accept_icmps: u32 = unsafe { ::core::mem::transmute(accept_icmps) };
+accept_icmps as u64
+});
+__bindgen_bitfield_unit.set(5usize, 27u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_getsockopt {
+#[inline]
+pub fn is_current(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_current(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn is_rnext(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_rnext(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn get_all(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_get_all(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 13u8) as u16) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 13u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(is_current: __u16, is_rnext: __u16, get_all: __u16, reserved: __u16) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let is_current: u16 = unsafe { ::core::mem::transmute(is_current) };
+is_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let is_rnext: u16 = unsafe { ::core::mem::transmute(is_rnext) };
+is_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let get_all: u16 = unsafe { ::core::mem::transmute(get_all) };
+get_all as u64
+});
+__bindgen_bitfield_unit.set(3usize, 13u8, {
+let reserved: u16 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
 });
 __bindgen_bitfield_unit
 }

--- a/src/arm/netlink.rs
+++ b/src/arm/netlink.rs
@@ -722,7 +722,8 @@ pub const RTAX_FEATURE_ECN: u32 = 1;
 pub const RTAX_FEATURE_SACK: u32 = 2;
 pub const RTAX_FEATURE_TIMESTAMP: u32 = 4;
 pub const RTAX_FEATURE_ALLFRAG: u32 = 8;
-pub const RTAX_FEATURE_MASK: u32 = 15;
+pub const RTAX_FEATURE_TCP_USEC_TS: u32 = 16;
+pub const RTAX_FEATURE_MASK: u32 = 31;
 pub const TCM_IFINDEX_MAGIC_BLOCK: u32 = 4294967295;
 pub const TCA_DUMP_FLAGS_TERSE: u32 = 1;
 pub const RTMGRP_LINK: u32 = 1;
@@ -819,6 +820,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_2 = _bindgen_ty_2::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_2 = _bindgen_ty_2::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_MASK;
@@ -887,6 +889,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_6 = _bindgen_ty_6::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_HAIRPIN;
@@ -934,6 +938,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_KIND;
@@ -995,501 +1000,510 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_17 = _bindgen_ty_17::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_18 = _bindgen_ty_18::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_21 = _bindgen_ty_21::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_44 = _bindgen_ty_44::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_DSA_MAX;
-pub const IFA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFA_UNSPEC;
-pub const IFA_ADDRESS: _bindgen_ty_54 = _bindgen_ty_54::IFA_ADDRESS;
-pub const IFA_LOCAL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LOCAL;
-pub const IFA_LABEL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LABEL;
-pub const IFA_BROADCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_BROADCAST;
-pub const IFA_ANYCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_ANYCAST;
-pub const IFA_CACHEINFO: _bindgen_ty_54 = _bindgen_ty_54::IFA_CACHEINFO;
-pub const IFA_MULTICAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_MULTICAST;
-pub const IFA_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFA_FLAGS;
-pub const IFA_RT_PRIORITY: _bindgen_ty_54 = _bindgen_ty_54::IFA_RT_PRIORITY;
-pub const IFA_TARGET_NETNSID: _bindgen_ty_54 = _bindgen_ty_54::IFA_TARGET_NETNSID;
-pub const IFA_PROTO: _bindgen_ty_54 = _bindgen_ty_54::IFA_PROTO;
-pub const __IFA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFA_MAX;
-pub const NDA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::NDA_UNSPEC;
-pub const NDA_DST: _bindgen_ty_55 = _bindgen_ty_55::NDA_DST;
-pub const NDA_LLADDR: _bindgen_ty_55 = _bindgen_ty_55::NDA_LLADDR;
-pub const NDA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::NDA_CACHEINFO;
-pub const NDA_PROBES: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROBES;
-pub const NDA_VLAN: _bindgen_ty_55 = _bindgen_ty_55::NDA_VLAN;
-pub const NDA_PORT: _bindgen_ty_55 = _bindgen_ty_55::NDA_PORT;
-pub const NDA_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_VNI;
-pub const NDA_IFINDEX: _bindgen_ty_55 = _bindgen_ty_55::NDA_IFINDEX;
-pub const NDA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::NDA_MASTER;
-pub const NDA_LINK_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::NDA_LINK_NETNSID;
-pub const NDA_SRC_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_SRC_VNI;
-pub const NDA_PROTOCOL: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROTOCOL;
-pub const NDA_NH_ID: _bindgen_ty_55 = _bindgen_ty_55::NDA_NH_ID;
-pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_55 = _bindgen_ty_55::NDA_FDB_EXT_ATTRS;
-pub const NDA_FLAGS_EXT: _bindgen_ty_55 = _bindgen_ty_55::NDA_FLAGS_EXT;
-pub const NDA_NDM_STATE_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_STATE_MASK;
-pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_FLAGS_MASK;
-pub const __NDA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__NDA_MAX;
-pub const NDTPA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UNSPEC;
-pub const NDTPA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_IFINDEX;
-pub const NDTPA_REFCNT: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REFCNT;
-pub const NDTPA_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REACHABLE_TIME;
-pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_BASE_REACHABLE_TIME;
-pub const NDTPA_RETRANS_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_RETRANS_TIME;
-pub const NDTPA_GC_STALETIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_GC_STALETIME;
-pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_DELAY_PROBE_TIME;
-pub const NDTPA_QUEUE_LEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LEN;
-pub const NDTPA_APP_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_APP_PROBES;
-pub const NDTPA_UCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UCAST_PROBES;
-pub const NDTPA_MCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_PROBES;
-pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_ANYCAST_DELAY;
-pub const NDTPA_PROXY_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_DELAY;
-pub const NDTPA_PROXY_QLEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_QLEN;
-pub const NDTPA_LOCKTIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_LOCKTIME;
-pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LENBYTES;
-pub const NDTPA_MCAST_REPROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_REPROBES;
-pub const NDTPA_PAD: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PAD;
-pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_INTERVAL_PROBE_TIME_MS;
-pub const __NDTPA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDTPA_MAX;
-pub const NDTA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTA_UNSPEC;
-pub const NDTA_NAME: _bindgen_ty_57 = _bindgen_ty_57::NDTA_NAME;
-pub const NDTA_THRESH1: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH1;
-pub const NDTA_THRESH2: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH2;
-pub const NDTA_THRESH3: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH3;
-pub const NDTA_CONFIG: _bindgen_ty_57 = _bindgen_ty_57::NDTA_CONFIG;
-pub const NDTA_PARMS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PARMS;
-pub const NDTA_STATS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_STATS;
-pub const NDTA_GC_INTERVAL: _bindgen_ty_57 = _bindgen_ty_57::NDTA_GC_INTERVAL;
-pub const NDTA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PAD;
-pub const __NDTA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTA_MAX;
-pub const FDB_NOTIFY_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_BIT;
-pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_INACTIVE_BIT;
-pub const NFEA_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::NFEA_UNSPEC;
-pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_59 = _bindgen_ty_59::NFEA_ACTIVITY_NOTIFY;
-pub const NFEA_DONT_REFRESH: _bindgen_ty_59 = _bindgen_ty_59::NFEA_DONT_REFRESH;
-pub const __NFEA_MAX: _bindgen_ty_59 = _bindgen_ty_59::__NFEA_MAX;
-pub const RTM_BASE: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_NEWLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_DELLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINK;
-pub const RTM_GETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINK;
-pub const RTM_SETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETLINK;
-pub const RTM_NEWADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDR;
-pub const RTM_DELADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDR;
-pub const RTM_GETADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDR;
-pub const RTM_NEWROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWROUTE;
-pub const RTM_DELROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELROUTE;
-pub const RTM_GETROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETROUTE;
-pub const RTM_NEWNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGH;
-pub const RTM_DELNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEIGH;
-pub const RTM_GETNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGH;
-pub const RTM_NEWRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWRULE;
-pub const RTM_DELRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELRULE;
-pub const RTM_GETRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETRULE;
-pub const RTM_NEWQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWQDISC;
-pub const RTM_DELQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELQDISC;
-pub const RTM_GETQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETQDISC;
-pub const RTM_NEWTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTCLASS;
-pub const RTM_DELTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTCLASS;
-pub const RTM_GETTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTCLASS;
-pub const RTM_NEWTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTFILTER;
-pub const RTM_DELTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTFILTER;
-pub const RTM_GETTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTFILTER;
-pub const RTM_NEWACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWACTION;
-pub const RTM_DELACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELACTION;
-pub const RTM_GETACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETACTION;
-pub const RTM_NEWPREFIX: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWPREFIX;
-pub const RTM_GETMULTICAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMULTICAST;
-pub const RTM_GETANYCAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETANYCAST;
-pub const RTM_NEWNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGHTBL;
-pub const RTM_GETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGHTBL;
-pub const RTM_SETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETNEIGHTBL;
-pub const RTM_NEWNDUSEROPT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNDUSEROPT;
-pub const RTM_NEWADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDRLABEL;
-pub const RTM_DELADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDRLABEL;
-pub const RTM_GETADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDRLABEL;
-pub const RTM_GETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETDCB;
-pub const RTM_SETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETDCB;
-pub const RTM_NEWNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNETCONF;
-pub const RTM_DELNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNETCONF;
-pub const RTM_GETNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNETCONF;
-pub const RTM_NEWMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWMDB;
-pub const RTM_DELMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELMDB;
-pub const RTM_GETMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMDB;
-pub const RTM_NEWNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNSID;
-pub const RTM_DELNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNSID;
-pub const RTM_GETNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNSID;
-pub const RTM_NEWSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWSTATS;
-pub const RTM_GETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETSTATS;
-pub const RTM_SETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETSTATS;
-pub const RTM_NEWCACHEREPORT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCACHEREPORT;
-pub const RTM_NEWCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCHAIN;
-pub const RTM_DELCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELCHAIN;
-pub const RTM_GETCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETCHAIN;
-pub const RTM_NEWNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOP;
-pub const RTM_DELNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOP;
-pub const RTM_GETNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOP;
-pub const RTM_NEWLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWLINKPROP;
-pub const RTM_DELLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINKPROP;
-pub const RTM_GETLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINKPROP;
-pub const RTM_NEWVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWVLAN;
-pub const RTM_DELVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELVLAN;
-pub const RTM_GETVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETVLAN;
-pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOPBUCKET;
-pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOPBUCKET;
-pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOPBUCKET;
-pub const RTM_NEWTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTUNNEL;
-pub const RTM_DELTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTUNNEL;
-pub const RTM_GETTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTUNNEL;
-pub const __RTM_MAX: _bindgen_ty_60 = _bindgen_ty_60::__RTM_MAX;
-pub const RTN_UNSPEC: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNSPEC;
-pub const RTN_UNICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNICAST;
-pub const RTN_LOCAL: _bindgen_ty_61 = _bindgen_ty_61::RTN_LOCAL;
-pub const RTN_BROADCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_BROADCAST;
-pub const RTN_ANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_ANYCAST;
-pub const RTN_MULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_MULTICAST;
-pub const RTN_BLACKHOLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_BLACKHOLE;
-pub const RTN_UNREACHABLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNREACHABLE;
-pub const RTN_PROHIBIT: _bindgen_ty_61 = _bindgen_ty_61::RTN_PROHIBIT;
-pub const RTN_THROW: _bindgen_ty_61 = _bindgen_ty_61::RTN_THROW;
-pub const RTN_NAT: _bindgen_ty_61 = _bindgen_ty_61::RTN_NAT;
-pub const RTN_XRESOLVE: _bindgen_ty_61 = _bindgen_ty_61::RTN_XRESOLVE;
-pub const __RTN_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTN_MAX;
-pub const RTAX_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTAX_UNSPEC;
-pub const RTAX_LOCK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_LOCK;
-pub const RTAX_MTU: _bindgen_ty_62 = _bindgen_ty_62::RTAX_MTU;
-pub const RTAX_WINDOW: _bindgen_ty_62 = _bindgen_ty_62::RTAX_WINDOW;
-pub const RTAX_RTT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTT;
-pub const RTAX_RTTVAR: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTTVAR;
-pub const RTAX_SSTHRESH: _bindgen_ty_62 = _bindgen_ty_62::RTAX_SSTHRESH;
-pub const RTAX_CWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CWND;
-pub const RTAX_ADVMSS: _bindgen_ty_62 = _bindgen_ty_62::RTAX_ADVMSS;
-pub const RTAX_REORDERING: _bindgen_ty_62 = _bindgen_ty_62::RTAX_REORDERING;
-pub const RTAX_HOPLIMIT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_HOPLIMIT;
-pub const RTAX_INITCWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITCWND;
-pub const RTAX_FEATURES: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FEATURES;
-pub const RTAX_RTO_MIN: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTO_MIN;
-pub const RTAX_INITRWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITRWND;
-pub const RTAX_QUICKACK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_QUICKACK;
-pub const RTAX_CC_ALGO: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CC_ALGO;
-pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FASTOPEN_NO_COOKIE;
-pub const __RTAX_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTAX_MAX;
-pub const PREFIX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_UNSPEC;
-pub const PREFIX_ADDRESS: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_ADDRESS;
-pub const PREFIX_CACHEINFO: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_CACHEINFO;
-pub const __PREFIX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__PREFIX_MAX;
-pub const TCA_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::TCA_UNSPEC;
-pub const TCA_KIND: _bindgen_ty_64 = _bindgen_ty_64::TCA_KIND;
-pub const TCA_OPTIONS: _bindgen_ty_64 = _bindgen_ty_64::TCA_OPTIONS;
-pub const TCA_STATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS;
-pub const TCA_XSTATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_XSTATS;
-pub const TCA_RATE: _bindgen_ty_64 = _bindgen_ty_64::TCA_RATE;
-pub const TCA_FCNT: _bindgen_ty_64 = _bindgen_ty_64::TCA_FCNT;
-pub const TCA_STATS2: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS2;
-pub const TCA_STAB: _bindgen_ty_64 = _bindgen_ty_64::TCA_STAB;
-pub const TCA_PAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_PAD;
-pub const TCA_DUMP_INVISIBLE: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_INVISIBLE;
-pub const TCA_CHAIN: _bindgen_ty_64 = _bindgen_ty_64::TCA_CHAIN;
-pub const TCA_HW_OFFLOAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_HW_OFFLOAD;
-pub const TCA_INGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_INGRESS_BLOCK;
-pub const TCA_EGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_EGRESS_BLOCK;
-pub const TCA_DUMP_FLAGS: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_FLAGS;
-pub const TCA_EXT_WARN_MSG: _bindgen_ty_64 = _bindgen_ty_64::TCA_EXT_WARN_MSG;
-pub const __TCA_MAX: _bindgen_ty_64 = _bindgen_ty_64::__TCA_MAX;
-pub const NDUSEROPT_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_UNSPEC;
-pub const NDUSEROPT_SRCADDR: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_SRCADDR;
-pub const __NDUSEROPT_MAX: _bindgen_ty_65 = _bindgen_ty_65::__NDUSEROPT_MAX;
-pub const TCA_ROOT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_UNSPEC;
-pub const TCA_ROOT_TAB: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TAB;
-pub const TCA_ROOT_FLAGS: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_FLAGS;
-pub const TCA_ROOT_COUNT: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_COUNT;
-pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TIME_DELTA;
-pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_EXT_WARN_MSG;
-pub const __TCA_ROOT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__TCA_ROOT_MAX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_18 = _bindgen_ty_18::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_39 = _bindgen_ty_39::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_45 = _bindgen_ty_45::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_DSA_MAX;
+pub const IFA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFA_UNSPEC;
+pub const IFA_ADDRESS: _bindgen_ty_55 = _bindgen_ty_55::IFA_ADDRESS;
+pub const IFA_LOCAL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LOCAL;
+pub const IFA_LABEL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LABEL;
+pub const IFA_BROADCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_BROADCAST;
+pub const IFA_ANYCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_ANYCAST;
+pub const IFA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::IFA_CACHEINFO;
+pub const IFA_MULTICAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_MULTICAST;
+pub const IFA_FLAGS: _bindgen_ty_55 = _bindgen_ty_55::IFA_FLAGS;
+pub const IFA_RT_PRIORITY: _bindgen_ty_55 = _bindgen_ty_55::IFA_RT_PRIORITY;
+pub const IFA_TARGET_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::IFA_TARGET_NETNSID;
+pub const IFA_PROTO: _bindgen_ty_55 = _bindgen_ty_55::IFA_PROTO;
+pub const __IFA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFA_MAX;
+pub const NDA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDA_UNSPEC;
+pub const NDA_DST: _bindgen_ty_56 = _bindgen_ty_56::NDA_DST;
+pub const NDA_LLADDR: _bindgen_ty_56 = _bindgen_ty_56::NDA_LLADDR;
+pub const NDA_CACHEINFO: _bindgen_ty_56 = _bindgen_ty_56::NDA_CACHEINFO;
+pub const NDA_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROBES;
+pub const NDA_VLAN: _bindgen_ty_56 = _bindgen_ty_56::NDA_VLAN;
+pub const NDA_PORT: _bindgen_ty_56 = _bindgen_ty_56::NDA_PORT;
+pub const NDA_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_VNI;
+pub const NDA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDA_IFINDEX;
+pub const NDA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::NDA_MASTER;
+pub const NDA_LINK_NETNSID: _bindgen_ty_56 = _bindgen_ty_56::NDA_LINK_NETNSID;
+pub const NDA_SRC_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_SRC_VNI;
+pub const NDA_PROTOCOL: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROTOCOL;
+pub const NDA_NH_ID: _bindgen_ty_56 = _bindgen_ty_56::NDA_NH_ID;
+pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_56 = _bindgen_ty_56::NDA_FDB_EXT_ATTRS;
+pub const NDA_FLAGS_EXT: _bindgen_ty_56 = _bindgen_ty_56::NDA_FLAGS_EXT;
+pub const NDA_NDM_STATE_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_STATE_MASK;
+pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_FLAGS_MASK;
+pub const __NDA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDA_MAX;
+pub const NDTPA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UNSPEC;
+pub const NDTPA_IFINDEX: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_IFINDEX;
+pub const NDTPA_REFCNT: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REFCNT;
+pub const NDTPA_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REACHABLE_TIME;
+pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_BASE_REACHABLE_TIME;
+pub const NDTPA_RETRANS_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_RETRANS_TIME;
+pub const NDTPA_GC_STALETIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_GC_STALETIME;
+pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_DELAY_PROBE_TIME;
+pub const NDTPA_QUEUE_LEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LEN;
+pub const NDTPA_APP_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_APP_PROBES;
+pub const NDTPA_UCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UCAST_PROBES;
+pub const NDTPA_MCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_PROBES;
+pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_ANYCAST_DELAY;
+pub const NDTPA_PROXY_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_DELAY;
+pub const NDTPA_PROXY_QLEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_QLEN;
+pub const NDTPA_LOCKTIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_LOCKTIME;
+pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LENBYTES;
+pub const NDTPA_MCAST_REPROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_REPROBES;
+pub const NDTPA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PAD;
+pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_INTERVAL_PROBE_TIME_MS;
+pub const __NDTPA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTPA_MAX;
+pub const NDTA_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDTA_UNSPEC;
+pub const NDTA_NAME: _bindgen_ty_58 = _bindgen_ty_58::NDTA_NAME;
+pub const NDTA_THRESH1: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH1;
+pub const NDTA_THRESH2: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH2;
+pub const NDTA_THRESH3: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH3;
+pub const NDTA_CONFIG: _bindgen_ty_58 = _bindgen_ty_58::NDTA_CONFIG;
+pub const NDTA_PARMS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PARMS;
+pub const NDTA_STATS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_STATS;
+pub const NDTA_GC_INTERVAL: _bindgen_ty_58 = _bindgen_ty_58::NDTA_GC_INTERVAL;
+pub const NDTA_PAD: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PAD;
+pub const __NDTA_MAX: _bindgen_ty_58 = _bindgen_ty_58::__NDTA_MAX;
+pub const FDB_NOTIFY_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_BIT;
+pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_INACTIVE_BIT;
+pub const NFEA_UNSPEC: _bindgen_ty_60 = _bindgen_ty_60::NFEA_UNSPEC;
+pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_60 = _bindgen_ty_60::NFEA_ACTIVITY_NOTIFY;
+pub const NFEA_DONT_REFRESH: _bindgen_ty_60 = _bindgen_ty_60::NFEA_DONT_REFRESH;
+pub const __NFEA_MAX: _bindgen_ty_60 = _bindgen_ty_60::__NFEA_MAX;
+pub const RTM_BASE: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_NEWLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_DELLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINK;
+pub const RTM_GETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINK;
+pub const RTM_SETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETLINK;
+pub const RTM_NEWADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDR;
+pub const RTM_DELADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDR;
+pub const RTM_GETADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDR;
+pub const RTM_NEWROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWROUTE;
+pub const RTM_DELROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELROUTE;
+pub const RTM_GETROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETROUTE;
+pub const RTM_NEWNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGH;
+pub const RTM_DELNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEIGH;
+pub const RTM_GETNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGH;
+pub const RTM_NEWRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWRULE;
+pub const RTM_DELRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELRULE;
+pub const RTM_GETRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETRULE;
+pub const RTM_NEWQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWQDISC;
+pub const RTM_DELQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELQDISC;
+pub const RTM_GETQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETQDISC;
+pub const RTM_NEWTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTCLASS;
+pub const RTM_DELTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTCLASS;
+pub const RTM_GETTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTCLASS;
+pub const RTM_NEWTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTFILTER;
+pub const RTM_DELTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTFILTER;
+pub const RTM_GETTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTFILTER;
+pub const RTM_NEWACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWACTION;
+pub const RTM_DELACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELACTION;
+pub const RTM_GETACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETACTION;
+pub const RTM_NEWPREFIX: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWPREFIX;
+pub const RTM_GETMULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMULTICAST;
+pub const RTM_GETANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETANYCAST;
+pub const RTM_NEWNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGHTBL;
+pub const RTM_GETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGHTBL;
+pub const RTM_SETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETNEIGHTBL;
+pub const RTM_NEWNDUSEROPT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNDUSEROPT;
+pub const RTM_NEWADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDRLABEL;
+pub const RTM_DELADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDRLABEL;
+pub const RTM_GETADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDRLABEL;
+pub const RTM_GETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETDCB;
+pub const RTM_SETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETDCB;
+pub const RTM_NEWNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNETCONF;
+pub const RTM_DELNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNETCONF;
+pub const RTM_GETNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNETCONF;
+pub const RTM_NEWMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWMDB;
+pub const RTM_DELMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELMDB;
+pub const RTM_GETMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMDB;
+pub const RTM_NEWNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNSID;
+pub const RTM_DELNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNSID;
+pub const RTM_GETNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNSID;
+pub const RTM_NEWSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWSTATS;
+pub const RTM_GETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETSTATS;
+pub const RTM_SETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETSTATS;
+pub const RTM_NEWCACHEREPORT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCACHEREPORT;
+pub const RTM_NEWCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCHAIN;
+pub const RTM_DELCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELCHAIN;
+pub const RTM_GETCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETCHAIN;
+pub const RTM_NEWNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOP;
+pub const RTM_DELNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOP;
+pub const RTM_GETNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOP;
+pub const RTM_NEWLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWLINKPROP;
+pub const RTM_DELLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINKPROP;
+pub const RTM_GETLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINKPROP;
+pub const RTM_NEWVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWVLAN;
+pub const RTM_DELVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELVLAN;
+pub const RTM_GETVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETVLAN;
+pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOPBUCKET;
+pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOPBUCKET;
+pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOPBUCKET;
+pub const RTM_NEWTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTUNNEL;
+pub const RTM_DELTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTUNNEL;
+pub const RTM_GETTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTUNNEL;
+pub const __RTM_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTM_MAX;
+pub const RTN_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNSPEC;
+pub const RTN_UNICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNICAST;
+pub const RTN_LOCAL: _bindgen_ty_62 = _bindgen_ty_62::RTN_LOCAL;
+pub const RTN_BROADCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_BROADCAST;
+pub const RTN_ANYCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_ANYCAST;
+pub const RTN_MULTICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_MULTICAST;
+pub const RTN_BLACKHOLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_BLACKHOLE;
+pub const RTN_UNREACHABLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNREACHABLE;
+pub const RTN_PROHIBIT: _bindgen_ty_62 = _bindgen_ty_62::RTN_PROHIBIT;
+pub const RTN_THROW: _bindgen_ty_62 = _bindgen_ty_62::RTN_THROW;
+pub const RTN_NAT: _bindgen_ty_62 = _bindgen_ty_62::RTN_NAT;
+pub const RTN_XRESOLVE: _bindgen_ty_62 = _bindgen_ty_62::RTN_XRESOLVE;
+pub const __RTN_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTN_MAX;
+pub const RTAX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::RTAX_UNSPEC;
+pub const RTAX_LOCK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_LOCK;
+pub const RTAX_MTU: _bindgen_ty_63 = _bindgen_ty_63::RTAX_MTU;
+pub const RTAX_WINDOW: _bindgen_ty_63 = _bindgen_ty_63::RTAX_WINDOW;
+pub const RTAX_RTT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTT;
+pub const RTAX_RTTVAR: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTTVAR;
+pub const RTAX_SSTHRESH: _bindgen_ty_63 = _bindgen_ty_63::RTAX_SSTHRESH;
+pub const RTAX_CWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CWND;
+pub const RTAX_ADVMSS: _bindgen_ty_63 = _bindgen_ty_63::RTAX_ADVMSS;
+pub const RTAX_REORDERING: _bindgen_ty_63 = _bindgen_ty_63::RTAX_REORDERING;
+pub const RTAX_HOPLIMIT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_HOPLIMIT;
+pub const RTAX_INITCWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITCWND;
+pub const RTAX_FEATURES: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FEATURES;
+pub const RTAX_RTO_MIN: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTO_MIN;
+pub const RTAX_INITRWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITRWND;
+pub const RTAX_QUICKACK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_QUICKACK;
+pub const RTAX_CC_ALGO: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CC_ALGO;
+pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FASTOPEN_NO_COOKIE;
+pub const __RTAX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__RTAX_MAX;
+pub const PREFIX_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_UNSPEC;
+pub const PREFIX_ADDRESS: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_ADDRESS;
+pub const PREFIX_CACHEINFO: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_CACHEINFO;
+pub const __PREFIX_MAX: _bindgen_ty_64 = _bindgen_ty_64::__PREFIX_MAX;
+pub const TCA_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::TCA_UNSPEC;
+pub const TCA_KIND: _bindgen_ty_65 = _bindgen_ty_65::TCA_KIND;
+pub const TCA_OPTIONS: _bindgen_ty_65 = _bindgen_ty_65::TCA_OPTIONS;
+pub const TCA_STATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS;
+pub const TCA_XSTATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_XSTATS;
+pub const TCA_RATE: _bindgen_ty_65 = _bindgen_ty_65::TCA_RATE;
+pub const TCA_FCNT: _bindgen_ty_65 = _bindgen_ty_65::TCA_FCNT;
+pub const TCA_STATS2: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS2;
+pub const TCA_STAB: _bindgen_ty_65 = _bindgen_ty_65::TCA_STAB;
+pub const TCA_PAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_PAD;
+pub const TCA_DUMP_INVISIBLE: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_INVISIBLE;
+pub const TCA_CHAIN: _bindgen_ty_65 = _bindgen_ty_65::TCA_CHAIN;
+pub const TCA_HW_OFFLOAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_HW_OFFLOAD;
+pub const TCA_INGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_INGRESS_BLOCK;
+pub const TCA_EGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_EGRESS_BLOCK;
+pub const TCA_DUMP_FLAGS: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_FLAGS;
+pub const TCA_EXT_WARN_MSG: _bindgen_ty_65 = _bindgen_ty_65::TCA_EXT_WARN_MSG;
+pub const __TCA_MAX: _bindgen_ty_65 = _bindgen_ty_65::__TCA_MAX;
+pub const NDUSEROPT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_UNSPEC;
+pub const NDUSEROPT_SRCADDR: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_SRCADDR;
+pub const __NDUSEROPT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__NDUSEROPT_MAX;
+pub const TCA_ROOT_UNSPEC: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_UNSPEC;
+pub const TCA_ROOT_TAB: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TAB;
+pub const TCA_ROOT_FLAGS: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_FLAGS;
+pub const TCA_ROOT_COUNT: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_COUNT;
+pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TIME_DELTA;
+pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_EXT_WARN_MSG;
+pub const __TCA_ROOT_MAX: _bindgen_ty_67 = _bindgen_ty_67::__TCA_ROOT_MAX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1540,6 +1554,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1629,7 +1645,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1725,7 +1742,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1782,7 +1801,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1935,10 +1955,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_18 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_19 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -1954,7 +2002,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_19 {
+pub enum _bindgen_ty_20 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -1966,7 +2014,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_20 {
+pub enum _bindgen_ty_21 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -1974,7 +2022,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2007,7 +2055,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2021,7 +2070,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_23 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2051,7 +2108,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2062,7 +2119,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum _bindgen_ty_25 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2077,7 +2134,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2090,7 +2147,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2128,7 +2185,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2140,7 +2197,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2156,7 +2213,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2164,7 +2221,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2184,7 +2241,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2192,7 +2249,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2201,7 +2258,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2216,7 +2273,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2224,7 +2281,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2238,7 +2295,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2247,7 +2304,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2265,7 +2322,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2275,14 +2332,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2290,7 +2347,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2304,7 +2361,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2316,7 +2373,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2325,7 +2382,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2334,7 +2391,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2344,7 +2401,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2353,7 +2410,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2363,7 +2420,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2378,7 +2435,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2390,7 +2447,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2406,7 +2463,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2415,7 +2472,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2423,15 +2480,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFA_UNSPEC = 0,
 IFA_ADDRESS = 1,
 IFA_LOCAL = 2,
@@ -2449,7 +2506,7 @@ __IFA_MAX = 12,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 NDA_UNSPEC = 0,
 NDA_DST = 1,
 NDA_LLADDR = 2,
@@ -2473,7 +2530,7 @@ __NDA_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 NDTPA_UNSPEC = 0,
 NDTPA_IFINDEX = 1,
 NDTPA_REFCNT = 2,
@@ -2499,7 +2556,7 @@ __NDTPA_MAX = 20,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_57 {
+pub enum _bindgen_ty_58 {
 NDTA_UNSPEC = 0,
 NDTA_NAME = 1,
 NDTA_THRESH1 = 2,
@@ -2515,14 +2572,14 @@ __NDTA_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_58 {
+pub enum _bindgen_ty_59 {
 FDB_NOTIFY_BIT = 1,
 FDB_NOTIFY_INACTIVE_BIT = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_59 {
+pub enum _bindgen_ty_60 {
 NFEA_UNSPEC = 0,
 NFEA_ACTIVITY_NOTIFY = 1,
 NFEA_DONT_REFRESH = 2,
@@ -2531,7 +2588,7 @@ __NFEA_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_60 {
+pub enum _bindgen_ty_61 {
 RTM_BASE = 16,
 RTM_DELLINK = 17,
 RTM_GETLINK = 18,
@@ -2608,7 +2665,7 @@ __RTM_MAX = 123,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_61 {
+pub enum _bindgen_ty_62 {
 RTN_UNSPEC = 0,
 RTN_UNICAST = 1,
 RTN_LOCAL = 2,
@@ -2684,7 +2741,7 @@ __RTA_MAX = 31,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_62 {
+pub enum _bindgen_ty_63 {
 RTAX_UNSPEC = 0,
 RTAX_LOCK = 1,
 RTAX_MTU = 2,
@@ -2708,7 +2765,7 @@ __RTAX_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_63 {
+pub enum _bindgen_ty_64 {
 PREFIX_UNSPEC = 0,
 PREFIX_ADDRESS = 1,
 PREFIX_CACHEINFO = 2,
@@ -2717,7 +2774,7 @@ __PREFIX_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_64 {
+pub enum _bindgen_ty_65 {
 TCA_UNSPEC = 0,
 TCA_KIND = 1,
 TCA_OPTIONS = 2,
@@ -2740,7 +2797,7 @@ __TCA_MAX = 17,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_65 {
+pub enum _bindgen_ty_66 {
 NDUSEROPT_UNSPEC = 0,
 NDUSEROPT_SRCADDR = 1,
 __NDUSEROPT_MAX = 2,
@@ -2791,7 +2848,7 @@ __RTNLGRP_MAX = 37,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_66 {
+pub enum _bindgen_ty_67 {
 TCA_ROOT_UNSPEC = 0,
 TCA_ROOT_TAB = 1,
 TCA_ROOT_FLAGS = 2,
@@ -2854,6 +2911,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/arm/prctl.rs
+++ b/src/arm/prctl.rs
@@ -216,6 +216,7 @@ pub const PR_SME_VL_LEN_MASK: u32 = 65535;
 pub const PR_SME_VL_INHERIT: u32 = 131072;
 pub const PR_SET_MDWE: u32 = 65;
 pub const PR_MDWE_REFUSE_EXEC_GAIN: u32 = 1;
+pub const PR_MDWE_NO_INHERIT: u32 = 2;
 pub const PR_GET_MDWE: u32 = 66;
 pub const PR_SET_VMA: u32 = 1398164801;
 pub const PR_SET_VMA_ANON_NAME: u32 = 0;

--- a/src/arm/xdp.rs
+++ b/src/arm/xdp.rs
@@ -81,6 +81,7 @@ pub len: __u64,
 pub chunk_size: __u32,
 pub headroom: __u32,
 pub flags: __u32,
+pub tx_metadata_len: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -96,6 +97,23 @@ pub tx_ring_empty_descs: __u64,
 #[derive(Debug, Copy, Clone)]
 pub struct xdp_options {
 pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct xsk_tx_metadata {
+pub flags: __u64,
+pub __bindgen_anon_1: xsk_tx_metadata__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1 {
+pub csum_start: __u16,
+pub csum_offset: __u16,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2 {
+pub tx_timestamp: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -138,7 +156,9 @@ pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
 pub const XDP_USE_NEED_WAKEUP: u32 = 8;
+pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
+pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;
@@ -155,5 +175,13 @@ pub const XDP_UMEM_PGOFF_FILL_RING: u64 = 4294967296;
 pub const XDP_UMEM_PGOFF_COMPLETION_RING: u64 = 6442450944;
 pub const XSK_UNALIGNED_BUF_OFFSET_SHIFT: u32 = 48;
 pub const XSK_UNALIGNED_BUF_ADDR_MASK: u64 = 281474976710655;
-pub const XDP_USE_SG: u32 = 16;
+pub const XDP_TXMD_FLAGS_TIMESTAMP: u32 = 1;
+pub const XDP_TXMD_FLAGS_CHECKSUM: u32 = 2;
 pub const XDP_PKT_CONTD: u32 = 1;
+pub const XDP_TX_METADATA: u32 = 2;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union xsk_tx_metadata__bindgen_ty_1 {
+pub request: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1,
+pub completion: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2,
+}

--- a/src/csky/general.rs
+++ b/src/csky/general.rs
@@ -181,7 +181,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -236,6 +237,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -294,6 +328,29 @@ pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
 pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -388,36 +445,6 @@ pub it_value: __kernel_old_timeval,
 pub struct __kernel_sock_timeval {
 pub tv_sec: __s64,
 pub tv_usec: __s64,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timespec {
-pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: crate::ctypes::c_long,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timeval {
-pub tv_sec: __kernel_old_time_t,
-pub tv_usec: __kernel_suseconds_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerspec {
-pub it_interval: timespec,
-pub it_value: timespec,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerval {
-pub it_interval: timeval,
-pub it_value: timeval,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timezone {
-pub tz_minuteswest: crate::ctypes::c_int,
-pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -671,6 +698,36 @@ pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct timespec {
+pub tv_sec: __kernel_old_time_t,
+pub tv_nsec: crate::ctypes::c_long,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timeval {
+pub tv_sec: __kernel_old_time_t,
+pub tv_usec: __kernel_suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerspec {
+pub it_interval: timespec,
+pub it_value: timespec,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerval {
+pub it_interval: timeval,
+pub it_value: timeval,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timezone {
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct iovec {
 pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
@@ -764,6 +821,22 @@ pub struct uffdio_continue {
 pub range: uffdio_range,
 pub mode: __u64,
 pub mapped: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_poison {
+pub range: uffdio_range,
+pub mode: __u64,
+pub updated: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_move {
+pub dst: __u64,
+pub src: __u64,
+pub len: __u64,
+pub mode: __u64,
+pub move_: __s64,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -892,9 +965,9 @@ pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 394496;
+pub const LINUX_VERSION_CODE: u32 = 395264;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 5;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_NULL: u32 = 0;
 pub const AT_IGNORE: u32 = 1;
@@ -1264,6 +1337,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1335,6 +1416,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const FUTEX_WAIT: u32 = 0;
 pub const FUTEX_WAKE: u32 = 1;
 pub const FUTEX_FD: u32 = 2;
@@ -1365,6 +1456,13 @@ pub const FUTEX_WAIT_BITSET_PRIVATE: u32 = 137;
 pub const FUTEX_WAKE_BITSET_PRIVATE: u32 = 138;
 pub const FUTEX_WAIT_REQUEUE_PI_PRIVATE: u32 = 139;
 pub const FUTEX_CMP_REQUEUE_PI_PRIVATE: u32 = 140;
+pub const FUTEX2_SIZE_U8: u32 = 0;
+pub const FUTEX2_SIZE_U16: u32 = 1;
+pub const FUTEX2_SIZE_U32: u32 = 2;
+pub const FUTEX2_SIZE_U64: u32 = 3;
+pub const FUTEX2_NUMA: u32 = 4;
+pub const FUTEX2_PRIVATE: u32 = 128;
+pub const FUTEX2_SIZE_MASK: u32 = 3;
 pub const FUTEX_32: u32 = 2;
 pub const FUTEX_WAITV_MAX: u32 = 128;
 pub const FUTEX_WAITERS: u32 = 2147483648;
@@ -1621,25 +1719,6 @@ pub const LINUX_REBOOT_CMD_POWER_OFF: u32 = 1126301404;
 pub const LINUX_REBOOT_CMD_RESTART2: u32 = 2712847316;
 pub const LINUX_REBOOT_CMD_SW_SUSPEND: u32 = 3489725666;
 pub const LINUX_REBOOT_CMD_KEXEC: u32 = 1163412803;
-pub const ITIMER_REAL: u32 = 0;
-pub const ITIMER_VIRTUAL: u32 = 1;
-pub const ITIMER_PROF: u32 = 2;
-pub const CLOCK_REALTIME: u32 = 0;
-pub const CLOCK_MONOTONIC: u32 = 1;
-pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
-pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
-pub const CLOCK_MONOTONIC_RAW: u32 = 4;
-pub const CLOCK_REALTIME_COARSE: u32 = 5;
-pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
-pub const CLOCK_BOOTTIME: u32 = 7;
-pub const CLOCK_REALTIME_ALARM: u32 = 8;
-pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
-pub const CLOCK_SGI_CYCLE: u32 = 10;
-pub const CLOCK_TAI: u32 = 11;
-pub const MAX_CLOCKS: u32 = 16;
-pub const CLOCKS_MASK: u32 = 1;
-pub const CLOCKS_MONO: u32 = 1;
-pub const TIMER_ABSTIME: u32 = 1;
 pub const RUSAGE_SELF: u32 = 0;
 pub const RUSAGE_CHILDREN: i32 = -1;
 pub const RUSAGE_BOTH: i32 = -2;
@@ -1819,7 +1898,8 @@ pub const SEGV_ADIDERR: u32 = 6;
 pub const SEGV_ADIPERR: u32 = 7;
 pub const SEGV_MTEAERR: u32 = 8;
 pub const SEGV_MTESERR: u32 = 9;
-pub const NSIGSEGV: u32 = 9;
+pub const SEGV_CPERR: u32 = 10;
+pub const NSIGSEGV: u32 = 10;
 pub const BUS_ADRALN: u32 = 1;
 pub const BUS_ADRERR: u32 = 2;
 pub const BUS_OBJERR: u32 = 3;
@@ -1900,6 +1980,7 @@ pub const STATX_BASIC_STATS: u32 = 2047;
 pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
+pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2077,6 +2158,25 @@ pub const TIOCM_RI: u32 = 128;
 pub const TIOCM_OUT1: u32 = 8192;
 pub const TIOCM_OUT2: u32 = 16384;
 pub const TIOCM_LOOP: u32 = 32768;
+pub const ITIMER_REAL: u32 = 0;
+pub const ITIMER_VIRTUAL: u32 = 1;
+pub const ITIMER_PROF: u32 = 2;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_SGI_CYCLE: u32 = 10;
+pub const CLOCK_TAI: u32 = 11;
+pub const MAX_CLOCKS: u32 = 16;
+pub const CLOCKS_MASK: u32 = 1;
+pub const CLOCKS_MONO: u32 = 1;
+pub const TIMER_ABSTIME: u32 = 1;
 pub const UIO_FASTIOV: u32 = 8;
 pub const UIO_MAXIOV: u32 = 1024;
 pub const __NR_io_setup: u32 = 0;
@@ -2405,7 +2505,17 @@ pub const __NR_process_mrelease: u32 = 448;
 pub const __NR_futex_waitv: u32 = 449;
 pub const __NR_set_mempolicy_home_node: u32 = 450;
 pub const __NR_cachestat: u32 = 451;
-pub const __NR_syscalls: u32 = 452;
+pub const __NR_fchmodat2: u32 = 452;
+pub const __NR_map_shadow_stack: u32 = 453;
+pub const __NR_futex_wake: u32 = 454;
+pub const __NR_futex_wait: u32 = 455;
+pub const __NR_futex_requeue: u32 = 456;
+pub const __NR_statmount: u32 = 457;
+pub const __NR_listmount: u32 = 458;
+pub const __NR_lsm_get_self_attr: u32 = 459;
+pub const __NR_lsm_set_self_attr: u32 = 460;
+pub const __NR_lsm_list_modules: u32 = 461;
+pub const __NR_syscalls: u32 = 462;
 pub const __NR_fcntl64: u32 = 25;
 pub const __NR_statfs64: u32 = 43;
 pub const __NR_fstatfs64: u32 = 44;
@@ -2497,8 +2607,10 @@ pub const _UFFDIO_UNREGISTER: u32 = 1;
 pub const _UFFDIO_WAKE: u32 = 2;
 pub const _UFFDIO_COPY: u32 = 3;
 pub const _UFFDIO_ZEROPAGE: u32 = 4;
+pub const _UFFDIO_MOVE: u32 = 5;
 pub const _UFFDIO_WRITEPROTECT: u32 = 6;
 pub const _UFFDIO_CONTINUE: u32 = 7;
+pub const _UFFDIO_POISON: u32 = 8;
 pub const _UFFDIO_API: u32 = 63;
 pub const UFFDIO: u32 = 170;
 pub const UFFD_EVENT_PAGEFAULT: u32 = 18;
@@ -2523,6 +2635,9 @@ pub const UFFD_FEATURE_MINOR_SHMEM: u32 = 1024;
 pub const UFFD_FEATURE_EXACT_ADDRESS: u32 = 2048;
 pub const UFFD_FEATURE_WP_HUGETLBFS_SHMEM: u32 = 4096;
 pub const UFFD_FEATURE_WP_UNPOPULATED: u32 = 8192;
+pub const UFFD_FEATURE_POISON: u32 = 16384;
+pub const UFFD_FEATURE_WP_ASYNC: u32 = 32768;
+pub const UFFD_FEATURE_MOVE: u32 = 65536;
 pub const UFFD_USER_MODE_ONLY: u32 = 1;
 pub const DT_UNKNOWN: u32 = 0;
 pub const DT_FIFO: u32 = 1;
@@ -2597,6 +2712,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/csky/if_arp.rs
+++ b/src/csky/if_arp.rs
@@ -50,11 +50,6 @@ pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
@@ -173,6 +168,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -180,23 +176,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -1126,6 +1107,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_4 = _bindgen_ty_4::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_4 = _bindgen_ty_4::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_MASK;
@@ -1194,6 +1176,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_HAIRPIN;
@@ -1241,6 +1225,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_10 = _bindgen_ty_10::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_KIND;
@@ -1302,301 +1287,310 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_19 = _bindgen_ty_19::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_40 = _bindgen_ty_40::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_46 = _bindgen_ty_46::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_DSA_MAX;
-pub const IF_PORT_UNKNOWN: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_UNKNOWN;
-pub const IF_PORT_10BASE2: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASE2;
-pub const IF_PORT_10BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASET;
-pub const IF_PORT_AUI: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_AUI;
-pub const IF_PORT_100BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASET;
-pub const IF_PORT_100BASETX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASETX;
-pub const IF_PORT_100BASEFX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASEFX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_20 = _bindgen_ty_20::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_23 = _bindgen_ty_23::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_47 = _bindgen_ty_47::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__IFLA_DSA_MAX;
+pub const IF_PORT_UNKNOWN: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_UNKNOWN;
+pub const IF_PORT_10BASE2: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASE2;
+pub const IF_PORT_10BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASET;
+pub const IF_PORT_AUI: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_AUI;
+pub const IF_PORT_100BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASET;
+pub const IF_PORT_100BASETX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASETX;
+pub const IF_PORT_100BASEFX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASEFX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1699,6 +1693,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1788,7 +1784,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1884,7 +1881,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1941,7 +1940,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2094,10 +2094,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_20 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_21 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -2113,7 +2141,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -2125,7 +2153,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum _bindgen_ty_23 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -2133,7 +2161,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2166,7 +2194,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2180,7 +2209,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_25 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2210,7 +2247,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2221,7 +2258,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2236,7 +2273,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2249,7 +2286,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2287,7 +2324,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2299,7 +2336,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2315,7 +2352,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2323,7 +2360,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2343,7 +2380,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2351,7 +2388,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2360,7 +2397,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2375,7 +2412,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2383,7 +2420,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2397,7 +2434,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2406,7 +2443,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2424,7 +2461,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2434,14 +2471,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2449,7 +2486,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2463,7 +2500,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2475,7 +2512,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2484,7 +2521,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2493,7 +2530,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2503,7 +2540,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2512,7 +2549,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2522,7 +2559,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2537,7 +2574,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2549,7 +2586,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2565,7 +2602,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2574,7 +2611,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2582,15 +2619,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 IF_PORT_UNKNOWN = 0,
 IF_PORT_10BASE2 = 1,
 IF_PORT_10BASET = 2,
@@ -2673,74 +2710,6 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 impl nlmsgerr_attrs {
 pub const NLMSGERR_ATTR_MAX: nlmsgerr_attrs = nlmsgerr_attrs::NLMSGERR_ATTR_MISS_NEST;
 }
@@ -2755,6 +2724,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/csky/if_packet.rs
+++ b/src/csky/if_packet.rs
@@ -49,11 +49,6 @@ pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_pkt {
 pub spkt_family: crate::ctypes::c_ushort,
@@ -61,6 +56,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -68,23 +64,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -327,71 +308,3 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}

--- a/src/csky/io_uring.rs
+++ b/src/csky/io_uring.rs
@@ -77,7 +77,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -132,6 +133,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -193,6 +227,29 @@ pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
 pub tv_nsec: crate::ctypes::c_longlong,
@@ -251,6 +308,12 @@ pub __pad1: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_sqe__bindgen_ty_2__bindgen_ty_1 {
+pub level: __u32,
+pub optname: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_sqe__bindgen_ty_5__bindgen_ty_1 {
 pub addr_len: __u16,
 pub __pad3: [__u16; 1usize],
@@ -258,6 +321,7 @@ pub __pad3: [__u16; 1usize],
 #[repr(C)]
 pub struct io_uring_sqe__bindgen_ty_6 {
 pub __bindgen_anon_1: __BindgenUnionField<io_uring_sqe__bindgen_ty_6__bindgen_ty_1>,
+pub optval: __BindgenUnionField<__u64>,
 pub cmd: __BindgenUnionField<[__u8; 0usize]>,
 pub bindgen_union_field: [u32; 4usize],
 }
@@ -423,6 +487,13 @@ pub resv: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_buf_status {
+pub buf_group: __u32,
+pub head: __u32,
+pub resv: [__u32; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -436,7 +507,9 @@ pub addr: __u64,
 pub fd: __s32,
 pub flags: __u32,
 pub timeout: __kernel_timespec,
-pub pad: [__u64; 4usize],
+pub opcode: __u8,
+pub pad: [__u8; 7usize],
+pub pad2: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -599,6 +672,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -670,6 +751,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const IORING_FILE_INDEX_ALLOC: i32 = -1;
 pub const IORING_SETUP_IOPOLL: u32 = 1;
 pub const IORING_SETUP_SQPOLL: u32 = 2;
@@ -687,8 +778,9 @@ pub const IORING_SETUP_SINGLE_ISSUER: u32 = 4096;
 pub const IORING_SETUP_DEFER_TASKRUN: u32 = 8192;
 pub const IORING_SETUP_NO_MMAP: u32 = 16384;
 pub const IORING_SETUP_REGISTERED_FD_ONLY: u32 = 32768;
+pub const IORING_SETUP_NO_SQARRAY: u32 = 65536;
 pub const IORING_URING_CMD_FIXED: u32 = 1;
-pub const IORING_URING_CMD_POLLED: u32 = 2147483648;
+pub const IORING_URING_CMD_MASK: u32 = 1;
 pub const IORING_FSYNC_DATASYNC: u32 = 1;
 pub const IORING_TIMEOUT_ABS: u32 = 1;
 pub const IORING_TIMEOUT_UPDATE: u32 = 2;
@@ -708,6 +800,8 @@ pub const IORING_ASYNC_CANCEL_ALL: u32 = 1;
 pub const IORING_ASYNC_CANCEL_FD: u32 = 2;
 pub const IORING_ASYNC_CANCEL_ANY: u32 = 4;
 pub const IORING_ASYNC_CANCEL_FD_FIXED: u32 = 8;
+pub const IORING_ASYNC_CANCEL_USERDATA: u32 = 16;
+pub const IORING_ASYNC_CANCEL_OP: u32 = 32;
 pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
@@ -716,6 +810,7 @@ pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
+pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
@@ -788,6 +883,7 @@ pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGIS
 pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
 pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
 pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
+pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
 pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
 pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
 pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
@@ -798,6 +894,10 @@ pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTR
 pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
 pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
 pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
+pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
+pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
+pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
+pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -810,6 +910,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -876,7 +977,13 @@ IORING_OP_SOCKET = 45,
 IORING_OP_URING_CMD = 46,
 IORING_OP_SEND_ZC = 47,
 IORING_OP_SENDMSG_ZC = 48,
-IORING_OP_LAST = 49,
+IORING_OP_READ_MULTISHOT = 49,
+IORING_OP_WAITID = 50,
+IORING_OP_FUTEX_WAIT = 51,
+IORING_OP_FUTEX_WAKE = 52,
+IORING_OP_FUTEX_WAITV = 53,
+IORING_OP_FIXED_FD_INSTALL = 54,
+IORING_OP_LAST = 55,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -921,7 +1028,8 @@ IORING_REGISTER_PBUF_RING = 22,
 IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
-IORING_REGISTER_LAST = 26,
+IORING_REGISTER_PBUF_STATUS = 26,
+IORING_REGISTER_LAST = 27,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
@@ -946,6 +1054,15 @@ IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
 IORING_RESTRICTION_SQE_FLAGS_REQUIRED = 3,
 IORING_RESTRICTION_LAST = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_8 {
+SOCKET_URING_OP_SIOCINQ = 0,
+SOCKET_URING_OP_SIOCOUTQ = 1,
+SOCKET_URING_OP_GETSOCKOPT = 2,
+SOCKET_URING_OP_SETSOCKOPT = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -973,6 +1090,7 @@ pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_1__bindgen_ty_1,
 pub union io_uring_sqe__bindgen_ty_2 {
 pub addr: __u64,
 pub splice_off_in: __u64,
+pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_2__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -996,6 +1114,9 @@ pub hardlink_flags: __u32,
 pub xattr_flags: __u32,
 pub msg_ring_flags: __u32,
 pub uring_cmd_flags: __u32,
+pub waitid_flags: __u32,
+pub futex_flags: __u32,
+pub install_fd_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]
@@ -1008,6 +1129,7 @@ pub buf_group: __u16,
 pub union io_uring_sqe__bindgen_ty_5 {
 pub splice_fd_in: __s32,
 pub file_index: __u32,
+pub optlen: __u32,
 pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]

--- a/src/csky/net.rs
+++ b/src/csky/net.rs
@@ -427,6 +427,9 @@ pub tcpi_rcv_ooopack: __u32,
 pub tcpi_snd_wnd: __u32,
 pub tcpi_rcv_wnd: __u32,
 pub tcpi_rehash: __u32,
+pub tcpi_total_rto: __u16,
+pub tcpi_total_rto_recoveries: __u16,
+pub tcpi_total_rto_time: __u32,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -446,6 +449,84 @@ pub tcpm_prefixlen: __u8,
 pub tcpm_keylen: __u16,
 pub tcpm_addr: [__be32; 4usize],
 pub tcpm_key: [__u8; 80usize],
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_add {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub key: [__u8; 80usize],
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_del {
+pub addr: __kernel_sockaddr_storage,
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub current_key: __u8,
+pub rnext: __u8,
+pub keyflags: __u8,
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_info_opt {
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub current_key: __u8,
+pub rnext: __u8,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+pub pkt_key_not_found: __u64,
+pub pkt_ao_required: __u64,
+pub pkt_dropped_icmp: __u64,
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_getsockopt {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub key: [__u8; 80usize],
+pub nkeys: __u32,
+pub _bitfield_align_1: [u16; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub prefix: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub ifindex: __s32,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_repair {
+pub snt_isn: __be32,
+pub rcv_isn: __be32,
+pub snd_sne: __u32,
+pub rcv_sne: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1175,6 +1256,11 @@ pub const TCP_ZEROCOPY_RECEIVE: u32 = 35;
 pub const TCP_INQ: u32 = 36;
 pub const TCP_CM_INQ: u32 = 36;
 pub const TCP_TX_DELAY: u32 = 37;
+pub const TCP_AO_ADD_KEY: u32 = 38;
+pub const TCP_AO_DEL_KEY: u32 = 39;
+pub const TCP_AO_INFO: u32 = 40;
+pub const TCP_AO_GET_KEYS: u32 = 41;
+pub const TCP_AO_REPAIR: u32 = 42;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1184,9 +1270,13 @@ pub const TCPI_OPT_WSCALE: u32 = 4;
 pub const TCPI_OPT_ECN: u32 = 8;
 pub const TCPI_OPT_ECN_SEEN: u32 = 16;
 pub const TCPI_OPT_SYN_DATA: u32 = 32;
+pub const TCPI_OPT_USEC_TS: u32 = 64;
 pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
+pub const TCP_AO_MAXKEYLEN: u32 = 80;
+pub const TCP_AO_KEYF_IFINDEX: u32 = 1;
+pub const TCP_AO_KEYF_EXCLUDE_OPT: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
@@ -1551,6 +1641,7 @@ pub const DEVCONF_IOAM6_ID: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID;
 pub const DEVCONF_IOAM6_ID_WIDE: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID_WIDE;
 pub const DEVCONF_NDISC_EVICT_NOCARRIER: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_NDISC_EVICT_NOCARRIER;
 pub const DEVCONF_ACCEPT_UNTRACKED_NA: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_UNTRACKED_NA;
+pub const DEVCONF_ACCEPT_RA_MIN_LFT: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_RA_MIN_LFT;
 pub const DEVCONF_MAX: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_MAX;
 pub const TCP_FLAG_CWR: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_CWR;
 pub const TCP_FLAG_ECE: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_ECE;
@@ -1748,7 +1839,8 @@ DEVCONF_IOAM6_ID = 54,
 DEVCONF_IOAM6_ID_WIDE = 55,
 DEVCONF_NDISC_EVICT_NOCARRIER = 56,
 DEVCONF_ACCEPT_UNTRACKED_NA = 57,
-DEVCONF_MAX = 58,
+DEVCONF_ACCEPT_RA_MIN_LFT = 58,
+DEVCONF_MAX = 59,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2466,6 +2558,289 @@ tcpi_delivery_rate_app_limited as u64
 __bindgen_bitfield_unit.set(9usize, 2u8, {
 let tcpi_fastopen_client_fail: u8 = unsafe { ::core::mem::transmute(tcpi_fastopen_client_fail) };
 tcpi_fastopen_client_fail as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_add {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 30u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 30u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_del {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn del_async(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_del_async(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 29u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 29u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, del_async: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let del_async: u32 = unsafe { ::core::mem::transmute(del_async) };
+del_async as u64
+});
+__bindgen_bitfield_unit.set(3usize, 29u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_info_opt {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn ao_required(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_ao_required(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_counters(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_counters(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn accept_icmps(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_accept_icmps(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(4usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(5usize, 27u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(5usize, 27u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, ao_required: __u32, set_counters: __u32, accept_icmps: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let ao_required: u32 = unsafe { ::core::mem::transmute(ao_required) };
+ao_required as u64
+});
+__bindgen_bitfield_unit.set(3usize, 1u8, {
+let set_counters: u32 = unsafe { ::core::mem::transmute(set_counters) };
+set_counters as u64
+});
+__bindgen_bitfield_unit.set(4usize, 1u8, {
+let accept_icmps: u32 = unsafe { ::core::mem::transmute(accept_icmps) };
+accept_icmps as u64
+});
+__bindgen_bitfield_unit.set(5usize, 27u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_getsockopt {
+#[inline]
+pub fn is_current(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_current(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn is_rnext(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_rnext(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn get_all(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_get_all(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 13u8) as u16) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 13u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(is_current: __u16, is_rnext: __u16, get_all: __u16, reserved: __u16) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let is_current: u16 = unsafe { ::core::mem::transmute(is_current) };
+is_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let is_rnext: u16 = unsafe { ::core::mem::transmute(is_rnext) };
+is_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let get_all: u16 = unsafe { ::core::mem::transmute(get_all) };
+get_all as u64
+});
+__bindgen_bitfield_unit.set(3usize, 13u8, {
+let reserved: u16 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
 });
 __bindgen_bitfield_unit
 }

--- a/src/csky/netlink.rs
+++ b/src/csky/netlink.rs
@@ -722,7 +722,8 @@ pub const RTAX_FEATURE_ECN: u32 = 1;
 pub const RTAX_FEATURE_SACK: u32 = 2;
 pub const RTAX_FEATURE_TIMESTAMP: u32 = 4;
 pub const RTAX_FEATURE_ALLFRAG: u32 = 8;
-pub const RTAX_FEATURE_MASK: u32 = 15;
+pub const RTAX_FEATURE_TCP_USEC_TS: u32 = 16;
+pub const RTAX_FEATURE_MASK: u32 = 31;
 pub const TCM_IFINDEX_MAGIC_BLOCK: u32 = 4294967295;
 pub const TCA_DUMP_FLAGS_TERSE: u32 = 1;
 pub const RTMGRP_LINK: u32 = 1;
@@ -819,6 +820,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_2 = _bindgen_ty_2::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_2 = _bindgen_ty_2::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_MASK;
@@ -887,6 +889,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_6 = _bindgen_ty_6::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_HAIRPIN;
@@ -934,6 +938,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_KIND;
@@ -995,501 +1000,510 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_17 = _bindgen_ty_17::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_18 = _bindgen_ty_18::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_21 = _bindgen_ty_21::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_44 = _bindgen_ty_44::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_DSA_MAX;
-pub const IFA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFA_UNSPEC;
-pub const IFA_ADDRESS: _bindgen_ty_54 = _bindgen_ty_54::IFA_ADDRESS;
-pub const IFA_LOCAL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LOCAL;
-pub const IFA_LABEL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LABEL;
-pub const IFA_BROADCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_BROADCAST;
-pub const IFA_ANYCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_ANYCAST;
-pub const IFA_CACHEINFO: _bindgen_ty_54 = _bindgen_ty_54::IFA_CACHEINFO;
-pub const IFA_MULTICAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_MULTICAST;
-pub const IFA_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFA_FLAGS;
-pub const IFA_RT_PRIORITY: _bindgen_ty_54 = _bindgen_ty_54::IFA_RT_PRIORITY;
-pub const IFA_TARGET_NETNSID: _bindgen_ty_54 = _bindgen_ty_54::IFA_TARGET_NETNSID;
-pub const IFA_PROTO: _bindgen_ty_54 = _bindgen_ty_54::IFA_PROTO;
-pub const __IFA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFA_MAX;
-pub const NDA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::NDA_UNSPEC;
-pub const NDA_DST: _bindgen_ty_55 = _bindgen_ty_55::NDA_DST;
-pub const NDA_LLADDR: _bindgen_ty_55 = _bindgen_ty_55::NDA_LLADDR;
-pub const NDA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::NDA_CACHEINFO;
-pub const NDA_PROBES: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROBES;
-pub const NDA_VLAN: _bindgen_ty_55 = _bindgen_ty_55::NDA_VLAN;
-pub const NDA_PORT: _bindgen_ty_55 = _bindgen_ty_55::NDA_PORT;
-pub const NDA_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_VNI;
-pub const NDA_IFINDEX: _bindgen_ty_55 = _bindgen_ty_55::NDA_IFINDEX;
-pub const NDA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::NDA_MASTER;
-pub const NDA_LINK_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::NDA_LINK_NETNSID;
-pub const NDA_SRC_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_SRC_VNI;
-pub const NDA_PROTOCOL: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROTOCOL;
-pub const NDA_NH_ID: _bindgen_ty_55 = _bindgen_ty_55::NDA_NH_ID;
-pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_55 = _bindgen_ty_55::NDA_FDB_EXT_ATTRS;
-pub const NDA_FLAGS_EXT: _bindgen_ty_55 = _bindgen_ty_55::NDA_FLAGS_EXT;
-pub const NDA_NDM_STATE_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_STATE_MASK;
-pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_FLAGS_MASK;
-pub const __NDA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__NDA_MAX;
-pub const NDTPA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UNSPEC;
-pub const NDTPA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_IFINDEX;
-pub const NDTPA_REFCNT: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REFCNT;
-pub const NDTPA_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REACHABLE_TIME;
-pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_BASE_REACHABLE_TIME;
-pub const NDTPA_RETRANS_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_RETRANS_TIME;
-pub const NDTPA_GC_STALETIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_GC_STALETIME;
-pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_DELAY_PROBE_TIME;
-pub const NDTPA_QUEUE_LEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LEN;
-pub const NDTPA_APP_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_APP_PROBES;
-pub const NDTPA_UCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UCAST_PROBES;
-pub const NDTPA_MCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_PROBES;
-pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_ANYCAST_DELAY;
-pub const NDTPA_PROXY_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_DELAY;
-pub const NDTPA_PROXY_QLEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_QLEN;
-pub const NDTPA_LOCKTIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_LOCKTIME;
-pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LENBYTES;
-pub const NDTPA_MCAST_REPROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_REPROBES;
-pub const NDTPA_PAD: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PAD;
-pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_INTERVAL_PROBE_TIME_MS;
-pub const __NDTPA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDTPA_MAX;
-pub const NDTA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTA_UNSPEC;
-pub const NDTA_NAME: _bindgen_ty_57 = _bindgen_ty_57::NDTA_NAME;
-pub const NDTA_THRESH1: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH1;
-pub const NDTA_THRESH2: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH2;
-pub const NDTA_THRESH3: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH3;
-pub const NDTA_CONFIG: _bindgen_ty_57 = _bindgen_ty_57::NDTA_CONFIG;
-pub const NDTA_PARMS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PARMS;
-pub const NDTA_STATS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_STATS;
-pub const NDTA_GC_INTERVAL: _bindgen_ty_57 = _bindgen_ty_57::NDTA_GC_INTERVAL;
-pub const NDTA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PAD;
-pub const __NDTA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTA_MAX;
-pub const FDB_NOTIFY_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_BIT;
-pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_INACTIVE_BIT;
-pub const NFEA_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::NFEA_UNSPEC;
-pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_59 = _bindgen_ty_59::NFEA_ACTIVITY_NOTIFY;
-pub const NFEA_DONT_REFRESH: _bindgen_ty_59 = _bindgen_ty_59::NFEA_DONT_REFRESH;
-pub const __NFEA_MAX: _bindgen_ty_59 = _bindgen_ty_59::__NFEA_MAX;
-pub const RTM_BASE: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_NEWLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_DELLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINK;
-pub const RTM_GETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINK;
-pub const RTM_SETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETLINK;
-pub const RTM_NEWADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDR;
-pub const RTM_DELADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDR;
-pub const RTM_GETADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDR;
-pub const RTM_NEWROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWROUTE;
-pub const RTM_DELROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELROUTE;
-pub const RTM_GETROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETROUTE;
-pub const RTM_NEWNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGH;
-pub const RTM_DELNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEIGH;
-pub const RTM_GETNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGH;
-pub const RTM_NEWRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWRULE;
-pub const RTM_DELRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELRULE;
-pub const RTM_GETRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETRULE;
-pub const RTM_NEWQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWQDISC;
-pub const RTM_DELQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELQDISC;
-pub const RTM_GETQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETQDISC;
-pub const RTM_NEWTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTCLASS;
-pub const RTM_DELTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTCLASS;
-pub const RTM_GETTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTCLASS;
-pub const RTM_NEWTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTFILTER;
-pub const RTM_DELTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTFILTER;
-pub const RTM_GETTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTFILTER;
-pub const RTM_NEWACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWACTION;
-pub const RTM_DELACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELACTION;
-pub const RTM_GETACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETACTION;
-pub const RTM_NEWPREFIX: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWPREFIX;
-pub const RTM_GETMULTICAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMULTICAST;
-pub const RTM_GETANYCAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETANYCAST;
-pub const RTM_NEWNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGHTBL;
-pub const RTM_GETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGHTBL;
-pub const RTM_SETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETNEIGHTBL;
-pub const RTM_NEWNDUSEROPT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNDUSEROPT;
-pub const RTM_NEWADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDRLABEL;
-pub const RTM_DELADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDRLABEL;
-pub const RTM_GETADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDRLABEL;
-pub const RTM_GETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETDCB;
-pub const RTM_SETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETDCB;
-pub const RTM_NEWNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNETCONF;
-pub const RTM_DELNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNETCONF;
-pub const RTM_GETNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNETCONF;
-pub const RTM_NEWMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWMDB;
-pub const RTM_DELMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELMDB;
-pub const RTM_GETMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMDB;
-pub const RTM_NEWNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNSID;
-pub const RTM_DELNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNSID;
-pub const RTM_GETNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNSID;
-pub const RTM_NEWSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWSTATS;
-pub const RTM_GETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETSTATS;
-pub const RTM_SETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETSTATS;
-pub const RTM_NEWCACHEREPORT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCACHEREPORT;
-pub const RTM_NEWCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCHAIN;
-pub const RTM_DELCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELCHAIN;
-pub const RTM_GETCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETCHAIN;
-pub const RTM_NEWNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOP;
-pub const RTM_DELNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOP;
-pub const RTM_GETNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOP;
-pub const RTM_NEWLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWLINKPROP;
-pub const RTM_DELLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINKPROP;
-pub const RTM_GETLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINKPROP;
-pub const RTM_NEWVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWVLAN;
-pub const RTM_DELVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELVLAN;
-pub const RTM_GETVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETVLAN;
-pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOPBUCKET;
-pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOPBUCKET;
-pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOPBUCKET;
-pub const RTM_NEWTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTUNNEL;
-pub const RTM_DELTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTUNNEL;
-pub const RTM_GETTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTUNNEL;
-pub const __RTM_MAX: _bindgen_ty_60 = _bindgen_ty_60::__RTM_MAX;
-pub const RTN_UNSPEC: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNSPEC;
-pub const RTN_UNICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNICAST;
-pub const RTN_LOCAL: _bindgen_ty_61 = _bindgen_ty_61::RTN_LOCAL;
-pub const RTN_BROADCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_BROADCAST;
-pub const RTN_ANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_ANYCAST;
-pub const RTN_MULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_MULTICAST;
-pub const RTN_BLACKHOLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_BLACKHOLE;
-pub const RTN_UNREACHABLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNREACHABLE;
-pub const RTN_PROHIBIT: _bindgen_ty_61 = _bindgen_ty_61::RTN_PROHIBIT;
-pub const RTN_THROW: _bindgen_ty_61 = _bindgen_ty_61::RTN_THROW;
-pub const RTN_NAT: _bindgen_ty_61 = _bindgen_ty_61::RTN_NAT;
-pub const RTN_XRESOLVE: _bindgen_ty_61 = _bindgen_ty_61::RTN_XRESOLVE;
-pub const __RTN_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTN_MAX;
-pub const RTAX_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTAX_UNSPEC;
-pub const RTAX_LOCK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_LOCK;
-pub const RTAX_MTU: _bindgen_ty_62 = _bindgen_ty_62::RTAX_MTU;
-pub const RTAX_WINDOW: _bindgen_ty_62 = _bindgen_ty_62::RTAX_WINDOW;
-pub const RTAX_RTT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTT;
-pub const RTAX_RTTVAR: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTTVAR;
-pub const RTAX_SSTHRESH: _bindgen_ty_62 = _bindgen_ty_62::RTAX_SSTHRESH;
-pub const RTAX_CWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CWND;
-pub const RTAX_ADVMSS: _bindgen_ty_62 = _bindgen_ty_62::RTAX_ADVMSS;
-pub const RTAX_REORDERING: _bindgen_ty_62 = _bindgen_ty_62::RTAX_REORDERING;
-pub const RTAX_HOPLIMIT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_HOPLIMIT;
-pub const RTAX_INITCWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITCWND;
-pub const RTAX_FEATURES: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FEATURES;
-pub const RTAX_RTO_MIN: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTO_MIN;
-pub const RTAX_INITRWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITRWND;
-pub const RTAX_QUICKACK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_QUICKACK;
-pub const RTAX_CC_ALGO: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CC_ALGO;
-pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FASTOPEN_NO_COOKIE;
-pub const __RTAX_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTAX_MAX;
-pub const PREFIX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_UNSPEC;
-pub const PREFIX_ADDRESS: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_ADDRESS;
-pub const PREFIX_CACHEINFO: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_CACHEINFO;
-pub const __PREFIX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__PREFIX_MAX;
-pub const TCA_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::TCA_UNSPEC;
-pub const TCA_KIND: _bindgen_ty_64 = _bindgen_ty_64::TCA_KIND;
-pub const TCA_OPTIONS: _bindgen_ty_64 = _bindgen_ty_64::TCA_OPTIONS;
-pub const TCA_STATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS;
-pub const TCA_XSTATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_XSTATS;
-pub const TCA_RATE: _bindgen_ty_64 = _bindgen_ty_64::TCA_RATE;
-pub const TCA_FCNT: _bindgen_ty_64 = _bindgen_ty_64::TCA_FCNT;
-pub const TCA_STATS2: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS2;
-pub const TCA_STAB: _bindgen_ty_64 = _bindgen_ty_64::TCA_STAB;
-pub const TCA_PAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_PAD;
-pub const TCA_DUMP_INVISIBLE: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_INVISIBLE;
-pub const TCA_CHAIN: _bindgen_ty_64 = _bindgen_ty_64::TCA_CHAIN;
-pub const TCA_HW_OFFLOAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_HW_OFFLOAD;
-pub const TCA_INGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_INGRESS_BLOCK;
-pub const TCA_EGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_EGRESS_BLOCK;
-pub const TCA_DUMP_FLAGS: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_FLAGS;
-pub const TCA_EXT_WARN_MSG: _bindgen_ty_64 = _bindgen_ty_64::TCA_EXT_WARN_MSG;
-pub const __TCA_MAX: _bindgen_ty_64 = _bindgen_ty_64::__TCA_MAX;
-pub const NDUSEROPT_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_UNSPEC;
-pub const NDUSEROPT_SRCADDR: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_SRCADDR;
-pub const __NDUSEROPT_MAX: _bindgen_ty_65 = _bindgen_ty_65::__NDUSEROPT_MAX;
-pub const TCA_ROOT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_UNSPEC;
-pub const TCA_ROOT_TAB: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TAB;
-pub const TCA_ROOT_FLAGS: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_FLAGS;
-pub const TCA_ROOT_COUNT: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_COUNT;
-pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TIME_DELTA;
-pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_EXT_WARN_MSG;
-pub const __TCA_ROOT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__TCA_ROOT_MAX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_18 = _bindgen_ty_18::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_39 = _bindgen_ty_39::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_45 = _bindgen_ty_45::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_DSA_MAX;
+pub const IFA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFA_UNSPEC;
+pub const IFA_ADDRESS: _bindgen_ty_55 = _bindgen_ty_55::IFA_ADDRESS;
+pub const IFA_LOCAL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LOCAL;
+pub const IFA_LABEL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LABEL;
+pub const IFA_BROADCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_BROADCAST;
+pub const IFA_ANYCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_ANYCAST;
+pub const IFA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::IFA_CACHEINFO;
+pub const IFA_MULTICAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_MULTICAST;
+pub const IFA_FLAGS: _bindgen_ty_55 = _bindgen_ty_55::IFA_FLAGS;
+pub const IFA_RT_PRIORITY: _bindgen_ty_55 = _bindgen_ty_55::IFA_RT_PRIORITY;
+pub const IFA_TARGET_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::IFA_TARGET_NETNSID;
+pub const IFA_PROTO: _bindgen_ty_55 = _bindgen_ty_55::IFA_PROTO;
+pub const __IFA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFA_MAX;
+pub const NDA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDA_UNSPEC;
+pub const NDA_DST: _bindgen_ty_56 = _bindgen_ty_56::NDA_DST;
+pub const NDA_LLADDR: _bindgen_ty_56 = _bindgen_ty_56::NDA_LLADDR;
+pub const NDA_CACHEINFO: _bindgen_ty_56 = _bindgen_ty_56::NDA_CACHEINFO;
+pub const NDA_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROBES;
+pub const NDA_VLAN: _bindgen_ty_56 = _bindgen_ty_56::NDA_VLAN;
+pub const NDA_PORT: _bindgen_ty_56 = _bindgen_ty_56::NDA_PORT;
+pub const NDA_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_VNI;
+pub const NDA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDA_IFINDEX;
+pub const NDA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::NDA_MASTER;
+pub const NDA_LINK_NETNSID: _bindgen_ty_56 = _bindgen_ty_56::NDA_LINK_NETNSID;
+pub const NDA_SRC_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_SRC_VNI;
+pub const NDA_PROTOCOL: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROTOCOL;
+pub const NDA_NH_ID: _bindgen_ty_56 = _bindgen_ty_56::NDA_NH_ID;
+pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_56 = _bindgen_ty_56::NDA_FDB_EXT_ATTRS;
+pub const NDA_FLAGS_EXT: _bindgen_ty_56 = _bindgen_ty_56::NDA_FLAGS_EXT;
+pub const NDA_NDM_STATE_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_STATE_MASK;
+pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_FLAGS_MASK;
+pub const __NDA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDA_MAX;
+pub const NDTPA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UNSPEC;
+pub const NDTPA_IFINDEX: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_IFINDEX;
+pub const NDTPA_REFCNT: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REFCNT;
+pub const NDTPA_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REACHABLE_TIME;
+pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_BASE_REACHABLE_TIME;
+pub const NDTPA_RETRANS_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_RETRANS_TIME;
+pub const NDTPA_GC_STALETIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_GC_STALETIME;
+pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_DELAY_PROBE_TIME;
+pub const NDTPA_QUEUE_LEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LEN;
+pub const NDTPA_APP_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_APP_PROBES;
+pub const NDTPA_UCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UCAST_PROBES;
+pub const NDTPA_MCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_PROBES;
+pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_ANYCAST_DELAY;
+pub const NDTPA_PROXY_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_DELAY;
+pub const NDTPA_PROXY_QLEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_QLEN;
+pub const NDTPA_LOCKTIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_LOCKTIME;
+pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LENBYTES;
+pub const NDTPA_MCAST_REPROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_REPROBES;
+pub const NDTPA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PAD;
+pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_INTERVAL_PROBE_TIME_MS;
+pub const __NDTPA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTPA_MAX;
+pub const NDTA_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDTA_UNSPEC;
+pub const NDTA_NAME: _bindgen_ty_58 = _bindgen_ty_58::NDTA_NAME;
+pub const NDTA_THRESH1: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH1;
+pub const NDTA_THRESH2: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH2;
+pub const NDTA_THRESH3: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH3;
+pub const NDTA_CONFIG: _bindgen_ty_58 = _bindgen_ty_58::NDTA_CONFIG;
+pub const NDTA_PARMS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PARMS;
+pub const NDTA_STATS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_STATS;
+pub const NDTA_GC_INTERVAL: _bindgen_ty_58 = _bindgen_ty_58::NDTA_GC_INTERVAL;
+pub const NDTA_PAD: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PAD;
+pub const __NDTA_MAX: _bindgen_ty_58 = _bindgen_ty_58::__NDTA_MAX;
+pub const FDB_NOTIFY_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_BIT;
+pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_INACTIVE_BIT;
+pub const NFEA_UNSPEC: _bindgen_ty_60 = _bindgen_ty_60::NFEA_UNSPEC;
+pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_60 = _bindgen_ty_60::NFEA_ACTIVITY_NOTIFY;
+pub const NFEA_DONT_REFRESH: _bindgen_ty_60 = _bindgen_ty_60::NFEA_DONT_REFRESH;
+pub const __NFEA_MAX: _bindgen_ty_60 = _bindgen_ty_60::__NFEA_MAX;
+pub const RTM_BASE: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_NEWLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_DELLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINK;
+pub const RTM_GETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINK;
+pub const RTM_SETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETLINK;
+pub const RTM_NEWADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDR;
+pub const RTM_DELADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDR;
+pub const RTM_GETADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDR;
+pub const RTM_NEWROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWROUTE;
+pub const RTM_DELROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELROUTE;
+pub const RTM_GETROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETROUTE;
+pub const RTM_NEWNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGH;
+pub const RTM_DELNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEIGH;
+pub const RTM_GETNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGH;
+pub const RTM_NEWRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWRULE;
+pub const RTM_DELRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELRULE;
+pub const RTM_GETRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETRULE;
+pub const RTM_NEWQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWQDISC;
+pub const RTM_DELQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELQDISC;
+pub const RTM_GETQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETQDISC;
+pub const RTM_NEWTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTCLASS;
+pub const RTM_DELTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTCLASS;
+pub const RTM_GETTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTCLASS;
+pub const RTM_NEWTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTFILTER;
+pub const RTM_DELTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTFILTER;
+pub const RTM_GETTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTFILTER;
+pub const RTM_NEWACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWACTION;
+pub const RTM_DELACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELACTION;
+pub const RTM_GETACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETACTION;
+pub const RTM_NEWPREFIX: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWPREFIX;
+pub const RTM_GETMULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMULTICAST;
+pub const RTM_GETANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETANYCAST;
+pub const RTM_NEWNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGHTBL;
+pub const RTM_GETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGHTBL;
+pub const RTM_SETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETNEIGHTBL;
+pub const RTM_NEWNDUSEROPT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNDUSEROPT;
+pub const RTM_NEWADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDRLABEL;
+pub const RTM_DELADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDRLABEL;
+pub const RTM_GETADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDRLABEL;
+pub const RTM_GETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETDCB;
+pub const RTM_SETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETDCB;
+pub const RTM_NEWNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNETCONF;
+pub const RTM_DELNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNETCONF;
+pub const RTM_GETNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNETCONF;
+pub const RTM_NEWMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWMDB;
+pub const RTM_DELMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELMDB;
+pub const RTM_GETMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMDB;
+pub const RTM_NEWNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNSID;
+pub const RTM_DELNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNSID;
+pub const RTM_GETNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNSID;
+pub const RTM_NEWSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWSTATS;
+pub const RTM_GETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETSTATS;
+pub const RTM_SETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETSTATS;
+pub const RTM_NEWCACHEREPORT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCACHEREPORT;
+pub const RTM_NEWCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCHAIN;
+pub const RTM_DELCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELCHAIN;
+pub const RTM_GETCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETCHAIN;
+pub const RTM_NEWNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOP;
+pub const RTM_DELNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOP;
+pub const RTM_GETNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOP;
+pub const RTM_NEWLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWLINKPROP;
+pub const RTM_DELLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINKPROP;
+pub const RTM_GETLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINKPROP;
+pub const RTM_NEWVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWVLAN;
+pub const RTM_DELVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELVLAN;
+pub const RTM_GETVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETVLAN;
+pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOPBUCKET;
+pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOPBUCKET;
+pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOPBUCKET;
+pub const RTM_NEWTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTUNNEL;
+pub const RTM_DELTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTUNNEL;
+pub const RTM_GETTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTUNNEL;
+pub const __RTM_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTM_MAX;
+pub const RTN_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNSPEC;
+pub const RTN_UNICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNICAST;
+pub const RTN_LOCAL: _bindgen_ty_62 = _bindgen_ty_62::RTN_LOCAL;
+pub const RTN_BROADCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_BROADCAST;
+pub const RTN_ANYCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_ANYCAST;
+pub const RTN_MULTICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_MULTICAST;
+pub const RTN_BLACKHOLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_BLACKHOLE;
+pub const RTN_UNREACHABLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNREACHABLE;
+pub const RTN_PROHIBIT: _bindgen_ty_62 = _bindgen_ty_62::RTN_PROHIBIT;
+pub const RTN_THROW: _bindgen_ty_62 = _bindgen_ty_62::RTN_THROW;
+pub const RTN_NAT: _bindgen_ty_62 = _bindgen_ty_62::RTN_NAT;
+pub const RTN_XRESOLVE: _bindgen_ty_62 = _bindgen_ty_62::RTN_XRESOLVE;
+pub const __RTN_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTN_MAX;
+pub const RTAX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::RTAX_UNSPEC;
+pub const RTAX_LOCK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_LOCK;
+pub const RTAX_MTU: _bindgen_ty_63 = _bindgen_ty_63::RTAX_MTU;
+pub const RTAX_WINDOW: _bindgen_ty_63 = _bindgen_ty_63::RTAX_WINDOW;
+pub const RTAX_RTT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTT;
+pub const RTAX_RTTVAR: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTTVAR;
+pub const RTAX_SSTHRESH: _bindgen_ty_63 = _bindgen_ty_63::RTAX_SSTHRESH;
+pub const RTAX_CWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CWND;
+pub const RTAX_ADVMSS: _bindgen_ty_63 = _bindgen_ty_63::RTAX_ADVMSS;
+pub const RTAX_REORDERING: _bindgen_ty_63 = _bindgen_ty_63::RTAX_REORDERING;
+pub const RTAX_HOPLIMIT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_HOPLIMIT;
+pub const RTAX_INITCWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITCWND;
+pub const RTAX_FEATURES: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FEATURES;
+pub const RTAX_RTO_MIN: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTO_MIN;
+pub const RTAX_INITRWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITRWND;
+pub const RTAX_QUICKACK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_QUICKACK;
+pub const RTAX_CC_ALGO: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CC_ALGO;
+pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FASTOPEN_NO_COOKIE;
+pub const __RTAX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__RTAX_MAX;
+pub const PREFIX_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_UNSPEC;
+pub const PREFIX_ADDRESS: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_ADDRESS;
+pub const PREFIX_CACHEINFO: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_CACHEINFO;
+pub const __PREFIX_MAX: _bindgen_ty_64 = _bindgen_ty_64::__PREFIX_MAX;
+pub const TCA_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::TCA_UNSPEC;
+pub const TCA_KIND: _bindgen_ty_65 = _bindgen_ty_65::TCA_KIND;
+pub const TCA_OPTIONS: _bindgen_ty_65 = _bindgen_ty_65::TCA_OPTIONS;
+pub const TCA_STATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS;
+pub const TCA_XSTATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_XSTATS;
+pub const TCA_RATE: _bindgen_ty_65 = _bindgen_ty_65::TCA_RATE;
+pub const TCA_FCNT: _bindgen_ty_65 = _bindgen_ty_65::TCA_FCNT;
+pub const TCA_STATS2: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS2;
+pub const TCA_STAB: _bindgen_ty_65 = _bindgen_ty_65::TCA_STAB;
+pub const TCA_PAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_PAD;
+pub const TCA_DUMP_INVISIBLE: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_INVISIBLE;
+pub const TCA_CHAIN: _bindgen_ty_65 = _bindgen_ty_65::TCA_CHAIN;
+pub const TCA_HW_OFFLOAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_HW_OFFLOAD;
+pub const TCA_INGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_INGRESS_BLOCK;
+pub const TCA_EGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_EGRESS_BLOCK;
+pub const TCA_DUMP_FLAGS: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_FLAGS;
+pub const TCA_EXT_WARN_MSG: _bindgen_ty_65 = _bindgen_ty_65::TCA_EXT_WARN_MSG;
+pub const __TCA_MAX: _bindgen_ty_65 = _bindgen_ty_65::__TCA_MAX;
+pub const NDUSEROPT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_UNSPEC;
+pub const NDUSEROPT_SRCADDR: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_SRCADDR;
+pub const __NDUSEROPT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__NDUSEROPT_MAX;
+pub const TCA_ROOT_UNSPEC: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_UNSPEC;
+pub const TCA_ROOT_TAB: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TAB;
+pub const TCA_ROOT_FLAGS: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_FLAGS;
+pub const TCA_ROOT_COUNT: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_COUNT;
+pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TIME_DELTA;
+pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_EXT_WARN_MSG;
+pub const __TCA_ROOT_MAX: _bindgen_ty_67 = _bindgen_ty_67::__TCA_ROOT_MAX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1540,6 +1554,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1629,7 +1645,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1725,7 +1742,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1782,7 +1801,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1935,10 +1955,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_18 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_19 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -1954,7 +2002,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_19 {
+pub enum _bindgen_ty_20 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -1966,7 +2014,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_20 {
+pub enum _bindgen_ty_21 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -1974,7 +2022,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2007,7 +2055,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2021,7 +2070,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_23 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2051,7 +2108,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2062,7 +2119,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum _bindgen_ty_25 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2077,7 +2134,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2090,7 +2147,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2128,7 +2185,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2140,7 +2197,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2156,7 +2213,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2164,7 +2221,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2184,7 +2241,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2192,7 +2249,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2201,7 +2258,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2216,7 +2273,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2224,7 +2281,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2238,7 +2295,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2247,7 +2304,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2265,7 +2322,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2275,14 +2332,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2290,7 +2347,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2304,7 +2361,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2316,7 +2373,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2325,7 +2382,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2334,7 +2391,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2344,7 +2401,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2353,7 +2410,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2363,7 +2420,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2378,7 +2435,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2390,7 +2447,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2406,7 +2463,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2415,7 +2472,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2423,15 +2480,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFA_UNSPEC = 0,
 IFA_ADDRESS = 1,
 IFA_LOCAL = 2,
@@ -2449,7 +2506,7 @@ __IFA_MAX = 12,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 NDA_UNSPEC = 0,
 NDA_DST = 1,
 NDA_LLADDR = 2,
@@ -2473,7 +2530,7 @@ __NDA_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 NDTPA_UNSPEC = 0,
 NDTPA_IFINDEX = 1,
 NDTPA_REFCNT = 2,
@@ -2499,7 +2556,7 @@ __NDTPA_MAX = 20,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_57 {
+pub enum _bindgen_ty_58 {
 NDTA_UNSPEC = 0,
 NDTA_NAME = 1,
 NDTA_THRESH1 = 2,
@@ -2515,14 +2572,14 @@ __NDTA_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_58 {
+pub enum _bindgen_ty_59 {
 FDB_NOTIFY_BIT = 1,
 FDB_NOTIFY_INACTIVE_BIT = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_59 {
+pub enum _bindgen_ty_60 {
 NFEA_UNSPEC = 0,
 NFEA_ACTIVITY_NOTIFY = 1,
 NFEA_DONT_REFRESH = 2,
@@ -2531,7 +2588,7 @@ __NFEA_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_60 {
+pub enum _bindgen_ty_61 {
 RTM_BASE = 16,
 RTM_DELLINK = 17,
 RTM_GETLINK = 18,
@@ -2608,7 +2665,7 @@ __RTM_MAX = 123,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_61 {
+pub enum _bindgen_ty_62 {
 RTN_UNSPEC = 0,
 RTN_UNICAST = 1,
 RTN_LOCAL = 2,
@@ -2684,7 +2741,7 @@ __RTA_MAX = 31,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_62 {
+pub enum _bindgen_ty_63 {
 RTAX_UNSPEC = 0,
 RTAX_LOCK = 1,
 RTAX_MTU = 2,
@@ -2708,7 +2765,7 @@ __RTAX_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_63 {
+pub enum _bindgen_ty_64 {
 PREFIX_UNSPEC = 0,
 PREFIX_ADDRESS = 1,
 PREFIX_CACHEINFO = 2,
@@ -2717,7 +2774,7 @@ __PREFIX_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_64 {
+pub enum _bindgen_ty_65 {
 TCA_UNSPEC = 0,
 TCA_KIND = 1,
 TCA_OPTIONS = 2,
@@ -2740,7 +2797,7 @@ __TCA_MAX = 17,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_65 {
+pub enum _bindgen_ty_66 {
 NDUSEROPT_UNSPEC = 0,
 NDUSEROPT_SRCADDR = 1,
 __NDUSEROPT_MAX = 2,
@@ -2791,7 +2848,7 @@ __RTNLGRP_MAX = 37,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_66 {
+pub enum _bindgen_ty_67 {
 TCA_ROOT_UNSPEC = 0,
 TCA_ROOT_TAB = 1,
 TCA_ROOT_FLAGS = 2,
@@ -2854,6 +2911,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/csky/prctl.rs
+++ b/src/csky/prctl.rs
@@ -216,6 +216,7 @@ pub const PR_SME_VL_LEN_MASK: u32 = 65535;
 pub const PR_SME_VL_INHERIT: u32 = 131072;
 pub const PR_SET_MDWE: u32 = 65;
 pub const PR_MDWE_REFUSE_EXEC_GAIN: u32 = 1;
+pub const PR_MDWE_NO_INHERIT: u32 = 2;
 pub const PR_GET_MDWE: u32 = 66;
 pub const PR_SET_VMA: u32 = 1398164801;
 pub const PR_SET_VMA_ANON_NAME: u32 = 0;

--- a/src/csky/xdp.rs
+++ b/src/csky/xdp.rs
@@ -81,6 +81,7 @@ pub len: __u64,
 pub chunk_size: __u32,
 pub headroom: __u32,
 pub flags: __u32,
+pub tx_metadata_len: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -96,6 +97,23 @@ pub tx_ring_empty_descs: __u64,
 #[derive(Debug, Copy, Clone)]
 pub struct xdp_options {
 pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct xsk_tx_metadata {
+pub flags: __u64,
+pub __bindgen_anon_1: xsk_tx_metadata__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1 {
+pub csum_start: __u16,
+pub csum_offset: __u16,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2 {
+pub tx_timestamp: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -138,7 +156,9 @@ pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
 pub const XDP_USE_NEED_WAKEUP: u32 = 8;
+pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
+pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;
@@ -155,5 +175,13 @@ pub const XDP_UMEM_PGOFF_FILL_RING: u64 = 4294967296;
 pub const XDP_UMEM_PGOFF_COMPLETION_RING: u64 = 6442450944;
 pub const XSK_UNALIGNED_BUF_OFFSET_SHIFT: u32 = 48;
 pub const XSK_UNALIGNED_BUF_ADDR_MASK: u64 = 281474976710655;
-pub const XDP_USE_SG: u32 = 16;
+pub const XDP_TXMD_FLAGS_TIMESTAMP: u32 = 1;
+pub const XDP_TXMD_FLAGS_CHECKSUM: u32 = 2;
 pub const XDP_PKT_CONTD: u32 = 1;
+pub const XDP_TX_METADATA: u32 = 2;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union xsk_tx_metadata__bindgen_ty_1 {
+pub request: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1,
+pub completion: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2,
+}

--- a/src/loongarch64/general.rs
+++ b/src/loongarch64/general.rs
@@ -183,7 +183,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -238,6 +239,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -296,6 +330,29 @@ pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
 pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -390,36 +447,6 @@ pub it_value: __kernel_old_timeval,
 pub struct __kernel_sock_timeval {
 pub tv_sec: __s64,
 pub tv_usec: __s64,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timespec {
-pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: crate::ctypes::c_long,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timeval {
-pub tv_sec: __kernel_old_time_t,
-pub tv_usec: __kernel_suseconds_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerspec {
-pub it_interval: timespec,
-pub it_value: timespec,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerval {
-pub it_interval: timeval,
-pub it_value: timeval,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timezone {
-pub tz_minuteswest: crate::ctypes::c_int,
-pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -672,6 +699,36 @@ pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct timespec {
+pub tv_sec: __kernel_old_time_t,
+pub tv_nsec: crate::ctypes::c_long,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timeval {
+pub tv_sec: __kernel_old_time_t,
+pub tv_usec: __kernel_suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerspec {
+pub it_interval: timespec,
+pub it_value: timespec,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerval {
+pub it_interval: timeval,
+pub it_value: timeval,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timezone {
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct iovec {
 pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
@@ -765,6 +822,22 @@ pub struct uffdio_continue {
 pub range: uffdio_range,
 pub mode: __u64,
 pub mapped: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_poison {
+pub range: uffdio_range,
+pub mode: __u64,
+pub updated: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_move {
+pub dst: __u64,
+pub src: __u64,
+pub len: __u64,
+pub mode: __u64,
+pub move_: __s64,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -869,9 +942,9 @@ pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 394496;
+pub const LINUX_VERSION_CODE: u32 = 395264;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 5;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_VECTOR_SIZE_ARCH: u32 = 1;
@@ -1240,6 +1313,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1311,6 +1392,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const FUTEX_WAIT: u32 = 0;
 pub const FUTEX_WAKE: u32 = 1;
 pub const FUTEX_FD: u32 = 2;
@@ -1341,6 +1432,13 @@ pub const FUTEX_WAIT_BITSET_PRIVATE: u32 = 137;
 pub const FUTEX_WAKE_BITSET_PRIVATE: u32 = 138;
 pub const FUTEX_WAIT_REQUEUE_PI_PRIVATE: u32 = 139;
 pub const FUTEX_CMP_REQUEUE_PI_PRIVATE: u32 = 140;
+pub const FUTEX2_SIZE_U8: u32 = 0;
+pub const FUTEX2_SIZE_U16: u32 = 1;
+pub const FUTEX2_SIZE_U32: u32 = 2;
+pub const FUTEX2_SIZE_U64: u32 = 3;
+pub const FUTEX2_NUMA: u32 = 4;
+pub const FUTEX2_PRIVATE: u32 = 128;
+pub const FUTEX2_SIZE_MASK: u32 = 3;
 pub const FUTEX_32: u32 = 2;
 pub const FUTEX_WAITV_MAX: u32 = 128;
 pub const FUTEX_WAITERS: u32 = 2147483648;
@@ -1597,25 +1695,6 @@ pub const LINUX_REBOOT_CMD_POWER_OFF: u32 = 1126301404;
 pub const LINUX_REBOOT_CMD_RESTART2: u32 = 2712847316;
 pub const LINUX_REBOOT_CMD_SW_SUSPEND: u32 = 3489725666;
 pub const LINUX_REBOOT_CMD_KEXEC: u32 = 1163412803;
-pub const ITIMER_REAL: u32 = 0;
-pub const ITIMER_VIRTUAL: u32 = 1;
-pub const ITIMER_PROF: u32 = 2;
-pub const CLOCK_REALTIME: u32 = 0;
-pub const CLOCK_MONOTONIC: u32 = 1;
-pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
-pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
-pub const CLOCK_MONOTONIC_RAW: u32 = 4;
-pub const CLOCK_REALTIME_COARSE: u32 = 5;
-pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
-pub const CLOCK_BOOTTIME: u32 = 7;
-pub const CLOCK_REALTIME_ALARM: u32 = 8;
-pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
-pub const CLOCK_SGI_CYCLE: u32 = 10;
-pub const CLOCK_TAI: u32 = 11;
-pub const MAX_CLOCKS: u32 = 16;
-pub const CLOCKS_MASK: u32 = 1;
-pub const CLOCKS_MONO: u32 = 1;
-pub const TIMER_ABSTIME: u32 = 1;
 pub const RUSAGE_SELF: u32 = 0;
 pub const RUSAGE_CHILDREN: i32 = -1;
 pub const RUSAGE_BOTH: i32 = -2;
@@ -1795,7 +1874,8 @@ pub const SEGV_ADIDERR: u32 = 6;
 pub const SEGV_ADIPERR: u32 = 7;
 pub const SEGV_MTEAERR: u32 = 8;
 pub const SEGV_MTESERR: u32 = 9;
-pub const NSIGSEGV: u32 = 9;
+pub const SEGV_CPERR: u32 = 10;
+pub const NSIGSEGV: u32 = 10;
 pub const BUS_ADRALN: u32 = 1;
 pub const BUS_ADRERR: u32 = 2;
 pub const BUS_OBJERR: u32 = 3;
@@ -1876,6 +1956,7 @@ pub const STATX_BASIC_STATS: u32 = 2047;
 pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
+pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2053,6 +2134,25 @@ pub const TIOCM_RI: u32 = 128;
 pub const TIOCM_OUT1: u32 = 8192;
 pub const TIOCM_OUT2: u32 = 16384;
 pub const TIOCM_LOOP: u32 = 32768;
+pub const ITIMER_REAL: u32 = 0;
+pub const ITIMER_VIRTUAL: u32 = 1;
+pub const ITIMER_PROF: u32 = 2;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_SGI_CYCLE: u32 = 10;
+pub const CLOCK_TAI: u32 = 11;
+pub const MAX_CLOCKS: u32 = 16;
+pub const CLOCKS_MASK: u32 = 1;
+pub const CLOCKS_MONO: u32 = 1;
+pub const TIMER_ABSTIME: u32 = 1;
 pub const UIO_FASTIOV: u32 = 8;
 pub const UIO_MAXIOV: u32 = 1024;
 pub const __NR_io_setup: u32 = 0;
@@ -2357,7 +2457,17 @@ pub const __NR_process_mrelease: u32 = 448;
 pub const __NR_futex_waitv: u32 = 449;
 pub const __NR_set_mempolicy_home_node: u32 = 450;
 pub const __NR_cachestat: u32 = 451;
-pub const __NR_syscalls: u32 = 452;
+pub const __NR_fchmodat2: u32 = 452;
+pub const __NR_map_shadow_stack: u32 = 453;
+pub const __NR_futex_wake: u32 = 454;
+pub const __NR_futex_wait: u32 = 455;
+pub const __NR_futex_requeue: u32 = 456;
+pub const __NR_statmount: u32 = 457;
+pub const __NR_listmount: u32 = 458;
+pub const __NR_lsm_get_self_attr: u32 = 459;
+pub const __NR_lsm_set_self_attr: u32 = 460;
+pub const __NR_lsm_list_modules: u32 = 461;
+pub const __NR_syscalls: u32 = 462;
 pub const __NR_fcntl: u32 = 25;
 pub const __NR_statfs: u32 = 43;
 pub const __NR_fstatfs: u32 = 44;
@@ -2445,8 +2555,10 @@ pub const _UFFDIO_UNREGISTER: u32 = 1;
 pub const _UFFDIO_WAKE: u32 = 2;
 pub const _UFFDIO_COPY: u32 = 3;
 pub const _UFFDIO_ZEROPAGE: u32 = 4;
+pub const _UFFDIO_MOVE: u32 = 5;
 pub const _UFFDIO_WRITEPROTECT: u32 = 6;
 pub const _UFFDIO_CONTINUE: u32 = 7;
+pub const _UFFDIO_POISON: u32 = 8;
 pub const _UFFDIO_API: u32 = 63;
 pub const UFFDIO: u32 = 170;
 pub const UFFD_EVENT_PAGEFAULT: u32 = 18;
@@ -2471,6 +2583,9 @@ pub const UFFD_FEATURE_MINOR_SHMEM: u32 = 1024;
 pub const UFFD_FEATURE_EXACT_ADDRESS: u32 = 2048;
 pub const UFFD_FEATURE_WP_HUGETLBFS_SHMEM: u32 = 4096;
 pub const UFFD_FEATURE_WP_UNPOPULATED: u32 = 8192;
+pub const UFFD_FEATURE_POISON: u32 = 16384;
+pub const UFFD_FEATURE_WP_ASYNC: u32 = 32768;
+pub const UFFD_FEATURE_MOVE: u32 = 65536;
 pub const UFFD_USER_MODE_ONLY: u32 = 1;
 pub const DT_UNKNOWN: u32 = 0;
 pub const DT_FIFO: u32 = 1;
@@ -2545,6 +2660,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/loongarch64/if_arp.rs
+++ b/src/loongarch64/if_arp.rs
@@ -52,11 +52,6 @@ pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
@@ -175,6 +170,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -182,23 +178,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -1126,6 +1107,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_4 = _bindgen_ty_4::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_4 = _bindgen_ty_4::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_MASK;
@@ -1194,6 +1176,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_HAIRPIN;
@@ -1241,6 +1225,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_10 = _bindgen_ty_10::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_KIND;
@@ -1302,301 +1287,310 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_19 = _bindgen_ty_19::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_40 = _bindgen_ty_40::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_46 = _bindgen_ty_46::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_DSA_MAX;
-pub const IF_PORT_UNKNOWN: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_UNKNOWN;
-pub const IF_PORT_10BASE2: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASE2;
-pub const IF_PORT_10BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASET;
-pub const IF_PORT_AUI: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_AUI;
-pub const IF_PORT_100BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASET;
-pub const IF_PORT_100BASETX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASETX;
-pub const IF_PORT_100BASEFX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASEFX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_20 = _bindgen_ty_20::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_23 = _bindgen_ty_23::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_47 = _bindgen_ty_47::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__IFLA_DSA_MAX;
+pub const IF_PORT_UNKNOWN: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_UNKNOWN;
+pub const IF_PORT_10BASE2: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASE2;
+pub const IF_PORT_10BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASET;
+pub const IF_PORT_AUI: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_AUI;
+pub const IF_PORT_100BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASET;
+pub const IF_PORT_100BASETX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASETX;
+pub const IF_PORT_100BASEFX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASEFX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1699,6 +1693,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1788,7 +1784,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1884,7 +1881,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1941,7 +1940,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2094,10 +2094,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_20 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_21 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -2113,7 +2141,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -2125,7 +2153,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum _bindgen_ty_23 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -2133,7 +2161,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2166,7 +2194,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2180,7 +2209,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_25 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2210,7 +2247,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2221,7 +2258,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2236,7 +2273,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2249,7 +2286,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2287,7 +2324,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2299,7 +2336,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2315,7 +2352,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2323,7 +2360,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2343,7 +2380,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2351,7 +2388,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2360,7 +2397,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2375,7 +2412,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2383,7 +2420,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2397,7 +2434,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2406,7 +2443,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2424,7 +2461,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2434,14 +2471,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2449,7 +2486,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2463,7 +2500,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2475,7 +2512,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2484,7 +2521,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2493,7 +2530,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2503,7 +2540,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2512,7 +2549,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2522,7 +2559,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2537,7 +2574,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2549,7 +2586,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2565,7 +2602,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2574,7 +2611,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2582,15 +2619,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 IF_PORT_UNKNOWN = 0,
 IF_PORT_10BASE2 = 1,
 IF_PORT_10BASET = 2,
@@ -2673,74 +2710,6 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 impl nlmsgerr_attrs {
 pub const NLMSGERR_ATTR_MAX: nlmsgerr_attrs = nlmsgerr_attrs::NLMSGERR_ATTR_MISS_NEST;
 }
@@ -2755,6 +2724,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/loongarch64/if_packet.rs
+++ b/src/loongarch64/if_packet.rs
@@ -51,11 +51,6 @@ pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_pkt {
 pub spkt_family: crate::ctypes::c_ushort,
@@ -63,6 +58,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -70,23 +66,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -327,71 +308,3 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}

--- a/src/loongarch64/io_uring.rs
+++ b/src/loongarch64/io_uring.rs
@@ -79,7 +79,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -134,6 +135,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -195,6 +229,29 @@ pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
 pub tv_nsec: crate::ctypes::c_longlong,
@@ -253,6 +310,12 @@ pub __pad1: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_sqe__bindgen_ty_2__bindgen_ty_1 {
+pub level: __u32,
+pub optname: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_sqe__bindgen_ty_5__bindgen_ty_1 {
 pub addr_len: __u16,
 pub __pad3: [__u16; 1usize],
@@ -260,6 +323,7 @@ pub __pad3: [__u16; 1usize],
 #[repr(C)]
 pub struct io_uring_sqe__bindgen_ty_6 {
 pub __bindgen_anon_1: __BindgenUnionField<io_uring_sqe__bindgen_ty_6__bindgen_ty_1>,
+pub optval: __BindgenUnionField<__u64>,
 pub cmd: __BindgenUnionField<[__u8; 0usize]>,
 pub bindgen_union_field: [u64; 2usize],
 }
@@ -421,6 +485,13 @@ pub resv: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_buf_status {
+pub buf_group: __u32,
+pub head: __u32,
+pub resv: [__u32; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -434,7 +505,9 @@ pub addr: __u64,
 pub fd: __s32,
 pub flags: __u32,
 pub timeout: __kernel_timespec,
-pub pad: [__u64; 4usize],
+pub opcode: __u8,
+pub pad: [__u8; 7usize],
+pub pad2: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -597,6 +670,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -668,6 +749,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const IORING_FILE_INDEX_ALLOC: i32 = -1;
 pub const IORING_SETUP_IOPOLL: u32 = 1;
 pub const IORING_SETUP_SQPOLL: u32 = 2;
@@ -685,8 +776,9 @@ pub const IORING_SETUP_SINGLE_ISSUER: u32 = 4096;
 pub const IORING_SETUP_DEFER_TASKRUN: u32 = 8192;
 pub const IORING_SETUP_NO_MMAP: u32 = 16384;
 pub const IORING_SETUP_REGISTERED_FD_ONLY: u32 = 32768;
+pub const IORING_SETUP_NO_SQARRAY: u32 = 65536;
 pub const IORING_URING_CMD_FIXED: u32 = 1;
-pub const IORING_URING_CMD_POLLED: u32 = 2147483648;
+pub const IORING_URING_CMD_MASK: u32 = 1;
 pub const IORING_FSYNC_DATASYNC: u32 = 1;
 pub const IORING_TIMEOUT_ABS: u32 = 1;
 pub const IORING_TIMEOUT_UPDATE: u32 = 2;
@@ -706,6 +798,8 @@ pub const IORING_ASYNC_CANCEL_ALL: u32 = 1;
 pub const IORING_ASYNC_CANCEL_FD: u32 = 2;
 pub const IORING_ASYNC_CANCEL_ANY: u32 = 4;
 pub const IORING_ASYNC_CANCEL_FD_FIXED: u32 = 8;
+pub const IORING_ASYNC_CANCEL_USERDATA: u32 = 16;
+pub const IORING_ASYNC_CANCEL_OP: u32 = 32;
 pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
@@ -714,6 +808,7 @@ pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
+pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
@@ -786,6 +881,7 @@ pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGIS
 pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
 pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
 pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
+pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
 pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
 pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
 pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
@@ -796,6 +892,10 @@ pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTR
 pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
 pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
 pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
+pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
+pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
+pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
+pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -808,6 +908,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -874,7 +975,13 @@ IORING_OP_SOCKET = 45,
 IORING_OP_URING_CMD = 46,
 IORING_OP_SEND_ZC = 47,
 IORING_OP_SENDMSG_ZC = 48,
-IORING_OP_LAST = 49,
+IORING_OP_READ_MULTISHOT = 49,
+IORING_OP_WAITID = 50,
+IORING_OP_FUTEX_WAIT = 51,
+IORING_OP_FUTEX_WAKE = 52,
+IORING_OP_FUTEX_WAITV = 53,
+IORING_OP_FIXED_FD_INSTALL = 54,
+IORING_OP_LAST = 55,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -919,7 +1026,8 @@ IORING_REGISTER_PBUF_RING = 22,
 IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
-IORING_REGISTER_LAST = 26,
+IORING_REGISTER_PBUF_STATUS = 26,
+IORING_REGISTER_LAST = 27,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
@@ -944,6 +1052,15 @@ IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
 IORING_RESTRICTION_SQE_FLAGS_REQUIRED = 3,
 IORING_RESTRICTION_LAST = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_8 {
+SOCKET_URING_OP_SIOCINQ = 0,
+SOCKET_URING_OP_SIOCOUTQ = 1,
+SOCKET_URING_OP_GETSOCKOPT = 2,
+SOCKET_URING_OP_SETSOCKOPT = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -971,6 +1088,7 @@ pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_1__bindgen_ty_1,
 pub union io_uring_sqe__bindgen_ty_2 {
 pub addr: __u64,
 pub splice_off_in: __u64,
+pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_2__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -994,6 +1112,9 @@ pub hardlink_flags: __u32,
 pub xattr_flags: __u32,
 pub msg_ring_flags: __u32,
 pub uring_cmd_flags: __u32,
+pub waitid_flags: __u32,
+pub futex_flags: __u32,
+pub install_fd_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]
@@ -1006,6 +1127,7 @@ pub buf_group: __u16,
 pub union io_uring_sqe__bindgen_ty_5 {
 pub splice_fd_in: __s32,
 pub file_index: __u32,
+pub optlen: __u32,
 pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]

--- a/src/loongarch64/net.rs
+++ b/src/loongarch64/net.rs
@@ -429,6 +429,9 @@ pub tcpi_rcv_ooopack: __u32,
 pub tcpi_snd_wnd: __u32,
 pub tcpi_rcv_wnd: __u32,
 pub tcpi_rehash: __u32,
+pub tcpi_total_rto: __u16,
+pub tcpi_total_rto_recoveries: __u16,
+pub tcpi_total_rto_time: __u32,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -448,6 +451,80 @@ pub tcpm_prefixlen: __u8,
 pub tcpm_keylen: __u16,
 pub tcpm_addr: [__be32; 4usize],
 pub tcpm_key: [__u8; 80usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_add {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub key: [__u8; 80usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_del {
+pub addr: __kernel_sockaddr_storage,
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub current_key: __u8,
+pub rnext: __u8,
+pub keyflags: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_info_opt {
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub current_key: __u8,
+pub rnext: __u8,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+pub pkt_key_not_found: __u64,
+pub pkt_ao_required: __u64,
+pub pkt_dropped_icmp: __u64,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_getsockopt {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub key: [__u8; 80usize],
+pub nkeys: __u32,
+pub _bitfield_align_1: [u16; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub prefix: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub ifindex: __s32,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_repair {
+pub snt_isn: __be32,
+pub rcv_isn: __be32,
+pub snd_sne: __u32,
+pub rcv_sne: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1185,6 +1262,11 @@ pub const TCP_ZEROCOPY_RECEIVE: u32 = 35;
 pub const TCP_INQ: u32 = 36;
 pub const TCP_CM_INQ: u32 = 36;
 pub const TCP_TX_DELAY: u32 = 37;
+pub const TCP_AO_ADD_KEY: u32 = 38;
+pub const TCP_AO_DEL_KEY: u32 = 39;
+pub const TCP_AO_INFO: u32 = 40;
+pub const TCP_AO_GET_KEYS: u32 = 41;
+pub const TCP_AO_REPAIR: u32 = 42;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1194,9 +1276,13 @@ pub const TCPI_OPT_WSCALE: u32 = 4;
 pub const TCPI_OPT_ECN: u32 = 8;
 pub const TCPI_OPT_ECN_SEEN: u32 = 16;
 pub const TCPI_OPT_SYN_DATA: u32 = 32;
+pub const TCPI_OPT_USEC_TS: u32 = 64;
 pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
+pub const TCP_AO_MAXKEYLEN: u32 = 80;
+pub const TCP_AO_KEYF_IFINDEX: u32 = 1;
+pub const TCP_AO_KEYF_EXCLUDE_OPT: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
@@ -1561,6 +1647,7 @@ pub const DEVCONF_IOAM6_ID: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID;
 pub const DEVCONF_IOAM6_ID_WIDE: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID_WIDE;
 pub const DEVCONF_NDISC_EVICT_NOCARRIER: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_NDISC_EVICT_NOCARRIER;
 pub const DEVCONF_ACCEPT_UNTRACKED_NA: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_UNTRACKED_NA;
+pub const DEVCONF_ACCEPT_RA_MIN_LFT: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_RA_MIN_LFT;
 pub const DEVCONF_MAX: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_MAX;
 pub const TCP_FLAG_CWR: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_CWR;
 pub const TCP_FLAG_ECE: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_ECE;
@@ -1758,7 +1845,8 @@ DEVCONF_IOAM6_ID = 54,
 DEVCONF_IOAM6_ID_WIDE = 55,
 DEVCONF_NDISC_EVICT_NOCARRIER = 56,
 DEVCONF_ACCEPT_UNTRACKED_NA = 57,
-DEVCONF_MAX = 58,
+DEVCONF_ACCEPT_RA_MIN_LFT = 58,
+DEVCONF_MAX = 59,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2476,6 +2564,289 @@ tcpi_delivery_rate_app_limited as u64
 __bindgen_bitfield_unit.set(9usize, 2u8, {
 let tcpi_fastopen_client_fail: u8 = unsafe { ::core::mem::transmute(tcpi_fastopen_client_fail) };
 tcpi_fastopen_client_fail as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_add {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 30u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 30u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_del {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn del_async(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_del_async(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 29u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 29u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, del_async: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let del_async: u32 = unsafe { ::core::mem::transmute(del_async) };
+del_async as u64
+});
+__bindgen_bitfield_unit.set(3usize, 29u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_info_opt {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn ao_required(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_ao_required(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_counters(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_counters(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn accept_icmps(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_accept_icmps(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(4usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(5usize, 27u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(5usize, 27u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, ao_required: __u32, set_counters: __u32, accept_icmps: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let ao_required: u32 = unsafe { ::core::mem::transmute(ao_required) };
+ao_required as u64
+});
+__bindgen_bitfield_unit.set(3usize, 1u8, {
+let set_counters: u32 = unsafe { ::core::mem::transmute(set_counters) };
+set_counters as u64
+});
+__bindgen_bitfield_unit.set(4usize, 1u8, {
+let accept_icmps: u32 = unsafe { ::core::mem::transmute(accept_icmps) };
+accept_icmps as u64
+});
+__bindgen_bitfield_unit.set(5usize, 27u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_getsockopt {
+#[inline]
+pub fn is_current(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_current(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn is_rnext(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_rnext(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn get_all(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_get_all(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 13u8) as u16) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 13u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(is_current: __u16, is_rnext: __u16, get_all: __u16, reserved: __u16) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let is_current: u16 = unsafe { ::core::mem::transmute(is_current) };
+is_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let is_rnext: u16 = unsafe { ::core::mem::transmute(is_rnext) };
+is_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let get_all: u16 = unsafe { ::core::mem::transmute(get_all) };
+get_all as u64
+});
+__bindgen_bitfield_unit.set(3usize, 13u8, {
+let reserved: u16 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
 });
 __bindgen_bitfield_unit
 }

--- a/src/loongarch64/netlink.rs
+++ b/src/loongarch64/netlink.rs
@@ -724,7 +724,8 @@ pub const RTAX_FEATURE_ECN: u32 = 1;
 pub const RTAX_FEATURE_SACK: u32 = 2;
 pub const RTAX_FEATURE_TIMESTAMP: u32 = 4;
 pub const RTAX_FEATURE_ALLFRAG: u32 = 8;
-pub const RTAX_FEATURE_MASK: u32 = 15;
+pub const RTAX_FEATURE_TCP_USEC_TS: u32 = 16;
+pub const RTAX_FEATURE_MASK: u32 = 31;
 pub const TCM_IFINDEX_MAGIC_BLOCK: u32 = 4294967295;
 pub const TCA_DUMP_FLAGS_TERSE: u32 = 1;
 pub const RTMGRP_LINK: u32 = 1;
@@ -821,6 +822,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_2 = _bindgen_ty_2::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_2 = _bindgen_ty_2::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_MASK;
@@ -889,6 +891,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_6 = _bindgen_ty_6::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_HAIRPIN;
@@ -936,6 +940,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_KIND;
@@ -997,501 +1002,510 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_17 = _bindgen_ty_17::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_18 = _bindgen_ty_18::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_21 = _bindgen_ty_21::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_44 = _bindgen_ty_44::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_DSA_MAX;
-pub const IFA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFA_UNSPEC;
-pub const IFA_ADDRESS: _bindgen_ty_54 = _bindgen_ty_54::IFA_ADDRESS;
-pub const IFA_LOCAL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LOCAL;
-pub const IFA_LABEL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LABEL;
-pub const IFA_BROADCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_BROADCAST;
-pub const IFA_ANYCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_ANYCAST;
-pub const IFA_CACHEINFO: _bindgen_ty_54 = _bindgen_ty_54::IFA_CACHEINFO;
-pub const IFA_MULTICAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_MULTICAST;
-pub const IFA_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFA_FLAGS;
-pub const IFA_RT_PRIORITY: _bindgen_ty_54 = _bindgen_ty_54::IFA_RT_PRIORITY;
-pub const IFA_TARGET_NETNSID: _bindgen_ty_54 = _bindgen_ty_54::IFA_TARGET_NETNSID;
-pub const IFA_PROTO: _bindgen_ty_54 = _bindgen_ty_54::IFA_PROTO;
-pub const __IFA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFA_MAX;
-pub const NDA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::NDA_UNSPEC;
-pub const NDA_DST: _bindgen_ty_55 = _bindgen_ty_55::NDA_DST;
-pub const NDA_LLADDR: _bindgen_ty_55 = _bindgen_ty_55::NDA_LLADDR;
-pub const NDA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::NDA_CACHEINFO;
-pub const NDA_PROBES: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROBES;
-pub const NDA_VLAN: _bindgen_ty_55 = _bindgen_ty_55::NDA_VLAN;
-pub const NDA_PORT: _bindgen_ty_55 = _bindgen_ty_55::NDA_PORT;
-pub const NDA_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_VNI;
-pub const NDA_IFINDEX: _bindgen_ty_55 = _bindgen_ty_55::NDA_IFINDEX;
-pub const NDA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::NDA_MASTER;
-pub const NDA_LINK_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::NDA_LINK_NETNSID;
-pub const NDA_SRC_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_SRC_VNI;
-pub const NDA_PROTOCOL: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROTOCOL;
-pub const NDA_NH_ID: _bindgen_ty_55 = _bindgen_ty_55::NDA_NH_ID;
-pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_55 = _bindgen_ty_55::NDA_FDB_EXT_ATTRS;
-pub const NDA_FLAGS_EXT: _bindgen_ty_55 = _bindgen_ty_55::NDA_FLAGS_EXT;
-pub const NDA_NDM_STATE_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_STATE_MASK;
-pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_FLAGS_MASK;
-pub const __NDA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__NDA_MAX;
-pub const NDTPA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UNSPEC;
-pub const NDTPA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_IFINDEX;
-pub const NDTPA_REFCNT: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REFCNT;
-pub const NDTPA_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REACHABLE_TIME;
-pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_BASE_REACHABLE_TIME;
-pub const NDTPA_RETRANS_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_RETRANS_TIME;
-pub const NDTPA_GC_STALETIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_GC_STALETIME;
-pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_DELAY_PROBE_TIME;
-pub const NDTPA_QUEUE_LEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LEN;
-pub const NDTPA_APP_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_APP_PROBES;
-pub const NDTPA_UCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UCAST_PROBES;
-pub const NDTPA_MCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_PROBES;
-pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_ANYCAST_DELAY;
-pub const NDTPA_PROXY_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_DELAY;
-pub const NDTPA_PROXY_QLEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_QLEN;
-pub const NDTPA_LOCKTIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_LOCKTIME;
-pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LENBYTES;
-pub const NDTPA_MCAST_REPROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_REPROBES;
-pub const NDTPA_PAD: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PAD;
-pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_INTERVAL_PROBE_TIME_MS;
-pub const __NDTPA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDTPA_MAX;
-pub const NDTA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTA_UNSPEC;
-pub const NDTA_NAME: _bindgen_ty_57 = _bindgen_ty_57::NDTA_NAME;
-pub const NDTA_THRESH1: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH1;
-pub const NDTA_THRESH2: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH2;
-pub const NDTA_THRESH3: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH3;
-pub const NDTA_CONFIG: _bindgen_ty_57 = _bindgen_ty_57::NDTA_CONFIG;
-pub const NDTA_PARMS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PARMS;
-pub const NDTA_STATS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_STATS;
-pub const NDTA_GC_INTERVAL: _bindgen_ty_57 = _bindgen_ty_57::NDTA_GC_INTERVAL;
-pub const NDTA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PAD;
-pub const __NDTA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTA_MAX;
-pub const FDB_NOTIFY_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_BIT;
-pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_INACTIVE_BIT;
-pub const NFEA_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::NFEA_UNSPEC;
-pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_59 = _bindgen_ty_59::NFEA_ACTIVITY_NOTIFY;
-pub const NFEA_DONT_REFRESH: _bindgen_ty_59 = _bindgen_ty_59::NFEA_DONT_REFRESH;
-pub const __NFEA_MAX: _bindgen_ty_59 = _bindgen_ty_59::__NFEA_MAX;
-pub const RTM_BASE: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_NEWLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_DELLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINK;
-pub const RTM_GETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINK;
-pub const RTM_SETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETLINK;
-pub const RTM_NEWADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDR;
-pub const RTM_DELADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDR;
-pub const RTM_GETADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDR;
-pub const RTM_NEWROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWROUTE;
-pub const RTM_DELROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELROUTE;
-pub const RTM_GETROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETROUTE;
-pub const RTM_NEWNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGH;
-pub const RTM_DELNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEIGH;
-pub const RTM_GETNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGH;
-pub const RTM_NEWRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWRULE;
-pub const RTM_DELRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELRULE;
-pub const RTM_GETRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETRULE;
-pub const RTM_NEWQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWQDISC;
-pub const RTM_DELQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELQDISC;
-pub const RTM_GETQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETQDISC;
-pub const RTM_NEWTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTCLASS;
-pub const RTM_DELTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTCLASS;
-pub const RTM_GETTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTCLASS;
-pub const RTM_NEWTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTFILTER;
-pub const RTM_DELTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTFILTER;
-pub const RTM_GETTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTFILTER;
-pub const RTM_NEWACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWACTION;
-pub const RTM_DELACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELACTION;
-pub const RTM_GETACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETACTION;
-pub const RTM_NEWPREFIX: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWPREFIX;
-pub const RTM_GETMULTICAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMULTICAST;
-pub const RTM_GETANYCAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETANYCAST;
-pub const RTM_NEWNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGHTBL;
-pub const RTM_GETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGHTBL;
-pub const RTM_SETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETNEIGHTBL;
-pub const RTM_NEWNDUSEROPT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNDUSEROPT;
-pub const RTM_NEWADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDRLABEL;
-pub const RTM_DELADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDRLABEL;
-pub const RTM_GETADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDRLABEL;
-pub const RTM_GETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETDCB;
-pub const RTM_SETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETDCB;
-pub const RTM_NEWNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNETCONF;
-pub const RTM_DELNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNETCONF;
-pub const RTM_GETNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNETCONF;
-pub const RTM_NEWMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWMDB;
-pub const RTM_DELMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELMDB;
-pub const RTM_GETMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMDB;
-pub const RTM_NEWNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNSID;
-pub const RTM_DELNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNSID;
-pub const RTM_GETNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNSID;
-pub const RTM_NEWSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWSTATS;
-pub const RTM_GETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETSTATS;
-pub const RTM_SETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETSTATS;
-pub const RTM_NEWCACHEREPORT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCACHEREPORT;
-pub const RTM_NEWCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCHAIN;
-pub const RTM_DELCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELCHAIN;
-pub const RTM_GETCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETCHAIN;
-pub const RTM_NEWNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOP;
-pub const RTM_DELNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOP;
-pub const RTM_GETNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOP;
-pub const RTM_NEWLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWLINKPROP;
-pub const RTM_DELLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINKPROP;
-pub const RTM_GETLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINKPROP;
-pub const RTM_NEWVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWVLAN;
-pub const RTM_DELVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELVLAN;
-pub const RTM_GETVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETVLAN;
-pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOPBUCKET;
-pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOPBUCKET;
-pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOPBUCKET;
-pub const RTM_NEWTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTUNNEL;
-pub const RTM_DELTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTUNNEL;
-pub const RTM_GETTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTUNNEL;
-pub const __RTM_MAX: _bindgen_ty_60 = _bindgen_ty_60::__RTM_MAX;
-pub const RTN_UNSPEC: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNSPEC;
-pub const RTN_UNICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNICAST;
-pub const RTN_LOCAL: _bindgen_ty_61 = _bindgen_ty_61::RTN_LOCAL;
-pub const RTN_BROADCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_BROADCAST;
-pub const RTN_ANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_ANYCAST;
-pub const RTN_MULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_MULTICAST;
-pub const RTN_BLACKHOLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_BLACKHOLE;
-pub const RTN_UNREACHABLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNREACHABLE;
-pub const RTN_PROHIBIT: _bindgen_ty_61 = _bindgen_ty_61::RTN_PROHIBIT;
-pub const RTN_THROW: _bindgen_ty_61 = _bindgen_ty_61::RTN_THROW;
-pub const RTN_NAT: _bindgen_ty_61 = _bindgen_ty_61::RTN_NAT;
-pub const RTN_XRESOLVE: _bindgen_ty_61 = _bindgen_ty_61::RTN_XRESOLVE;
-pub const __RTN_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTN_MAX;
-pub const RTAX_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTAX_UNSPEC;
-pub const RTAX_LOCK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_LOCK;
-pub const RTAX_MTU: _bindgen_ty_62 = _bindgen_ty_62::RTAX_MTU;
-pub const RTAX_WINDOW: _bindgen_ty_62 = _bindgen_ty_62::RTAX_WINDOW;
-pub const RTAX_RTT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTT;
-pub const RTAX_RTTVAR: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTTVAR;
-pub const RTAX_SSTHRESH: _bindgen_ty_62 = _bindgen_ty_62::RTAX_SSTHRESH;
-pub const RTAX_CWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CWND;
-pub const RTAX_ADVMSS: _bindgen_ty_62 = _bindgen_ty_62::RTAX_ADVMSS;
-pub const RTAX_REORDERING: _bindgen_ty_62 = _bindgen_ty_62::RTAX_REORDERING;
-pub const RTAX_HOPLIMIT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_HOPLIMIT;
-pub const RTAX_INITCWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITCWND;
-pub const RTAX_FEATURES: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FEATURES;
-pub const RTAX_RTO_MIN: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTO_MIN;
-pub const RTAX_INITRWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITRWND;
-pub const RTAX_QUICKACK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_QUICKACK;
-pub const RTAX_CC_ALGO: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CC_ALGO;
-pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FASTOPEN_NO_COOKIE;
-pub const __RTAX_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTAX_MAX;
-pub const PREFIX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_UNSPEC;
-pub const PREFIX_ADDRESS: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_ADDRESS;
-pub const PREFIX_CACHEINFO: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_CACHEINFO;
-pub const __PREFIX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__PREFIX_MAX;
-pub const TCA_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::TCA_UNSPEC;
-pub const TCA_KIND: _bindgen_ty_64 = _bindgen_ty_64::TCA_KIND;
-pub const TCA_OPTIONS: _bindgen_ty_64 = _bindgen_ty_64::TCA_OPTIONS;
-pub const TCA_STATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS;
-pub const TCA_XSTATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_XSTATS;
-pub const TCA_RATE: _bindgen_ty_64 = _bindgen_ty_64::TCA_RATE;
-pub const TCA_FCNT: _bindgen_ty_64 = _bindgen_ty_64::TCA_FCNT;
-pub const TCA_STATS2: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS2;
-pub const TCA_STAB: _bindgen_ty_64 = _bindgen_ty_64::TCA_STAB;
-pub const TCA_PAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_PAD;
-pub const TCA_DUMP_INVISIBLE: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_INVISIBLE;
-pub const TCA_CHAIN: _bindgen_ty_64 = _bindgen_ty_64::TCA_CHAIN;
-pub const TCA_HW_OFFLOAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_HW_OFFLOAD;
-pub const TCA_INGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_INGRESS_BLOCK;
-pub const TCA_EGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_EGRESS_BLOCK;
-pub const TCA_DUMP_FLAGS: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_FLAGS;
-pub const TCA_EXT_WARN_MSG: _bindgen_ty_64 = _bindgen_ty_64::TCA_EXT_WARN_MSG;
-pub const __TCA_MAX: _bindgen_ty_64 = _bindgen_ty_64::__TCA_MAX;
-pub const NDUSEROPT_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_UNSPEC;
-pub const NDUSEROPT_SRCADDR: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_SRCADDR;
-pub const __NDUSEROPT_MAX: _bindgen_ty_65 = _bindgen_ty_65::__NDUSEROPT_MAX;
-pub const TCA_ROOT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_UNSPEC;
-pub const TCA_ROOT_TAB: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TAB;
-pub const TCA_ROOT_FLAGS: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_FLAGS;
-pub const TCA_ROOT_COUNT: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_COUNT;
-pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TIME_DELTA;
-pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_EXT_WARN_MSG;
-pub const __TCA_ROOT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__TCA_ROOT_MAX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_18 = _bindgen_ty_18::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_39 = _bindgen_ty_39::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_45 = _bindgen_ty_45::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_DSA_MAX;
+pub const IFA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFA_UNSPEC;
+pub const IFA_ADDRESS: _bindgen_ty_55 = _bindgen_ty_55::IFA_ADDRESS;
+pub const IFA_LOCAL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LOCAL;
+pub const IFA_LABEL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LABEL;
+pub const IFA_BROADCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_BROADCAST;
+pub const IFA_ANYCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_ANYCAST;
+pub const IFA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::IFA_CACHEINFO;
+pub const IFA_MULTICAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_MULTICAST;
+pub const IFA_FLAGS: _bindgen_ty_55 = _bindgen_ty_55::IFA_FLAGS;
+pub const IFA_RT_PRIORITY: _bindgen_ty_55 = _bindgen_ty_55::IFA_RT_PRIORITY;
+pub const IFA_TARGET_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::IFA_TARGET_NETNSID;
+pub const IFA_PROTO: _bindgen_ty_55 = _bindgen_ty_55::IFA_PROTO;
+pub const __IFA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFA_MAX;
+pub const NDA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDA_UNSPEC;
+pub const NDA_DST: _bindgen_ty_56 = _bindgen_ty_56::NDA_DST;
+pub const NDA_LLADDR: _bindgen_ty_56 = _bindgen_ty_56::NDA_LLADDR;
+pub const NDA_CACHEINFO: _bindgen_ty_56 = _bindgen_ty_56::NDA_CACHEINFO;
+pub const NDA_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROBES;
+pub const NDA_VLAN: _bindgen_ty_56 = _bindgen_ty_56::NDA_VLAN;
+pub const NDA_PORT: _bindgen_ty_56 = _bindgen_ty_56::NDA_PORT;
+pub const NDA_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_VNI;
+pub const NDA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDA_IFINDEX;
+pub const NDA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::NDA_MASTER;
+pub const NDA_LINK_NETNSID: _bindgen_ty_56 = _bindgen_ty_56::NDA_LINK_NETNSID;
+pub const NDA_SRC_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_SRC_VNI;
+pub const NDA_PROTOCOL: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROTOCOL;
+pub const NDA_NH_ID: _bindgen_ty_56 = _bindgen_ty_56::NDA_NH_ID;
+pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_56 = _bindgen_ty_56::NDA_FDB_EXT_ATTRS;
+pub const NDA_FLAGS_EXT: _bindgen_ty_56 = _bindgen_ty_56::NDA_FLAGS_EXT;
+pub const NDA_NDM_STATE_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_STATE_MASK;
+pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_FLAGS_MASK;
+pub const __NDA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDA_MAX;
+pub const NDTPA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UNSPEC;
+pub const NDTPA_IFINDEX: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_IFINDEX;
+pub const NDTPA_REFCNT: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REFCNT;
+pub const NDTPA_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REACHABLE_TIME;
+pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_BASE_REACHABLE_TIME;
+pub const NDTPA_RETRANS_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_RETRANS_TIME;
+pub const NDTPA_GC_STALETIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_GC_STALETIME;
+pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_DELAY_PROBE_TIME;
+pub const NDTPA_QUEUE_LEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LEN;
+pub const NDTPA_APP_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_APP_PROBES;
+pub const NDTPA_UCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UCAST_PROBES;
+pub const NDTPA_MCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_PROBES;
+pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_ANYCAST_DELAY;
+pub const NDTPA_PROXY_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_DELAY;
+pub const NDTPA_PROXY_QLEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_QLEN;
+pub const NDTPA_LOCKTIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_LOCKTIME;
+pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LENBYTES;
+pub const NDTPA_MCAST_REPROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_REPROBES;
+pub const NDTPA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PAD;
+pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_INTERVAL_PROBE_TIME_MS;
+pub const __NDTPA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTPA_MAX;
+pub const NDTA_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDTA_UNSPEC;
+pub const NDTA_NAME: _bindgen_ty_58 = _bindgen_ty_58::NDTA_NAME;
+pub const NDTA_THRESH1: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH1;
+pub const NDTA_THRESH2: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH2;
+pub const NDTA_THRESH3: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH3;
+pub const NDTA_CONFIG: _bindgen_ty_58 = _bindgen_ty_58::NDTA_CONFIG;
+pub const NDTA_PARMS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PARMS;
+pub const NDTA_STATS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_STATS;
+pub const NDTA_GC_INTERVAL: _bindgen_ty_58 = _bindgen_ty_58::NDTA_GC_INTERVAL;
+pub const NDTA_PAD: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PAD;
+pub const __NDTA_MAX: _bindgen_ty_58 = _bindgen_ty_58::__NDTA_MAX;
+pub const FDB_NOTIFY_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_BIT;
+pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_INACTIVE_BIT;
+pub const NFEA_UNSPEC: _bindgen_ty_60 = _bindgen_ty_60::NFEA_UNSPEC;
+pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_60 = _bindgen_ty_60::NFEA_ACTIVITY_NOTIFY;
+pub const NFEA_DONT_REFRESH: _bindgen_ty_60 = _bindgen_ty_60::NFEA_DONT_REFRESH;
+pub const __NFEA_MAX: _bindgen_ty_60 = _bindgen_ty_60::__NFEA_MAX;
+pub const RTM_BASE: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_NEWLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_DELLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINK;
+pub const RTM_GETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINK;
+pub const RTM_SETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETLINK;
+pub const RTM_NEWADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDR;
+pub const RTM_DELADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDR;
+pub const RTM_GETADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDR;
+pub const RTM_NEWROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWROUTE;
+pub const RTM_DELROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELROUTE;
+pub const RTM_GETROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETROUTE;
+pub const RTM_NEWNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGH;
+pub const RTM_DELNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEIGH;
+pub const RTM_GETNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGH;
+pub const RTM_NEWRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWRULE;
+pub const RTM_DELRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELRULE;
+pub const RTM_GETRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETRULE;
+pub const RTM_NEWQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWQDISC;
+pub const RTM_DELQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELQDISC;
+pub const RTM_GETQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETQDISC;
+pub const RTM_NEWTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTCLASS;
+pub const RTM_DELTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTCLASS;
+pub const RTM_GETTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTCLASS;
+pub const RTM_NEWTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTFILTER;
+pub const RTM_DELTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTFILTER;
+pub const RTM_GETTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTFILTER;
+pub const RTM_NEWACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWACTION;
+pub const RTM_DELACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELACTION;
+pub const RTM_GETACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETACTION;
+pub const RTM_NEWPREFIX: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWPREFIX;
+pub const RTM_GETMULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMULTICAST;
+pub const RTM_GETANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETANYCAST;
+pub const RTM_NEWNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGHTBL;
+pub const RTM_GETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGHTBL;
+pub const RTM_SETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETNEIGHTBL;
+pub const RTM_NEWNDUSEROPT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNDUSEROPT;
+pub const RTM_NEWADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDRLABEL;
+pub const RTM_DELADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDRLABEL;
+pub const RTM_GETADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDRLABEL;
+pub const RTM_GETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETDCB;
+pub const RTM_SETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETDCB;
+pub const RTM_NEWNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNETCONF;
+pub const RTM_DELNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNETCONF;
+pub const RTM_GETNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNETCONF;
+pub const RTM_NEWMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWMDB;
+pub const RTM_DELMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELMDB;
+pub const RTM_GETMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMDB;
+pub const RTM_NEWNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNSID;
+pub const RTM_DELNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNSID;
+pub const RTM_GETNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNSID;
+pub const RTM_NEWSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWSTATS;
+pub const RTM_GETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETSTATS;
+pub const RTM_SETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETSTATS;
+pub const RTM_NEWCACHEREPORT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCACHEREPORT;
+pub const RTM_NEWCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCHAIN;
+pub const RTM_DELCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELCHAIN;
+pub const RTM_GETCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETCHAIN;
+pub const RTM_NEWNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOP;
+pub const RTM_DELNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOP;
+pub const RTM_GETNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOP;
+pub const RTM_NEWLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWLINKPROP;
+pub const RTM_DELLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINKPROP;
+pub const RTM_GETLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINKPROP;
+pub const RTM_NEWVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWVLAN;
+pub const RTM_DELVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELVLAN;
+pub const RTM_GETVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETVLAN;
+pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOPBUCKET;
+pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOPBUCKET;
+pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOPBUCKET;
+pub const RTM_NEWTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTUNNEL;
+pub const RTM_DELTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTUNNEL;
+pub const RTM_GETTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTUNNEL;
+pub const __RTM_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTM_MAX;
+pub const RTN_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNSPEC;
+pub const RTN_UNICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNICAST;
+pub const RTN_LOCAL: _bindgen_ty_62 = _bindgen_ty_62::RTN_LOCAL;
+pub const RTN_BROADCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_BROADCAST;
+pub const RTN_ANYCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_ANYCAST;
+pub const RTN_MULTICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_MULTICAST;
+pub const RTN_BLACKHOLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_BLACKHOLE;
+pub const RTN_UNREACHABLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNREACHABLE;
+pub const RTN_PROHIBIT: _bindgen_ty_62 = _bindgen_ty_62::RTN_PROHIBIT;
+pub const RTN_THROW: _bindgen_ty_62 = _bindgen_ty_62::RTN_THROW;
+pub const RTN_NAT: _bindgen_ty_62 = _bindgen_ty_62::RTN_NAT;
+pub const RTN_XRESOLVE: _bindgen_ty_62 = _bindgen_ty_62::RTN_XRESOLVE;
+pub const __RTN_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTN_MAX;
+pub const RTAX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::RTAX_UNSPEC;
+pub const RTAX_LOCK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_LOCK;
+pub const RTAX_MTU: _bindgen_ty_63 = _bindgen_ty_63::RTAX_MTU;
+pub const RTAX_WINDOW: _bindgen_ty_63 = _bindgen_ty_63::RTAX_WINDOW;
+pub const RTAX_RTT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTT;
+pub const RTAX_RTTVAR: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTTVAR;
+pub const RTAX_SSTHRESH: _bindgen_ty_63 = _bindgen_ty_63::RTAX_SSTHRESH;
+pub const RTAX_CWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CWND;
+pub const RTAX_ADVMSS: _bindgen_ty_63 = _bindgen_ty_63::RTAX_ADVMSS;
+pub const RTAX_REORDERING: _bindgen_ty_63 = _bindgen_ty_63::RTAX_REORDERING;
+pub const RTAX_HOPLIMIT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_HOPLIMIT;
+pub const RTAX_INITCWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITCWND;
+pub const RTAX_FEATURES: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FEATURES;
+pub const RTAX_RTO_MIN: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTO_MIN;
+pub const RTAX_INITRWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITRWND;
+pub const RTAX_QUICKACK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_QUICKACK;
+pub const RTAX_CC_ALGO: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CC_ALGO;
+pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FASTOPEN_NO_COOKIE;
+pub const __RTAX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__RTAX_MAX;
+pub const PREFIX_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_UNSPEC;
+pub const PREFIX_ADDRESS: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_ADDRESS;
+pub const PREFIX_CACHEINFO: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_CACHEINFO;
+pub const __PREFIX_MAX: _bindgen_ty_64 = _bindgen_ty_64::__PREFIX_MAX;
+pub const TCA_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::TCA_UNSPEC;
+pub const TCA_KIND: _bindgen_ty_65 = _bindgen_ty_65::TCA_KIND;
+pub const TCA_OPTIONS: _bindgen_ty_65 = _bindgen_ty_65::TCA_OPTIONS;
+pub const TCA_STATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS;
+pub const TCA_XSTATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_XSTATS;
+pub const TCA_RATE: _bindgen_ty_65 = _bindgen_ty_65::TCA_RATE;
+pub const TCA_FCNT: _bindgen_ty_65 = _bindgen_ty_65::TCA_FCNT;
+pub const TCA_STATS2: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS2;
+pub const TCA_STAB: _bindgen_ty_65 = _bindgen_ty_65::TCA_STAB;
+pub const TCA_PAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_PAD;
+pub const TCA_DUMP_INVISIBLE: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_INVISIBLE;
+pub const TCA_CHAIN: _bindgen_ty_65 = _bindgen_ty_65::TCA_CHAIN;
+pub const TCA_HW_OFFLOAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_HW_OFFLOAD;
+pub const TCA_INGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_INGRESS_BLOCK;
+pub const TCA_EGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_EGRESS_BLOCK;
+pub const TCA_DUMP_FLAGS: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_FLAGS;
+pub const TCA_EXT_WARN_MSG: _bindgen_ty_65 = _bindgen_ty_65::TCA_EXT_WARN_MSG;
+pub const __TCA_MAX: _bindgen_ty_65 = _bindgen_ty_65::__TCA_MAX;
+pub const NDUSEROPT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_UNSPEC;
+pub const NDUSEROPT_SRCADDR: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_SRCADDR;
+pub const __NDUSEROPT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__NDUSEROPT_MAX;
+pub const TCA_ROOT_UNSPEC: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_UNSPEC;
+pub const TCA_ROOT_TAB: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TAB;
+pub const TCA_ROOT_FLAGS: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_FLAGS;
+pub const TCA_ROOT_COUNT: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_COUNT;
+pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TIME_DELTA;
+pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_EXT_WARN_MSG;
+pub const __TCA_ROOT_MAX: _bindgen_ty_67 = _bindgen_ty_67::__TCA_ROOT_MAX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1542,6 +1556,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1631,7 +1647,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1727,7 +1744,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1784,7 +1803,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1937,10 +1957,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_18 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_19 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -1956,7 +2004,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_19 {
+pub enum _bindgen_ty_20 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -1968,7 +2016,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_20 {
+pub enum _bindgen_ty_21 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -1976,7 +2024,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2009,7 +2057,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2023,7 +2072,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_23 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2053,7 +2110,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2064,7 +2121,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum _bindgen_ty_25 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2079,7 +2136,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2092,7 +2149,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2130,7 +2187,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2142,7 +2199,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2158,7 +2215,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2166,7 +2223,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2186,7 +2243,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2194,7 +2251,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2203,7 +2260,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2218,7 +2275,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2226,7 +2283,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2240,7 +2297,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2249,7 +2306,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2267,7 +2324,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2277,14 +2334,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2292,7 +2349,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2306,7 +2363,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2318,7 +2375,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2327,7 +2384,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2336,7 +2393,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2346,7 +2403,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2355,7 +2412,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2365,7 +2422,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2380,7 +2437,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2392,7 +2449,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2408,7 +2465,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2417,7 +2474,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2425,15 +2482,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFA_UNSPEC = 0,
 IFA_ADDRESS = 1,
 IFA_LOCAL = 2,
@@ -2451,7 +2508,7 @@ __IFA_MAX = 12,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 NDA_UNSPEC = 0,
 NDA_DST = 1,
 NDA_LLADDR = 2,
@@ -2475,7 +2532,7 @@ __NDA_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 NDTPA_UNSPEC = 0,
 NDTPA_IFINDEX = 1,
 NDTPA_REFCNT = 2,
@@ -2501,7 +2558,7 @@ __NDTPA_MAX = 20,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_57 {
+pub enum _bindgen_ty_58 {
 NDTA_UNSPEC = 0,
 NDTA_NAME = 1,
 NDTA_THRESH1 = 2,
@@ -2517,14 +2574,14 @@ __NDTA_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_58 {
+pub enum _bindgen_ty_59 {
 FDB_NOTIFY_BIT = 1,
 FDB_NOTIFY_INACTIVE_BIT = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_59 {
+pub enum _bindgen_ty_60 {
 NFEA_UNSPEC = 0,
 NFEA_ACTIVITY_NOTIFY = 1,
 NFEA_DONT_REFRESH = 2,
@@ -2533,7 +2590,7 @@ __NFEA_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_60 {
+pub enum _bindgen_ty_61 {
 RTM_BASE = 16,
 RTM_DELLINK = 17,
 RTM_GETLINK = 18,
@@ -2610,7 +2667,7 @@ __RTM_MAX = 123,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_61 {
+pub enum _bindgen_ty_62 {
 RTN_UNSPEC = 0,
 RTN_UNICAST = 1,
 RTN_LOCAL = 2,
@@ -2686,7 +2743,7 @@ __RTA_MAX = 31,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_62 {
+pub enum _bindgen_ty_63 {
 RTAX_UNSPEC = 0,
 RTAX_LOCK = 1,
 RTAX_MTU = 2,
@@ -2710,7 +2767,7 @@ __RTAX_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_63 {
+pub enum _bindgen_ty_64 {
 PREFIX_UNSPEC = 0,
 PREFIX_ADDRESS = 1,
 PREFIX_CACHEINFO = 2,
@@ -2719,7 +2776,7 @@ __PREFIX_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_64 {
+pub enum _bindgen_ty_65 {
 TCA_UNSPEC = 0,
 TCA_KIND = 1,
 TCA_OPTIONS = 2,
@@ -2742,7 +2799,7 @@ __TCA_MAX = 17,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_65 {
+pub enum _bindgen_ty_66 {
 NDUSEROPT_UNSPEC = 0,
 NDUSEROPT_SRCADDR = 1,
 __NDUSEROPT_MAX = 2,
@@ -2793,7 +2850,7 @@ __RTNLGRP_MAX = 37,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_66 {
+pub enum _bindgen_ty_67 {
 TCA_ROOT_UNSPEC = 0,
 TCA_ROOT_TAB = 1,
 TCA_ROOT_FLAGS = 2,
@@ -2856,6 +2913,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/loongarch64/prctl.rs
+++ b/src/loongarch64/prctl.rs
@@ -218,6 +218,7 @@ pub const PR_SME_VL_LEN_MASK: u32 = 65535;
 pub const PR_SME_VL_INHERIT: u32 = 131072;
 pub const PR_SET_MDWE: u32 = 65;
 pub const PR_MDWE_REFUSE_EXEC_GAIN: u32 = 1;
+pub const PR_MDWE_NO_INHERIT: u32 = 2;
 pub const PR_GET_MDWE: u32 = 66;
 pub const PR_SET_VMA: u32 = 1398164801;
 pub const PR_SET_VMA_ANON_NAME: u32 = 0;

--- a/src/loongarch64/xdp.rs
+++ b/src/loongarch64/xdp.rs
@@ -83,6 +83,7 @@ pub len: __u64,
 pub chunk_size: __u32,
 pub headroom: __u32,
 pub flags: __u32,
+pub tx_metadata_len: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -98,6 +99,23 @@ pub tx_ring_empty_descs: __u64,
 #[derive(Debug, Copy, Clone)]
 pub struct xdp_options {
 pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct xsk_tx_metadata {
+pub flags: __u64,
+pub __bindgen_anon_1: xsk_tx_metadata__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1 {
+pub csum_start: __u16,
+pub csum_offset: __u16,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2 {
+pub tx_timestamp: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -140,7 +158,9 @@ pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
 pub const XDP_USE_NEED_WAKEUP: u32 = 8;
+pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
+pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;
@@ -157,5 +177,13 @@ pub const XDP_UMEM_PGOFF_FILL_RING: u64 = 4294967296;
 pub const XDP_UMEM_PGOFF_COMPLETION_RING: u64 = 6442450944;
 pub const XSK_UNALIGNED_BUF_OFFSET_SHIFT: u32 = 48;
 pub const XSK_UNALIGNED_BUF_ADDR_MASK: u64 = 281474976710655;
-pub const XDP_USE_SG: u32 = 16;
+pub const XDP_TXMD_FLAGS_TIMESTAMP: u32 = 1;
+pub const XDP_TXMD_FLAGS_CHECKSUM: u32 = 2;
 pub const XDP_PKT_CONTD: u32 = 1;
+pub const XDP_TX_METADATA: u32 = 2;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union xsk_tx_metadata__bindgen_ty_1 {
+pub request: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1,
+pub completion: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2,
+}

--- a/src/mips/general.rs
+++ b/src/mips/general.rs
@@ -184,7 +184,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -239,6 +240,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -297,6 +331,29 @@ pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
 pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -391,36 +448,6 @@ pub it_value: __kernel_old_timeval,
 pub struct __kernel_sock_timeval {
 pub tv_sec: __s64,
 pub tv_usec: __s64,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timespec {
-pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: crate::ctypes::c_long,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timeval {
-pub tv_sec: __kernel_old_time_t,
-pub tv_usec: __kernel_suseconds_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerspec {
-pub it_interval: timespec,
-pub it_value: timespec,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerval {
-pub it_interval: timeval,
-pub it_value: timeval,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timezone {
-pub tz_minuteswest: crate::ctypes::c_int,
-pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -702,6 +729,36 @@ pub c_cc: [crate::ctypes::c_uchar; 23usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct timespec {
+pub tv_sec: __kernel_old_time_t,
+pub tv_nsec: crate::ctypes::c_long,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timeval {
+pub tv_sec: __kernel_old_time_t,
+pub tv_usec: __kernel_suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerspec {
+pub it_interval: timespec,
+pub it_value: timespec,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerval {
+pub it_interval: timeval,
+pub it_value: timeval,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timezone {
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct iovec {
 pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
@@ -795,6 +852,22 @@ pub struct uffdio_continue {
 pub range: uffdio_range,
 pub mode: __u64,
 pub mapped: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_poison {
+pub range: uffdio_range,
+pub mode: __u64,
+pub updated: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_move {
+pub dst: __u64,
+pub src: __u64,
+pub len: __u64,
+pub mode: __u64,
+pub move_: __s64,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -907,9 +980,9 @@ pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 394496;
+pub const LINUX_VERSION_CODE: u32 = 395264;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 5;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_VECTOR_SIZE_ARCH: u32 = 1;
@@ -1291,6 +1364,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1362,6 +1443,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const FUTEX_WAIT: u32 = 0;
 pub const FUTEX_WAKE: u32 = 1;
 pub const FUTEX_FD: u32 = 2;
@@ -1392,6 +1483,13 @@ pub const FUTEX_WAIT_BITSET_PRIVATE: u32 = 137;
 pub const FUTEX_WAKE_BITSET_PRIVATE: u32 = 138;
 pub const FUTEX_WAIT_REQUEUE_PI_PRIVATE: u32 = 139;
 pub const FUTEX_CMP_REQUEUE_PI_PRIVATE: u32 = 140;
+pub const FUTEX2_SIZE_U8: u32 = 0;
+pub const FUTEX2_SIZE_U16: u32 = 1;
+pub const FUTEX2_SIZE_U32: u32 = 2;
+pub const FUTEX2_SIZE_U64: u32 = 3;
+pub const FUTEX2_NUMA: u32 = 4;
+pub const FUTEX2_PRIVATE: u32 = 128;
+pub const FUTEX2_SIZE_MASK: u32 = 3;
 pub const FUTEX_32: u32 = 2;
 pub const FUTEX_WAITV_MAX: u32 = 128;
 pub const FUTEX_WAITERS: u32 = 2147483648;
@@ -1648,25 +1746,6 @@ pub const LINUX_REBOOT_CMD_POWER_OFF: u32 = 1126301404;
 pub const LINUX_REBOOT_CMD_RESTART2: u32 = 2712847316;
 pub const LINUX_REBOOT_CMD_SW_SUSPEND: u32 = 3489725666;
 pub const LINUX_REBOOT_CMD_KEXEC: u32 = 1163412803;
-pub const ITIMER_REAL: u32 = 0;
-pub const ITIMER_VIRTUAL: u32 = 1;
-pub const ITIMER_PROF: u32 = 2;
-pub const CLOCK_REALTIME: u32 = 0;
-pub const CLOCK_MONOTONIC: u32 = 1;
-pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
-pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
-pub const CLOCK_MONOTONIC_RAW: u32 = 4;
-pub const CLOCK_REALTIME_COARSE: u32 = 5;
-pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
-pub const CLOCK_BOOTTIME: u32 = 7;
-pub const CLOCK_REALTIME_ALARM: u32 = 8;
-pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
-pub const CLOCK_SGI_CYCLE: u32 = 10;
-pub const CLOCK_TAI: u32 = 11;
-pub const MAX_CLOCKS: u32 = 16;
-pub const CLOCKS_MASK: u32 = 1;
-pub const CLOCKS_MONO: u32 = 1;
-pub const TIMER_ABSTIME: u32 = 1;
 pub const RUSAGE_SELF: u32 = 0;
 pub const RUSAGE_CHILDREN: i32 = -1;
 pub const RUSAGE_BOTH: i32 = -2;
@@ -1846,7 +1925,8 @@ pub const SEGV_ADIDERR: u32 = 6;
 pub const SEGV_ADIPERR: u32 = 7;
 pub const SEGV_MTEAERR: u32 = 8;
 pub const SEGV_MTESERR: u32 = 9;
-pub const NSIGSEGV: u32 = 9;
+pub const SEGV_CPERR: u32 = 10;
+pub const NSIGSEGV: u32 = 10;
 pub const BUS_ADRALN: u32 = 1;
 pub const BUS_ADRERR: u32 = 2;
 pub const BUS_OBJERR: u32 = 3;
@@ -1927,6 +2007,7 @@ pub const STATX_BASIC_STATS: u32 = 2047;
 pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
+pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2243,6 +2324,25 @@ pub const TIOCM_DSR: u32 = 1024;
 pub const TIOCM_OUT1: u32 = 8192;
 pub const TIOCM_OUT2: u32 = 16384;
 pub const TIOCM_LOOP: u32 = 32768;
+pub const ITIMER_REAL: u32 = 0;
+pub const ITIMER_VIRTUAL: u32 = 1;
+pub const ITIMER_PROF: u32 = 2;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_SGI_CYCLE: u32 = 10;
+pub const CLOCK_TAI: u32 = 11;
+pub const MAX_CLOCKS: u32 = 16;
+pub const CLOCKS_MASK: u32 = 1;
+pub const CLOCKS_MONO: u32 = 1;
+pub const TIMER_ABSTIME: u32 = 1;
 pub const UIO_FASTIOV: u32 = 8;
 pub const UIO_MAXIOV: u32 = 1024;
 pub const __NR_Linux: u32 = 4000;
@@ -2671,6 +2771,16 @@ pub const __NR_process_mrelease: u32 = 4448;
 pub const __NR_futex_waitv: u32 = 4449;
 pub const __NR_set_mempolicy_home_node: u32 = 4450;
 pub const __NR_cachestat: u32 = 4451;
+pub const __NR_fchmodat2: u32 = 4452;
+pub const __NR_map_shadow_stack: u32 = 4453;
+pub const __NR_futex_wake: u32 = 4454;
+pub const __NR_futex_wait: u32 = 4455;
+pub const __NR_futex_requeue: u32 = 4456;
+pub const __NR_statmount: u32 = 4457;
+pub const __NR_listmount: u32 = 4458;
+pub const __NR_lsm_get_self_attr: u32 = 4459;
+pub const __NR_lsm_set_self_attr: u32 = 4460;
+pub const __NR_lsm_list_modules: u32 = 4461;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
 pub const WSTOPPED: u32 = 2;
@@ -2749,8 +2859,10 @@ pub const _UFFDIO_UNREGISTER: u32 = 1;
 pub const _UFFDIO_WAKE: u32 = 2;
 pub const _UFFDIO_COPY: u32 = 3;
 pub const _UFFDIO_ZEROPAGE: u32 = 4;
+pub const _UFFDIO_MOVE: u32 = 5;
 pub const _UFFDIO_WRITEPROTECT: u32 = 6;
 pub const _UFFDIO_CONTINUE: u32 = 7;
+pub const _UFFDIO_POISON: u32 = 8;
 pub const _UFFDIO_API: u32 = 63;
 pub const UFFDIO: u32 = 170;
 pub const UFFD_EVENT_PAGEFAULT: u32 = 18;
@@ -2775,6 +2887,9 @@ pub const UFFD_FEATURE_MINOR_SHMEM: u32 = 1024;
 pub const UFFD_FEATURE_EXACT_ADDRESS: u32 = 2048;
 pub const UFFD_FEATURE_WP_HUGETLBFS_SHMEM: u32 = 4096;
 pub const UFFD_FEATURE_WP_UNPOPULATED: u32 = 8192;
+pub const UFFD_FEATURE_POISON: u32 = 16384;
+pub const UFFD_FEATURE_WP_ASYNC: u32 = 32768;
+pub const UFFD_FEATURE_MOVE: u32 = 65536;
 pub const UFFD_USER_MODE_ONLY: u32 = 1;
 pub const DT_UNKNOWN: u32 = 0;
 pub const DT_FIFO: u32 = 1;
@@ -2853,6 +2968,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/mips/if_arp.rs
+++ b/src/mips/if_arp.rs
@@ -50,11 +50,6 @@ pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
@@ -173,6 +168,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -180,23 +176,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -1134,6 +1115,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_4 = _bindgen_ty_4::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_4 = _bindgen_ty_4::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_MASK;
@@ -1202,6 +1184,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_HAIRPIN;
@@ -1249,6 +1233,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_10 = _bindgen_ty_10::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_KIND;
@@ -1310,301 +1295,310 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_19 = _bindgen_ty_19::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_40 = _bindgen_ty_40::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_46 = _bindgen_ty_46::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_DSA_MAX;
-pub const IF_PORT_UNKNOWN: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_UNKNOWN;
-pub const IF_PORT_10BASE2: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASE2;
-pub const IF_PORT_10BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASET;
-pub const IF_PORT_AUI: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_AUI;
-pub const IF_PORT_100BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASET;
-pub const IF_PORT_100BASETX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASETX;
-pub const IF_PORT_100BASEFX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASEFX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_20 = _bindgen_ty_20::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_23 = _bindgen_ty_23::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_47 = _bindgen_ty_47::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__IFLA_DSA_MAX;
+pub const IF_PORT_UNKNOWN: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_UNKNOWN;
+pub const IF_PORT_10BASE2: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASE2;
+pub const IF_PORT_10BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASET;
+pub const IF_PORT_AUI: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_AUI;
+pub const IF_PORT_100BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASET;
+pub const IF_PORT_100BASETX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASETX;
+pub const IF_PORT_100BASEFX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASEFX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1707,6 +1701,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1796,7 +1792,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1892,7 +1889,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1949,7 +1948,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2102,10 +2102,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_20 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_21 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -2121,7 +2149,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -2133,7 +2161,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum _bindgen_ty_23 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -2141,7 +2169,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2174,7 +2202,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2188,7 +2217,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_25 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2218,7 +2255,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2229,7 +2266,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2244,7 +2281,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2257,7 +2294,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2295,7 +2332,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2307,7 +2344,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2323,7 +2360,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2331,7 +2368,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2351,7 +2388,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2359,7 +2396,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2368,7 +2405,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2383,7 +2420,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2391,7 +2428,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2405,7 +2442,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2414,7 +2451,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2432,7 +2469,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2442,14 +2479,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2457,7 +2494,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2471,7 +2508,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2483,7 +2520,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2492,7 +2529,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2501,7 +2538,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2511,7 +2548,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2520,7 +2557,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2530,7 +2567,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2545,7 +2582,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2557,7 +2594,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2573,7 +2610,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2582,7 +2619,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2590,15 +2627,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 IF_PORT_UNKNOWN = 0,
 IF_PORT_10BASE2 = 1,
 IF_PORT_10BASET = 2,
@@ -2681,74 +2718,6 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 impl nlmsgerr_attrs {
 pub const NLMSGERR_ATTR_MAX: nlmsgerr_attrs = nlmsgerr_attrs::NLMSGERR_ATTR_MISS_NEST;
 }
@@ -2763,6 +2732,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/mips/if_packet.rs
+++ b/src/mips/if_packet.rs
@@ -49,11 +49,6 @@ pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_pkt {
 pub spkt_family: crate::ctypes::c_ushort,
@@ -61,6 +56,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -68,23 +64,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -335,71 +316,3 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}

--- a/src/mips/io_uring.rs
+++ b/src/mips/io_uring.rs
@@ -77,7 +77,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -132,6 +133,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -193,6 +227,29 @@ pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
 pub tv_nsec: crate::ctypes::c_longlong,
@@ -251,6 +308,12 @@ pub __pad1: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_sqe__bindgen_ty_2__bindgen_ty_1 {
+pub level: __u32,
+pub optname: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_sqe__bindgen_ty_5__bindgen_ty_1 {
 pub addr_len: __u16,
 pub __pad3: [__u16; 1usize],
@@ -258,6 +321,7 @@ pub __pad3: [__u16; 1usize],
 #[repr(C)]
 pub struct io_uring_sqe__bindgen_ty_6 {
 pub __bindgen_anon_1: __BindgenUnionField<io_uring_sqe__bindgen_ty_6__bindgen_ty_1>,
+pub optval: __BindgenUnionField<__u64>,
 pub cmd: __BindgenUnionField<[__u8; 0usize]>,
 pub bindgen_union_field: [u64; 2usize],
 }
@@ -419,6 +483,13 @@ pub resv: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_buf_status {
+pub buf_group: __u32,
+pub head: __u32,
+pub resv: [__u32; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -432,7 +503,9 @@ pub addr: __u64,
 pub fd: __s32,
 pub flags: __u32,
 pub timeout: __kernel_timespec,
-pub pad: [__u64; 4usize],
+pub opcode: __u8,
+pub pad: [__u8; 7usize],
+pub pad2: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -605,6 +678,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -676,6 +757,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const IORING_FILE_INDEX_ALLOC: i32 = -1;
 pub const IORING_SETUP_IOPOLL: u32 = 1;
 pub const IORING_SETUP_SQPOLL: u32 = 2;
@@ -693,8 +784,9 @@ pub const IORING_SETUP_SINGLE_ISSUER: u32 = 4096;
 pub const IORING_SETUP_DEFER_TASKRUN: u32 = 8192;
 pub const IORING_SETUP_NO_MMAP: u32 = 16384;
 pub const IORING_SETUP_REGISTERED_FD_ONLY: u32 = 32768;
+pub const IORING_SETUP_NO_SQARRAY: u32 = 65536;
 pub const IORING_URING_CMD_FIXED: u32 = 1;
-pub const IORING_URING_CMD_POLLED: u32 = 2147483648;
+pub const IORING_URING_CMD_MASK: u32 = 1;
 pub const IORING_FSYNC_DATASYNC: u32 = 1;
 pub const IORING_TIMEOUT_ABS: u32 = 1;
 pub const IORING_TIMEOUT_UPDATE: u32 = 2;
@@ -714,6 +806,8 @@ pub const IORING_ASYNC_CANCEL_ALL: u32 = 1;
 pub const IORING_ASYNC_CANCEL_FD: u32 = 2;
 pub const IORING_ASYNC_CANCEL_ANY: u32 = 4;
 pub const IORING_ASYNC_CANCEL_FD_FIXED: u32 = 8;
+pub const IORING_ASYNC_CANCEL_USERDATA: u32 = 16;
+pub const IORING_ASYNC_CANCEL_OP: u32 = 32;
 pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
@@ -722,6 +816,7 @@ pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
+pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
@@ -794,6 +889,7 @@ pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGIS
 pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
 pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
 pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
+pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
 pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
 pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
 pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
@@ -804,6 +900,10 @@ pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTR
 pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
 pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
 pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
+pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
+pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
+pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
+pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -816,6 +916,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -882,7 +983,13 @@ IORING_OP_SOCKET = 45,
 IORING_OP_URING_CMD = 46,
 IORING_OP_SEND_ZC = 47,
 IORING_OP_SENDMSG_ZC = 48,
-IORING_OP_LAST = 49,
+IORING_OP_READ_MULTISHOT = 49,
+IORING_OP_WAITID = 50,
+IORING_OP_FUTEX_WAIT = 51,
+IORING_OP_FUTEX_WAKE = 52,
+IORING_OP_FUTEX_WAITV = 53,
+IORING_OP_FIXED_FD_INSTALL = 54,
+IORING_OP_LAST = 55,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -927,7 +1034,8 @@ IORING_REGISTER_PBUF_RING = 22,
 IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
-IORING_REGISTER_LAST = 26,
+IORING_REGISTER_PBUF_STATUS = 26,
+IORING_REGISTER_LAST = 27,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
@@ -952,6 +1060,15 @@ IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
 IORING_RESTRICTION_SQE_FLAGS_REQUIRED = 3,
 IORING_RESTRICTION_LAST = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_8 {
+SOCKET_URING_OP_SIOCINQ = 0,
+SOCKET_URING_OP_SIOCOUTQ = 1,
+SOCKET_URING_OP_GETSOCKOPT = 2,
+SOCKET_URING_OP_SETSOCKOPT = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -979,6 +1096,7 @@ pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_1__bindgen_ty_1,
 pub union io_uring_sqe__bindgen_ty_2 {
 pub addr: __u64,
 pub splice_off_in: __u64,
+pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_2__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -1002,6 +1120,9 @@ pub hardlink_flags: __u32,
 pub xattr_flags: __u32,
 pub msg_ring_flags: __u32,
 pub uring_cmd_flags: __u32,
+pub waitid_flags: __u32,
+pub futex_flags: __u32,
+pub install_fd_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]
@@ -1014,6 +1135,7 @@ pub buf_group: __u16,
 pub union io_uring_sqe__bindgen_ty_5 {
 pub splice_fd_in: __s32,
 pub file_index: __u32,
+pub optlen: __u32,
 pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]

--- a/src/mips/net.rs
+++ b/src/mips/net.rs
@@ -427,6 +427,9 @@ pub tcpi_rcv_ooopack: __u32,
 pub tcpi_snd_wnd: __u32,
 pub tcpi_rcv_wnd: __u32,
 pub tcpi_rehash: __u32,
+pub tcpi_total_rto: __u16,
+pub tcpi_total_rto_recoveries: __u16,
+pub tcpi_total_rto_time: __u32,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -446,6 +449,82 @@ pub tcpm_prefixlen: __u8,
 pub tcpm_keylen: __u16,
 pub tcpm_addr: [__be32; 4usize],
 pub tcpm_key: [__u8; 80usize],
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_add {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub key: [__u8; 80usize],
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_del {
+pub addr: __kernel_sockaddr_storage,
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub current_key: __u8,
+pub rnext: __u8,
+pub keyflags: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_info_opt {
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub current_key: __u8,
+pub rnext: __u8,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+pub pkt_key_not_found: __u64,
+pub pkt_ao_required: __u64,
+pub pkt_dropped_icmp: __u64,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_getsockopt {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub key: [__u8; 80usize],
+pub nkeys: __u32,
+pub _bitfield_align_1: [u16; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub prefix: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub ifindex: __s32,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_repair {
+pub snt_isn: __be32,
+pub rcv_isn: __be32,
+pub snd_sne: __u32,
+pub rcv_sne: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1206,6 +1285,11 @@ pub const TCP_ZEROCOPY_RECEIVE: u32 = 35;
 pub const TCP_INQ: u32 = 36;
 pub const TCP_CM_INQ: u32 = 36;
 pub const TCP_TX_DELAY: u32 = 37;
+pub const TCP_AO_ADD_KEY: u32 = 38;
+pub const TCP_AO_DEL_KEY: u32 = 39;
+pub const TCP_AO_INFO: u32 = 40;
+pub const TCP_AO_GET_KEYS: u32 = 41;
+pub const TCP_AO_REPAIR: u32 = 42;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1215,9 +1299,13 @@ pub const TCPI_OPT_WSCALE: u32 = 4;
 pub const TCPI_OPT_ECN: u32 = 8;
 pub const TCPI_OPT_ECN_SEEN: u32 = 16;
 pub const TCPI_OPT_SYN_DATA: u32 = 32;
+pub const TCPI_OPT_USEC_TS: u32 = 64;
 pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
+pub const TCP_AO_MAXKEYLEN: u32 = 80;
+pub const TCP_AO_KEYF_IFINDEX: u32 = 1;
+pub const TCP_AO_KEYF_EXCLUDE_OPT: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
@@ -1582,6 +1670,7 @@ pub const DEVCONF_IOAM6_ID: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID;
 pub const DEVCONF_IOAM6_ID_WIDE: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID_WIDE;
 pub const DEVCONF_NDISC_EVICT_NOCARRIER: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_NDISC_EVICT_NOCARRIER;
 pub const DEVCONF_ACCEPT_UNTRACKED_NA: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_UNTRACKED_NA;
+pub const DEVCONF_ACCEPT_RA_MIN_LFT: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_RA_MIN_LFT;
 pub const DEVCONF_MAX: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_MAX;
 pub const TCP_FLAG_CWR: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_CWR;
 pub const TCP_FLAG_ECE: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_ECE;
@@ -1779,7 +1868,8 @@ DEVCONF_IOAM6_ID = 54,
 DEVCONF_IOAM6_ID_WIDE = 55,
 DEVCONF_NDISC_EVICT_NOCARRIER = 56,
 DEVCONF_ACCEPT_UNTRACKED_NA = 57,
-DEVCONF_MAX = 58,
+DEVCONF_ACCEPT_RA_MIN_LFT = 58,
+DEVCONF_MAX = 59,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2497,6 +2587,289 @@ tcpi_delivery_rate_app_limited as u64
 __bindgen_bitfield_unit.set(9usize, 2u8, {
 let tcpi_fastopen_client_fail: u8 = unsafe { ::core::mem::transmute(tcpi_fastopen_client_fail) };
 tcpi_fastopen_client_fail as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_add {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 30u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 30u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_del {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn del_async(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_del_async(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 29u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 29u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, del_async: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let del_async: u32 = unsafe { ::core::mem::transmute(del_async) };
+del_async as u64
+});
+__bindgen_bitfield_unit.set(3usize, 29u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_info_opt {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn ao_required(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_ao_required(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_counters(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_counters(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn accept_icmps(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_accept_icmps(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(4usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(5usize, 27u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(5usize, 27u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, ao_required: __u32, set_counters: __u32, accept_icmps: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let ao_required: u32 = unsafe { ::core::mem::transmute(ao_required) };
+ao_required as u64
+});
+__bindgen_bitfield_unit.set(3usize, 1u8, {
+let set_counters: u32 = unsafe { ::core::mem::transmute(set_counters) };
+set_counters as u64
+});
+__bindgen_bitfield_unit.set(4usize, 1u8, {
+let accept_icmps: u32 = unsafe { ::core::mem::transmute(accept_icmps) };
+accept_icmps as u64
+});
+__bindgen_bitfield_unit.set(5usize, 27u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_getsockopt {
+#[inline]
+pub fn is_current(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_current(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn is_rnext(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_rnext(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn get_all(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_get_all(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 13u8) as u16) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 13u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(is_current: __u16, is_rnext: __u16, get_all: __u16, reserved: __u16) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let is_current: u16 = unsafe { ::core::mem::transmute(is_current) };
+is_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let is_rnext: u16 = unsafe { ::core::mem::transmute(is_rnext) };
+is_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let get_all: u16 = unsafe { ::core::mem::transmute(get_all) };
+get_all as u64
+});
+__bindgen_bitfield_unit.set(3usize, 13u8, {
+let reserved: u16 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
 });
 __bindgen_bitfield_unit
 }

--- a/src/mips/netlink.rs
+++ b/src/mips/netlink.rs
@@ -732,7 +732,8 @@ pub const RTAX_FEATURE_ECN: u32 = 1;
 pub const RTAX_FEATURE_SACK: u32 = 2;
 pub const RTAX_FEATURE_TIMESTAMP: u32 = 4;
 pub const RTAX_FEATURE_ALLFRAG: u32 = 8;
-pub const RTAX_FEATURE_MASK: u32 = 15;
+pub const RTAX_FEATURE_TCP_USEC_TS: u32 = 16;
+pub const RTAX_FEATURE_MASK: u32 = 31;
 pub const TCM_IFINDEX_MAGIC_BLOCK: u32 = 4294967295;
 pub const TCA_DUMP_FLAGS_TERSE: u32 = 1;
 pub const RTMGRP_LINK: u32 = 1;
@@ -829,6 +830,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_2 = _bindgen_ty_2::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_2 = _bindgen_ty_2::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_MASK;
@@ -897,6 +899,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_6 = _bindgen_ty_6::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_HAIRPIN;
@@ -944,6 +948,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_KIND;
@@ -1005,501 +1010,510 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_17 = _bindgen_ty_17::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_18 = _bindgen_ty_18::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_21 = _bindgen_ty_21::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_44 = _bindgen_ty_44::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_DSA_MAX;
-pub const IFA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFA_UNSPEC;
-pub const IFA_ADDRESS: _bindgen_ty_54 = _bindgen_ty_54::IFA_ADDRESS;
-pub const IFA_LOCAL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LOCAL;
-pub const IFA_LABEL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LABEL;
-pub const IFA_BROADCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_BROADCAST;
-pub const IFA_ANYCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_ANYCAST;
-pub const IFA_CACHEINFO: _bindgen_ty_54 = _bindgen_ty_54::IFA_CACHEINFO;
-pub const IFA_MULTICAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_MULTICAST;
-pub const IFA_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFA_FLAGS;
-pub const IFA_RT_PRIORITY: _bindgen_ty_54 = _bindgen_ty_54::IFA_RT_PRIORITY;
-pub const IFA_TARGET_NETNSID: _bindgen_ty_54 = _bindgen_ty_54::IFA_TARGET_NETNSID;
-pub const IFA_PROTO: _bindgen_ty_54 = _bindgen_ty_54::IFA_PROTO;
-pub const __IFA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFA_MAX;
-pub const NDA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::NDA_UNSPEC;
-pub const NDA_DST: _bindgen_ty_55 = _bindgen_ty_55::NDA_DST;
-pub const NDA_LLADDR: _bindgen_ty_55 = _bindgen_ty_55::NDA_LLADDR;
-pub const NDA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::NDA_CACHEINFO;
-pub const NDA_PROBES: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROBES;
-pub const NDA_VLAN: _bindgen_ty_55 = _bindgen_ty_55::NDA_VLAN;
-pub const NDA_PORT: _bindgen_ty_55 = _bindgen_ty_55::NDA_PORT;
-pub const NDA_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_VNI;
-pub const NDA_IFINDEX: _bindgen_ty_55 = _bindgen_ty_55::NDA_IFINDEX;
-pub const NDA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::NDA_MASTER;
-pub const NDA_LINK_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::NDA_LINK_NETNSID;
-pub const NDA_SRC_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_SRC_VNI;
-pub const NDA_PROTOCOL: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROTOCOL;
-pub const NDA_NH_ID: _bindgen_ty_55 = _bindgen_ty_55::NDA_NH_ID;
-pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_55 = _bindgen_ty_55::NDA_FDB_EXT_ATTRS;
-pub const NDA_FLAGS_EXT: _bindgen_ty_55 = _bindgen_ty_55::NDA_FLAGS_EXT;
-pub const NDA_NDM_STATE_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_STATE_MASK;
-pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_FLAGS_MASK;
-pub const __NDA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__NDA_MAX;
-pub const NDTPA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UNSPEC;
-pub const NDTPA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_IFINDEX;
-pub const NDTPA_REFCNT: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REFCNT;
-pub const NDTPA_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REACHABLE_TIME;
-pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_BASE_REACHABLE_TIME;
-pub const NDTPA_RETRANS_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_RETRANS_TIME;
-pub const NDTPA_GC_STALETIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_GC_STALETIME;
-pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_DELAY_PROBE_TIME;
-pub const NDTPA_QUEUE_LEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LEN;
-pub const NDTPA_APP_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_APP_PROBES;
-pub const NDTPA_UCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UCAST_PROBES;
-pub const NDTPA_MCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_PROBES;
-pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_ANYCAST_DELAY;
-pub const NDTPA_PROXY_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_DELAY;
-pub const NDTPA_PROXY_QLEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_QLEN;
-pub const NDTPA_LOCKTIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_LOCKTIME;
-pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LENBYTES;
-pub const NDTPA_MCAST_REPROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_REPROBES;
-pub const NDTPA_PAD: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PAD;
-pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_INTERVAL_PROBE_TIME_MS;
-pub const __NDTPA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDTPA_MAX;
-pub const NDTA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTA_UNSPEC;
-pub const NDTA_NAME: _bindgen_ty_57 = _bindgen_ty_57::NDTA_NAME;
-pub const NDTA_THRESH1: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH1;
-pub const NDTA_THRESH2: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH2;
-pub const NDTA_THRESH3: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH3;
-pub const NDTA_CONFIG: _bindgen_ty_57 = _bindgen_ty_57::NDTA_CONFIG;
-pub const NDTA_PARMS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PARMS;
-pub const NDTA_STATS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_STATS;
-pub const NDTA_GC_INTERVAL: _bindgen_ty_57 = _bindgen_ty_57::NDTA_GC_INTERVAL;
-pub const NDTA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PAD;
-pub const __NDTA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTA_MAX;
-pub const FDB_NOTIFY_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_BIT;
-pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_INACTIVE_BIT;
-pub const NFEA_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::NFEA_UNSPEC;
-pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_59 = _bindgen_ty_59::NFEA_ACTIVITY_NOTIFY;
-pub const NFEA_DONT_REFRESH: _bindgen_ty_59 = _bindgen_ty_59::NFEA_DONT_REFRESH;
-pub const __NFEA_MAX: _bindgen_ty_59 = _bindgen_ty_59::__NFEA_MAX;
-pub const RTM_BASE: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_NEWLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_DELLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINK;
-pub const RTM_GETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINK;
-pub const RTM_SETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETLINK;
-pub const RTM_NEWADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDR;
-pub const RTM_DELADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDR;
-pub const RTM_GETADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDR;
-pub const RTM_NEWROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWROUTE;
-pub const RTM_DELROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELROUTE;
-pub const RTM_GETROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETROUTE;
-pub const RTM_NEWNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGH;
-pub const RTM_DELNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEIGH;
-pub const RTM_GETNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGH;
-pub const RTM_NEWRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWRULE;
-pub const RTM_DELRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELRULE;
-pub const RTM_GETRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETRULE;
-pub const RTM_NEWQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWQDISC;
-pub const RTM_DELQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELQDISC;
-pub const RTM_GETQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETQDISC;
-pub const RTM_NEWTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTCLASS;
-pub const RTM_DELTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTCLASS;
-pub const RTM_GETTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTCLASS;
-pub const RTM_NEWTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTFILTER;
-pub const RTM_DELTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTFILTER;
-pub const RTM_GETTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTFILTER;
-pub const RTM_NEWACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWACTION;
-pub const RTM_DELACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELACTION;
-pub const RTM_GETACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETACTION;
-pub const RTM_NEWPREFIX: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWPREFIX;
-pub const RTM_GETMULTICAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMULTICAST;
-pub const RTM_GETANYCAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETANYCAST;
-pub const RTM_NEWNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGHTBL;
-pub const RTM_GETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGHTBL;
-pub const RTM_SETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETNEIGHTBL;
-pub const RTM_NEWNDUSEROPT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNDUSEROPT;
-pub const RTM_NEWADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDRLABEL;
-pub const RTM_DELADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDRLABEL;
-pub const RTM_GETADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDRLABEL;
-pub const RTM_GETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETDCB;
-pub const RTM_SETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETDCB;
-pub const RTM_NEWNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNETCONF;
-pub const RTM_DELNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNETCONF;
-pub const RTM_GETNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNETCONF;
-pub const RTM_NEWMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWMDB;
-pub const RTM_DELMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELMDB;
-pub const RTM_GETMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMDB;
-pub const RTM_NEWNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNSID;
-pub const RTM_DELNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNSID;
-pub const RTM_GETNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNSID;
-pub const RTM_NEWSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWSTATS;
-pub const RTM_GETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETSTATS;
-pub const RTM_SETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETSTATS;
-pub const RTM_NEWCACHEREPORT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCACHEREPORT;
-pub const RTM_NEWCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCHAIN;
-pub const RTM_DELCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELCHAIN;
-pub const RTM_GETCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETCHAIN;
-pub const RTM_NEWNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOP;
-pub const RTM_DELNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOP;
-pub const RTM_GETNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOP;
-pub const RTM_NEWLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWLINKPROP;
-pub const RTM_DELLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINKPROP;
-pub const RTM_GETLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINKPROP;
-pub const RTM_NEWVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWVLAN;
-pub const RTM_DELVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELVLAN;
-pub const RTM_GETVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETVLAN;
-pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOPBUCKET;
-pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOPBUCKET;
-pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOPBUCKET;
-pub const RTM_NEWTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTUNNEL;
-pub const RTM_DELTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTUNNEL;
-pub const RTM_GETTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTUNNEL;
-pub const __RTM_MAX: _bindgen_ty_60 = _bindgen_ty_60::__RTM_MAX;
-pub const RTN_UNSPEC: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNSPEC;
-pub const RTN_UNICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNICAST;
-pub const RTN_LOCAL: _bindgen_ty_61 = _bindgen_ty_61::RTN_LOCAL;
-pub const RTN_BROADCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_BROADCAST;
-pub const RTN_ANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_ANYCAST;
-pub const RTN_MULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_MULTICAST;
-pub const RTN_BLACKHOLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_BLACKHOLE;
-pub const RTN_UNREACHABLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNREACHABLE;
-pub const RTN_PROHIBIT: _bindgen_ty_61 = _bindgen_ty_61::RTN_PROHIBIT;
-pub const RTN_THROW: _bindgen_ty_61 = _bindgen_ty_61::RTN_THROW;
-pub const RTN_NAT: _bindgen_ty_61 = _bindgen_ty_61::RTN_NAT;
-pub const RTN_XRESOLVE: _bindgen_ty_61 = _bindgen_ty_61::RTN_XRESOLVE;
-pub const __RTN_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTN_MAX;
-pub const RTAX_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTAX_UNSPEC;
-pub const RTAX_LOCK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_LOCK;
-pub const RTAX_MTU: _bindgen_ty_62 = _bindgen_ty_62::RTAX_MTU;
-pub const RTAX_WINDOW: _bindgen_ty_62 = _bindgen_ty_62::RTAX_WINDOW;
-pub const RTAX_RTT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTT;
-pub const RTAX_RTTVAR: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTTVAR;
-pub const RTAX_SSTHRESH: _bindgen_ty_62 = _bindgen_ty_62::RTAX_SSTHRESH;
-pub const RTAX_CWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CWND;
-pub const RTAX_ADVMSS: _bindgen_ty_62 = _bindgen_ty_62::RTAX_ADVMSS;
-pub const RTAX_REORDERING: _bindgen_ty_62 = _bindgen_ty_62::RTAX_REORDERING;
-pub const RTAX_HOPLIMIT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_HOPLIMIT;
-pub const RTAX_INITCWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITCWND;
-pub const RTAX_FEATURES: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FEATURES;
-pub const RTAX_RTO_MIN: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTO_MIN;
-pub const RTAX_INITRWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITRWND;
-pub const RTAX_QUICKACK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_QUICKACK;
-pub const RTAX_CC_ALGO: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CC_ALGO;
-pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FASTOPEN_NO_COOKIE;
-pub const __RTAX_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTAX_MAX;
-pub const PREFIX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_UNSPEC;
-pub const PREFIX_ADDRESS: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_ADDRESS;
-pub const PREFIX_CACHEINFO: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_CACHEINFO;
-pub const __PREFIX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__PREFIX_MAX;
-pub const TCA_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::TCA_UNSPEC;
-pub const TCA_KIND: _bindgen_ty_64 = _bindgen_ty_64::TCA_KIND;
-pub const TCA_OPTIONS: _bindgen_ty_64 = _bindgen_ty_64::TCA_OPTIONS;
-pub const TCA_STATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS;
-pub const TCA_XSTATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_XSTATS;
-pub const TCA_RATE: _bindgen_ty_64 = _bindgen_ty_64::TCA_RATE;
-pub const TCA_FCNT: _bindgen_ty_64 = _bindgen_ty_64::TCA_FCNT;
-pub const TCA_STATS2: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS2;
-pub const TCA_STAB: _bindgen_ty_64 = _bindgen_ty_64::TCA_STAB;
-pub const TCA_PAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_PAD;
-pub const TCA_DUMP_INVISIBLE: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_INVISIBLE;
-pub const TCA_CHAIN: _bindgen_ty_64 = _bindgen_ty_64::TCA_CHAIN;
-pub const TCA_HW_OFFLOAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_HW_OFFLOAD;
-pub const TCA_INGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_INGRESS_BLOCK;
-pub const TCA_EGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_EGRESS_BLOCK;
-pub const TCA_DUMP_FLAGS: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_FLAGS;
-pub const TCA_EXT_WARN_MSG: _bindgen_ty_64 = _bindgen_ty_64::TCA_EXT_WARN_MSG;
-pub const __TCA_MAX: _bindgen_ty_64 = _bindgen_ty_64::__TCA_MAX;
-pub const NDUSEROPT_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_UNSPEC;
-pub const NDUSEROPT_SRCADDR: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_SRCADDR;
-pub const __NDUSEROPT_MAX: _bindgen_ty_65 = _bindgen_ty_65::__NDUSEROPT_MAX;
-pub const TCA_ROOT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_UNSPEC;
-pub const TCA_ROOT_TAB: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TAB;
-pub const TCA_ROOT_FLAGS: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_FLAGS;
-pub const TCA_ROOT_COUNT: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_COUNT;
-pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TIME_DELTA;
-pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_EXT_WARN_MSG;
-pub const __TCA_ROOT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__TCA_ROOT_MAX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_18 = _bindgen_ty_18::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_39 = _bindgen_ty_39::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_45 = _bindgen_ty_45::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_DSA_MAX;
+pub const IFA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFA_UNSPEC;
+pub const IFA_ADDRESS: _bindgen_ty_55 = _bindgen_ty_55::IFA_ADDRESS;
+pub const IFA_LOCAL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LOCAL;
+pub const IFA_LABEL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LABEL;
+pub const IFA_BROADCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_BROADCAST;
+pub const IFA_ANYCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_ANYCAST;
+pub const IFA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::IFA_CACHEINFO;
+pub const IFA_MULTICAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_MULTICAST;
+pub const IFA_FLAGS: _bindgen_ty_55 = _bindgen_ty_55::IFA_FLAGS;
+pub const IFA_RT_PRIORITY: _bindgen_ty_55 = _bindgen_ty_55::IFA_RT_PRIORITY;
+pub const IFA_TARGET_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::IFA_TARGET_NETNSID;
+pub const IFA_PROTO: _bindgen_ty_55 = _bindgen_ty_55::IFA_PROTO;
+pub const __IFA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFA_MAX;
+pub const NDA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDA_UNSPEC;
+pub const NDA_DST: _bindgen_ty_56 = _bindgen_ty_56::NDA_DST;
+pub const NDA_LLADDR: _bindgen_ty_56 = _bindgen_ty_56::NDA_LLADDR;
+pub const NDA_CACHEINFO: _bindgen_ty_56 = _bindgen_ty_56::NDA_CACHEINFO;
+pub const NDA_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROBES;
+pub const NDA_VLAN: _bindgen_ty_56 = _bindgen_ty_56::NDA_VLAN;
+pub const NDA_PORT: _bindgen_ty_56 = _bindgen_ty_56::NDA_PORT;
+pub const NDA_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_VNI;
+pub const NDA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDA_IFINDEX;
+pub const NDA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::NDA_MASTER;
+pub const NDA_LINK_NETNSID: _bindgen_ty_56 = _bindgen_ty_56::NDA_LINK_NETNSID;
+pub const NDA_SRC_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_SRC_VNI;
+pub const NDA_PROTOCOL: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROTOCOL;
+pub const NDA_NH_ID: _bindgen_ty_56 = _bindgen_ty_56::NDA_NH_ID;
+pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_56 = _bindgen_ty_56::NDA_FDB_EXT_ATTRS;
+pub const NDA_FLAGS_EXT: _bindgen_ty_56 = _bindgen_ty_56::NDA_FLAGS_EXT;
+pub const NDA_NDM_STATE_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_STATE_MASK;
+pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_FLAGS_MASK;
+pub const __NDA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDA_MAX;
+pub const NDTPA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UNSPEC;
+pub const NDTPA_IFINDEX: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_IFINDEX;
+pub const NDTPA_REFCNT: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REFCNT;
+pub const NDTPA_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REACHABLE_TIME;
+pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_BASE_REACHABLE_TIME;
+pub const NDTPA_RETRANS_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_RETRANS_TIME;
+pub const NDTPA_GC_STALETIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_GC_STALETIME;
+pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_DELAY_PROBE_TIME;
+pub const NDTPA_QUEUE_LEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LEN;
+pub const NDTPA_APP_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_APP_PROBES;
+pub const NDTPA_UCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UCAST_PROBES;
+pub const NDTPA_MCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_PROBES;
+pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_ANYCAST_DELAY;
+pub const NDTPA_PROXY_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_DELAY;
+pub const NDTPA_PROXY_QLEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_QLEN;
+pub const NDTPA_LOCKTIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_LOCKTIME;
+pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LENBYTES;
+pub const NDTPA_MCAST_REPROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_REPROBES;
+pub const NDTPA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PAD;
+pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_INTERVAL_PROBE_TIME_MS;
+pub const __NDTPA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTPA_MAX;
+pub const NDTA_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDTA_UNSPEC;
+pub const NDTA_NAME: _bindgen_ty_58 = _bindgen_ty_58::NDTA_NAME;
+pub const NDTA_THRESH1: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH1;
+pub const NDTA_THRESH2: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH2;
+pub const NDTA_THRESH3: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH3;
+pub const NDTA_CONFIG: _bindgen_ty_58 = _bindgen_ty_58::NDTA_CONFIG;
+pub const NDTA_PARMS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PARMS;
+pub const NDTA_STATS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_STATS;
+pub const NDTA_GC_INTERVAL: _bindgen_ty_58 = _bindgen_ty_58::NDTA_GC_INTERVAL;
+pub const NDTA_PAD: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PAD;
+pub const __NDTA_MAX: _bindgen_ty_58 = _bindgen_ty_58::__NDTA_MAX;
+pub const FDB_NOTIFY_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_BIT;
+pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_INACTIVE_BIT;
+pub const NFEA_UNSPEC: _bindgen_ty_60 = _bindgen_ty_60::NFEA_UNSPEC;
+pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_60 = _bindgen_ty_60::NFEA_ACTIVITY_NOTIFY;
+pub const NFEA_DONT_REFRESH: _bindgen_ty_60 = _bindgen_ty_60::NFEA_DONT_REFRESH;
+pub const __NFEA_MAX: _bindgen_ty_60 = _bindgen_ty_60::__NFEA_MAX;
+pub const RTM_BASE: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_NEWLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_DELLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINK;
+pub const RTM_GETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINK;
+pub const RTM_SETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETLINK;
+pub const RTM_NEWADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDR;
+pub const RTM_DELADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDR;
+pub const RTM_GETADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDR;
+pub const RTM_NEWROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWROUTE;
+pub const RTM_DELROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELROUTE;
+pub const RTM_GETROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETROUTE;
+pub const RTM_NEWNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGH;
+pub const RTM_DELNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEIGH;
+pub const RTM_GETNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGH;
+pub const RTM_NEWRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWRULE;
+pub const RTM_DELRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELRULE;
+pub const RTM_GETRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETRULE;
+pub const RTM_NEWQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWQDISC;
+pub const RTM_DELQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELQDISC;
+pub const RTM_GETQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETQDISC;
+pub const RTM_NEWTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTCLASS;
+pub const RTM_DELTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTCLASS;
+pub const RTM_GETTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTCLASS;
+pub const RTM_NEWTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTFILTER;
+pub const RTM_DELTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTFILTER;
+pub const RTM_GETTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTFILTER;
+pub const RTM_NEWACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWACTION;
+pub const RTM_DELACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELACTION;
+pub const RTM_GETACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETACTION;
+pub const RTM_NEWPREFIX: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWPREFIX;
+pub const RTM_GETMULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMULTICAST;
+pub const RTM_GETANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETANYCAST;
+pub const RTM_NEWNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGHTBL;
+pub const RTM_GETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGHTBL;
+pub const RTM_SETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETNEIGHTBL;
+pub const RTM_NEWNDUSEROPT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNDUSEROPT;
+pub const RTM_NEWADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDRLABEL;
+pub const RTM_DELADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDRLABEL;
+pub const RTM_GETADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDRLABEL;
+pub const RTM_GETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETDCB;
+pub const RTM_SETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETDCB;
+pub const RTM_NEWNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNETCONF;
+pub const RTM_DELNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNETCONF;
+pub const RTM_GETNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNETCONF;
+pub const RTM_NEWMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWMDB;
+pub const RTM_DELMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELMDB;
+pub const RTM_GETMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMDB;
+pub const RTM_NEWNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNSID;
+pub const RTM_DELNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNSID;
+pub const RTM_GETNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNSID;
+pub const RTM_NEWSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWSTATS;
+pub const RTM_GETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETSTATS;
+pub const RTM_SETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETSTATS;
+pub const RTM_NEWCACHEREPORT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCACHEREPORT;
+pub const RTM_NEWCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCHAIN;
+pub const RTM_DELCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELCHAIN;
+pub const RTM_GETCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETCHAIN;
+pub const RTM_NEWNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOP;
+pub const RTM_DELNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOP;
+pub const RTM_GETNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOP;
+pub const RTM_NEWLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWLINKPROP;
+pub const RTM_DELLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINKPROP;
+pub const RTM_GETLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINKPROP;
+pub const RTM_NEWVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWVLAN;
+pub const RTM_DELVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELVLAN;
+pub const RTM_GETVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETVLAN;
+pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOPBUCKET;
+pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOPBUCKET;
+pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOPBUCKET;
+pub const RTM_NEWTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTUNNEL;
+pub const RTM_DELTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTUNNEL;
+pub const RTM_GETTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTUNNEL;
+pub const __RTM_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTM_MAX;
+pub const RTN_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNSPEC;
+pub const RTN_UNICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNICAST;
+pub const RTN_LOCAL: _bindgen_ty_62 = _bindgen_ty_62::RTN_LOCAL;
+pub const RTN_BROADCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_BROADCAST;
+pub const RTN_ANYCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_ANYCAST;
+pub const RTN_MULTICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_MULTICAST;
+pub const RTN_BLACKHOLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_BLACKHOLE;
+pub const RTN_UNREACHABLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNREACHABLE;
+pub const RTN_PROHIBIT: _bindgen_ty_62 = _bindgen_ty_62::RTN_PROHIBIT;
+pub const RTN_THROW: _bindgen_ty_62 = _bindgen_ty_62::RTN_THROW;
+pub const RTN_NAT: _bindgen_ty_62 = _bindgen_ty_62::RTN_NAT;
+pub const RTN_XRESOLVE: _bindgen_ty_62 = _bindgen_ty_62::RTN_XRESOLVE;
+pub const __RTN_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTN_MAX;
+pub const RTAX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::RTAX_UNSPEC;
+pub const RTAX_LOCK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_LOCK;
+pub const RTAX_MTU: _bindgen_ty_63 = _bindgen_ty_63::RTAX_MTU;
+pub const RTAX_WINDOW: _bindgen_ty_63 = _bindgen_ty_63::RTAX_WINDOW;
+pub const RTAX_RTT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTT;
+pub const RTAX_RTTVAR: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTTVAR;
+pub const RTAX_SSTHRESH: _bindgen_ty_63 = _bindgen_ty_63::RTAX_SSTHRESH;
+pub const RTAX_CWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CWND;
+pub const RTAX_ADVMSS: _bindgen_ty_63 = _bindgen_ty_63::RTAX_ADVMSS;
+pub const RTAX_REORDERING: _bindgen_ty_63 = _bindgen_ty_63::RTAX_REORDERING;
+pub const RTAX_HOPLIMIT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_HOPLIMIT;
+pub const RTAX_INITCWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITCWND;
+pub const RTAX_FEATURES: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FEATURES;
+pub const RTAX_RTO_MIN: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTO_MIN;
+pub const RTAX_INITRWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITRWND;
+pub const RTAX_QUICKACK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_QUICKACK;
+pub const RTAX_CC_ALGO: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CC_ALGO;
+pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FASTOPEN_NO_COOKIE;
+pub const __RTAX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__RTAX_MAX;
+pub const PREFIX_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_UNSPEC;
+pub const PREFIX_ADDRESS: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_ADDRESS;
+pub const PREFIX_CACHEINFO: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_CACHEINFO;
+pub const __PREFIX_MAX: _bindgen_ty_64 = _bindgen_ty_64::__PREFIX_MAX;
+pub const TCA_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::TCA_UNSPEC;
+pub const TCA_KIND: _bindgen_ty_65 = _bindgen_ty_65::TCA_KIND;
+pub const TCA_OPTIONS: _bindgen_ty_65 = _bindgen_ty_65::TCA_OPTIONS;
+pub const TCA_STATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS;
+pub const TCA_XSTATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_XSTATS;
+pub const TCA_RATE: _bindgen_ty_65 = _bindgen_ty_65::TCA_RATE;
+pub const TCA_FCNT: _bindgen_ty_65 = _bindgen_ty_65::TCA_FCNT;
+pub const TCA_STATS2: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS2;
+pub const TCA_STAB: _bindgen_ty_65 = _bindgen_ty_65::TCA_STAB;
+pub const TCA_PAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_PAD;
+pub const TCA_DUMP_INVISIBLE: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_INVISIBLE;
+pub const TCA_CHAIN: _bindgen_ty_65 = _bindgen_ty_65::TCA_CHAIN;
+pub const TCA_HW_OFFLOAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_HW_OFFLOAD;
+pub const TCA_INGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_INGRESS_BLOCK;
+pub const TCA_EGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_EGRESS_BLOCK;
+pub const TCA_DUMP_FLAGS: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_FLAGS;
+pub const TCA_EXT_WARN_MSG: _bindgen_ty_65 = _bindgen_ty_65::TCA_EXT_WARN_MSG;
+pub const __TCA_MAX: _bindgen_ty_65 = _bindgen_ty_65::__TCA_MAX;
+pub const NDUSEROPT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_UNSPEC;
+pub const NDUSEROPT_SRCADDR: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_SRCADDR;
+pub const __NDUSEROPT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__NDUSEROPT_MAX;
+pub const TCA_ROOT_UNSPEC: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_UNSPEC;
+pub const TCA_ROOT_TAB: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TAB;
+pub const TCA_ROOT_FLAGS: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_FLAGS;
+pub const TCA_ROOT_COUNT: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_COUNT;
+pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TIME_DELTA;
+pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_EXT_WARN_MSG;
+pub const __TCA_ROOT_MAX: _bindgen_ty_67 = _bindgen_ty_67::__TCA_ROOT_MAX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1550,6 +1564,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1639,7 +1655,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1735,7 +1752,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1792,7 +1811,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1945,10 +1965,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_18 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_19 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -1964,7 +2012,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_19 {
+pub enum _bindgen_ty_20 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -1976,7 +2024,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_20 {
+pub enum _bindgen_ty_21 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -1984,7 +2032,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2017,7 +2065,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2031,7 +2080,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_23 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2061,7 +2118,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2072,7 +2129,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum _bindgen_ty_25 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2087,7 +2144,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2100,7 +2157,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2138,7 +2195,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2150,7 +2207,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2166,7 +2223,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2174,7 +2231,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2194,7 +2251,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2202,7 +2259,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2211,7 +2268,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2226,7 +2283,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2234,7 +2291,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2248,7 +2305,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2257,7 +2314,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2275,7 +2332,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2285,14 +2342,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2300,7 +2357,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2314,7 +2371,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2326,7 +2383,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2335,7 +2392,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2344,7 +2401,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2354,7 +2411,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2363,7 +2420,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2373,7 +2430,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2388,7 +2445,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2400,7 +2457,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2416,7 +2473,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2425,7 +2482,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2433,15 +2490,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFA_UNSPEC = 0,
 IFA_ADDRESS = 1,
 IFA_LOCAL = 2,
@@ -2459,7 +2516,7 @@ __IFA_MAX = 12,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 NDA_UNSPEC = 0,
 NDA_DST = 1,
 NDA_LLADDR = 2,
@@ -2483,7 +2540,7 @@ __NDA_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 NDTPA_UNSPEC = 0,
 NDTPA_IFINDEX = 1,
 NDTPA_REFCNT = 2,
@@ -2509,7 +2566,7 @@ __NDTPA_MAX = 20,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_57 {
+pub enum _bindgen_ty_58 {
 NDTA_UNSPEC = 0,
 NDTA_NAME = 1,
 NDTA_THRESH1 = 2,
@@ -2525,14 +2582,14 @@ __NDTA_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_58 {
+pub enum _bindgen_ty_59 {
 FDB_NOTIFY_BIT = 1,
 FDB_NOTIFY_INACTIVE_BIT = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_59 {
+pub enum _bindgen_ty_60 {
 NFEA_UNSPEC = 0,
 NFEA_ACTIVITY_NOTIFY = 1,
 NFEA_DONT_REFRESH = 2,
@@ -2541,7 +2598,7 @@ __NFEA_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_60 {
+pub enum _bindgen_ty_61 {
 RTM_BASE = 16,
 RTM_DELLINK = 17,
 RTM_GETLINK = 18,
@@ -2618,7 +2675,7 @@ __RTM_MAX = 123,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_61 {
+pub enum _bindgen_ty_62 {
 RTN_UNSPEC = 0,
 RTN_UNICAST = 1,
 RTN_LOCAL = 2,
@@ -2694,7 +2751,7 @@ __RTA_MAX = 31,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_62 {
+pub enum _bindgen_ty_63 {
 RTAX_UNSPEC = 0,
 RTAX_LOCK = 1,
 RTAX_MTU = 2,
@@ -2718,7 +2775,7 @@ __RTAX_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_63 {
+pub enum _bindgen_ty_64 {
 PREFIX_UNSPEC = 0,
 PREFIX_ADDRESS = 1,
 PREFIX_CACHEINFO = 2,
@@ -2727,7 +2784,7 @@ __PREFIX_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_64 {
+pub enum _bindgen_ty_65 {
 TCA_UNSPEC = 0,
 TCA_KIND = 1,
 TCA_OPTIONS = 2,
@@ -2750,7 +2807,7 @@ __TCA_MAX = 17,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_65 {
+pub enum _bindgen_ty_66 {
 NDUSEROPT_UNSPEC = 0,
 NDUSEROPT_SRCADDR = 1,
 __NDUSEROPT_MAX = 2,
@@ -2801,7 +2858,7 @@ __RTNLGRP_MAX = 37,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_66 {
+pub enum _bindgen_ty_67 {
 TCA_ROOT_UNSPEC = 0,
 TCA_ROOT_TAB = 1,
 TCA_ROOT_FLAGS = 2,
@@ -2864,6 +2921,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/mips/prctl.rs
+++ b/src/mips/prctl.rs
@@ -226,6 +226,7 @@ pub const PR_SME_VL_LEN_MASK: u32 = 65535;
 pub const PR_SME_VL_INHERIT: u32 = 131072;
 pub const PR_SET_MDWE: u32 = 65;
 pub const PR_MDWE_REFUSE_EXEC_GAIN: u32 = 1;
+pub const PR_MDWE_NO_INHERIT: u32 = 2;
 pub const PR_GET_MDWE: u32 = 66;
 pub const PR_SET_VMA: u32 = 1398164801;
 pub const PR_SET_VMA_ANON_NAME: u32 = 0;

--- a/src/mips/xdp.rs
+++ b/src/mips/xdp.rs
@@ -81,6 +81,7 @@ pub len: __u64,
 pub chunk_size: __u32,
 pub headroom: __u32,
 pub flags: __u32,
+pub tx_metadata_len: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -96,6 +97,23 @@ pub tx_ring_empty_descs: __u64,
 #[derive(Debug, Copy, Clone)]
 pub struct xdp_options {
 pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct xsk_tx_metadata {
+pub flags: __u64,
+pub __bindgen_anon_1: xsk_tx_metadata__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1 {
+pub csum_start: __u16,
+pub csum_offset: __u16,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2 {
+pub tx_timestamp: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -148,7 +166,9 @@ pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
 pub const XDP_USE_NEED_WAKEUP: u32 = 8;
+pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
+pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;
@@ -165,5 +185,13 @@ pub const XDP_UMEM_PGOFF_FILL_RING: u64 = 4294967296;
 pub const XDP_UMEM_PGOFF_COMPLETION_RING: u64 = 6442450944;
 pub const XSK_UNALIGNED_BUF_OFFSET_SHIFT: u32 = 48;
 pub const XSK_UNALIGNED_BUF_ADDR_MASK: u64 = 281474976710655;
-pub const XDP_USE_SG: u32 = 16;
+pub const XDP_TXMD_FLAGS_TIMESTAMP: u32 = 1;
+pub const XDP_TXMD_FLAGS_CHECKSUM: u32 = 2;
 pub const XDP_PKT_CONTD: u32 = 1;
+pub const XDP_TX_METADATA: u32 = 2;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union xsk_tx_metadata__bindgen_ty_1 {
+pub request: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1,
+pub completion: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2,
+}

--- a/src/mips32r6/general.rs
+++ b/src/mips32r6/general.rs
@@ -184,7 +184,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -239,6 +240,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -297,6 +331,29 @@ pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
 pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -391,36 +448,6 @@ pub it_value: __kernel_old_timeval,
 pub struct __kernel_sock_timeval {
 pub tv_sec: __s64,
 pub tv_usec: __s64,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timespec {
-pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: crate::ctypes::c_long,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timeval {
-pub tv_sec: __kernel_old_time_t,
-pub tv_usec: __kernel_suseconds_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerspec {
-pub it_interval: timespec,
-pub it_value: timespec,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerval {
-pub it_interval: timeval,
-pub it_value: timeval,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timezone {
-pub tz_minuteswest: crate::ctypes::c_int,
-pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -702,6 +729,36 @@ pub c_cc: [crate::ctypes::c_uchar; 23usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct timespec {
+pub tv_sec: __kernel_old_time_t,
+pub tv_nsec: crate::ctypes::c_long,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timeval {
+pub tv_sec: __kernel_old_time_t,
+pub tv_usec: __kernel_suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerspec {
+pub it_interval: timespec,
+pub it_value: timespec,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerval {
+pub it_interval: timeval,
+pub it_value: timeval,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timezone {
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct iovec {
 pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
@@ -795,6 +852,22 @@ pub struct uffdio_continue {
 pub range: uffdio_range,
 pub mode: __u64,
 pub mapped: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_poison {
+pub range: uffdio_range,
+pub mode: __u64,
+pub updated: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_move {
+pub dst: __u64,
+pub src: __u64,
+pub len: __u64,
+pub mode: __u64,
+pub move_: __s64,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -907,9 +980,9 @@ pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 394496;
+pub const LINUX_VERSION_CODE: u32 = 395264;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 5;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_VECTOR_SIZE_ARCH: u32 = 1;
@@ -1291,6 +1364,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1362,6 +1443,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const FUTEX_WAIT: u32 = 0;
 pub const FUTEX_WAKE: u32 = 1;
 pub const FUTEX_FD: u32 = 2;
@@ -1392,6 +1483,13 @@ pub const FUTEX_WAIT_BITSET_PRIVATE: u32 = 137;
 pub const FUTEX_WAKE_BITSET_PRIVATE: u32 = 138;
 pub const FUTEX_WAIT_REQUEUE_PI_PRIVATE: u32 = 139;
 pub const FUTEX_CMP_REQUEUE_PI_PRIVATE: u32 = 140;
+pub const FUTEX2_SIZE_U8: u32 = 0;
+pub const FUTEX2_SIZE_U16: u32 = 1;
+pub const FUTEX2_SIZE_U32: u32 = 2;
+pub const FUTEX2_SIZE_U64: u32 = 3;
+pub const FUTEX2_NUMA: u32 = 4;
+pub const FUTEX2_PRIVATE: u32 = 128;
+pub const FUTEX2_SIZE_MASK: u32 = 3;
 pub const FUTEX_32: u32 = 2;
 pub const FUTEX_WAITV_MAX: u32 = 128;
 pub const FUTEX_WAITERS: u32 = 2147483648;
@@ -1648,25 +1746,6 @@ pub const LINUX_REBOOT_CMD_POWER_OFF: u32 = 1126301404;
 pub const LINUX_REBOOT_CMD_RESTART2: u32 = 2712847316;
 pub const LINUX_REBOOT_CMD_SW_SUSPEND: u32 = 3489725666;
 pub const LINUX_REBOOT_CMD_KEXEC: u32 = 1163412803;
-pub const ITIMER_REAL: u32 = 0;
-pub const ITIMER_VIRTUAL: u32 = 1;
-pub const ITIMER_PROF: u32 = 2;
-pub const CLOCK_REALTIME: u32 = 0;
-pub const CLOCK_MONOTONIC: u32 = 1;
-pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
-pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
-pub const CLOCK_MONOTONIC_RAW: u32 = 4;
-pub const CLOCK_REALTIME_COARSE: u32 = 5;
-pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
-pub const CLOCK_BOOTTIME: u32 = 7;
-pub const CLOCK_REALTIME_ALARM: u32 = 8;
-pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
-pub const CLOCK_SGI_CYCLE: u32 = 10;
-pub const CLOCK_TAI: u32 = 11;
-pub const MAX_CLOCKS: u32 = 16;
-pub const CLOCKS_MASK: u32 = 1;
-pub const CLOCKS_MONO: u32 = 1;
-pub const TIMER_ABSTIME: u32 = 1;
 pub const RUSAGE_SELF: u32 = 0;
 pub const RUSAGE_CHILDREN: i32 = -1;
 pub const RUSAGE_BOTH: i32 = -2;
@@ -1846,7 +1925,8 @@ pub const SEGV_ADIDERR: u32 = 6;
 pub const SEGV_ADIPERR: u32 = 7;
 pub const SEGV_MTEAERR: u32 = 8;
 pub const SEGV_MTESERR: u32 = 9;
-pub const NSIGSEGV: u32 = 9;
+pub const SEGV_CPERR: u32 = 10;
+pub const NSIGSEGV: u32 = 10;
 pub const BUS_ADRALN: u32 = 1;
 pub const BUS_ADRERR: u32 = 2;
 pub const BUS_OBJERR: u32 = 3;
@@ -1927,6 +2007,7 @@ pub const STATX_BASIC_STATS: u32 = 2047;
 pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
+pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2243,6 +2324,25 @@ pub const TIOCM_DSR: u32 = 1024;
 pub const TIOCM_OUT1: u32 = 8192;
 pub const TIOCM_OUT2: u32 = 16384;
 pub const TIOCM_LOOP: u32 = 32768;
+pub const ITIMER_REAL: u32 = 0;
+pub const ITIMER_VIRTUAL: u32 = 1;
+pub const ITIMER_PROF: u32 = 2;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_SGI_CYCLE: u32 = 10;
+pub const CLOCK_TAI: u32 = 11;
+pub const MAX_CLOCKS: u32 = 16;
+pub const CLOCKS_MASK: u32 = 1;
+pub const CLOCKS_MONO: u32 = 1;
+pub const TIMER_ABSTIME: u32 = 1;
 pub const UIO_FASTIOV: u32 = 8;
 pub const UIO_MAXIOV: u32 = 1024;
 pub const __NR_Linux: u32 = 4000;
@@ -2671,6 +2771,16 @@ pub const __NR_process_mrelease: u32 = 4448;
 pub const __NR_futex_waitv: u32 = 4449;
 pub const __NR_set_mempolicy_home_node: u32 = 4450;
 pub const __NR_cachestat: u32 = 4451;
+pub const __NR_fchmodat2: u32 = 4452;
+pub const __NR_map_shadow_stack: u32 = 4453;
+pub const __NR_futex_wake: u32 = 4454;
+pub const __NR_futex_wait: u32 = 4455;
+pub const __NR_futex_requeue: u32 = 4456;
+pub const __NR_statmount: u32 = 4457;
+pub const __NR_listmount: u32 = 4458;
+pub const __NR_lsm_get_self_attr: u32 = 4459;
+pub const __NR_lsm_set_self_attr: u32 = 4460;
+pub const __NR_lsm_list_modules: u32 = 4461;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
 pub const WSTOPPED: u32 = 2;
@@ -2749,8 +2859,10 @@ pub const _UFFDIO_UNREGISTER: u32 = 1;
 pub const _UFFDIO_WAKE: u32 = 2;
 pub const _UFFDIO_COPY: u32 = 3;
 pub const _UFFDIO_ZEROPAGE: u32 = 4;
+pub const _UFFDIO_MOVE: u32 = 5;
 pub const _UFFDIO_WRITEPROTECT: u32 = 6;
 pub const _UFFDIO_CONTINUE: u32 = 7;
+pub const _UFFDIO_POISON: u32 = 8;
 pub const _UFFDIO_API: u32 = 63;
 pub const UFFDIO: u32 = 170;
 pub const UFFD_EVENT_PAGEFAULT: u32 = 18;
@@ -2775,6 +2887,9 @@ pub const UFFD_FEATURE_MINOR_SHMEM: u32 = 1024;
 pub const UFFD_FEATURE_EXACT_ADDRESS: u32 = 2048;
 pub const UFFD_FEATURE_WP_HUGETLBFS_SHMEM: u32 = 4096;
 pub const UFFD_FEATURE_WP_UNPOPULATED: u32 = 8192;
+pub const UFFD_FEATURE_POISON: u32 = 16384;
+pub const UFFD_FEATURE_WP_ASYNC: u32 = 32768;
+pub const UFFD_FEATURE_MOVE: u32 = 65536;
 pub const UFFD_USER_MODE_ONLY: u32 = 1;
 pub const DT_UNKNOWN: u32 = 0;
 pub const DT_FIFO: u32 = 1;
@@ -2853,6 +2968,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/mips32r6/if_arp.rs
+++ b/src/mips32r6/if_arp.rs
@@ -50,11 +50,6 @@ pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
@@ -173,6 +168,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -180,23 +176,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -1134,6 +1115,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_4 = _bindgen_ty_4::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_4 = _bindgen_ty_4::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_MASK;
@@ -1202,6 +1184,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_HAIRPIN;
@@ -1249,6 +1233,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_10 = _bindgen_ty_10::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_KIND;
@@ -1310,301 +1295,310 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_19 = _bindgen_ty_19::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_40 = _bindgen_ty_40::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_46 = _bindgen_ty_46::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_DSA_MAX;
-pub const IF_PORT_UNKNOWN: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_UNKNOWN;
-pub const IF_PORT_10BASE2: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASE2;
-pub const IF_PORT_10BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASET;
-pub const IF_PORT_AUI: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_AUI;
-pub const IF_PORT_100BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASET;
-pub const IF_PORT_100BASETX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASETX;
-pub const IF_PORT_100BASEFX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASEFX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_20 = _bindgen_ty_20::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_23 = _bindgen_ty_23::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_47 = _bindgen_ty_47::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__IFLA_DSA_MAX;
+pub const IF_PORT_UNKNOWN: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_UNKNOWN;
+pub const IF_PORT_10BASE2: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASE2;
+pub const IF_PORT_10BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASET;
+pub const IF_PORT_AUI: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_AUI;
+pub const IF_PORT_100BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASET;
+pub const IF_PORT_100BASETX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASETX;
+pub const IF_PORT_100BASEFX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASEFX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1707,6 +1701,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1796,7 +1792,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1892,7 +1889,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1949,7 +1948,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2102,10 +2102,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_20 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_21 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -2121,7 +2149,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -2133,7 +2161,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum _bindgen_ty_23 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -2141,7 +2169,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2174,7 +2202,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2188,7 +2217,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_25 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2218,7 +2255,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2229,7 +2266,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2244,7 +2281,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2257,7 +2294,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2295,7 +2332,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2307,7 +2344,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2323,7 +2360,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2331,7 +2368,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2351,7 +2388,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2359,7 +2396,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2368,7 +2405,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2383,7 +2420,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2391,7 +2428,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2405,7 +2442,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2414,7 +2451,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2432,7 +2469,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2442,14 +2479,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2457,7 +2494,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2471,7 +2508,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2483,7 +2520,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2492,7 +2529,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2501,7 +2538,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2511,7 +2548,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2520,7 +2557,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2530,7 +2567,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2545,7 +2582,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2557,7 +2594,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2573,7 +2610,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2582,7 +2619,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2590,15 +2627,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 IF_PORT_UNKNOWN = 0,
 IF_PORT_10BASE2 = 1,
 IF_PORT_10BASET = 2,
@@ -2681,74 +2718,6 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 impl nlmsgerr_attrs {
 pub const NLMSGERR_ATTR_MAX: nlmsgerr_attrs = nlmsgerr_attrs::NLMSGERR_ATTR_MISS_NEST;
 }
@@ -2763,6 +2732,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/mips32r6/if_packet.rs
+++ b/src/mips32r6/if_packet.rs
@@ -49,11 +49,6 @@ pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_pkt {
 pub spkt_family: crate::ctypes::c_ushort,
@@ -61,6 +56,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -68,23 +64,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -335,71 +316,3 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}

--- a/src/mips32r6/io_uring.rs
+++ b/src/mips32r6/io_uring.rs
@@ -77,7 +77,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -132,6 +133,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -193,6 +227,29 @@ pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
 pub tv_nsec: crate::ctypes::c_longlong,
@@ -251,6 +308,12 @@ pub __pad1: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_sqe__bindgen_ty_2__bindgen_ty_1 {
+pub level: __u32,
+pub optname: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_sqe__bindgen_ty_5__bindgen_ty_1 {
 pub addr_len: __u16,
 pub __pad3: [__u16; 1usize],
@@ -258,6 +321,7 @@ pub __pad3: [__u16; 1usize],
 #[repr(C)]
 pub struct io_uring_sqe__bindgen_ty_6 {
 pub __bindgen_anon_1: __BindgenUnionField<io_uring_sqe__bindgen_ty_6__bindgen_ty_1>,
+pub optval: __BindgenUnionField<__u64>,
 pub cmd: __BindgenUnionField<[__u8; 0usize]>,
 pub bindgen_union_field: [u64; 2usize],
 }
@@ -419,6 +483,13 @@ pub resv: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_buf_status {
+pub buf_group: __u32,
+pub head: __u32,
+pub resv: [__u32; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -432,7 +503,9 @@ pub addr: __u64,
 pub fd: __s32,
 pub flags: __u32,
 pub timeout: __kernel_timespec,
-pub pad: [__u64; 4usize],
+pub opcode: __u8,
+pub pad: [__u8; 7usize],
+pub pad2: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -605,6 +678,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -676,6 +757,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const IORING_FILE_INDEX_ALLOC: i32 = -1;
 pub const IORING_SETUP_IOPOLL: u32 = 1;
 pub const IORING_SETUP_SQPOLL: u32 = 2;
@@ -693,8 +784,9 @@ pub const IORING_SETUP_SINGLE_ISSUER: u32 = 4096;
 pub const IORING_SETUP_DEFER_TASKRUN: u32 = 8192;
 pub const IORING_SETUP_NO_MMAP: u32 = 16384;
 pub const IORING_SETUP_REGISTERED_FD_ONLY: u32 = 32768;
+pub const IORING_SETUP_NO_SQARRAY: u32 = 65536;
 pub const IORING_URING_CMD_FIXED: u32 = 1;
-pub const IORING_URING_CMD_POLLED: u32 = 2147483648;
+pub const IORING_URING_CMD_MASK: u32 = 1;
 pub const IORING_FSYNC_DATASYNC: u32 = 1;
 pub const IORING_TIMEOUT_ABS: u32 = 1;
 pub const IORING_TIMEOUT_UPDATE: u32 = 2;
@@ -714,6 +806,8 @@ pub const IORING_ASYNC_CANCEL_ALL: u32 = 1;
 pub const IORING_ASYNC_CANCEL_FD: u32 = 2;
 pub const IORING_ASYNC_CANCEL_ANY: u32 = 4;
 pub const IORING_ASYNC_CANCEL_FD_FIXED: u32 = 8;
+pub const IORING_ASYNC_CANCEL_USERDATA: u32 = 16;
+pub const IORING_ASYNC_CANCEL_OP: u32 = 32;
 pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
@@ -722,6 +816,7 @@ pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
+pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
@@ -794,6 +889,7 @@ pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGIS
 pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
 pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
 pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
+pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
 pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
 pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
 pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
@@ -804,6 +900,10 @@ pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTR
 pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
 pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
 pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
+pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
+pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
+pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
+pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -816,6 +916,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -882,7 +983,13 @@ IORING_OP_SOCKET = 45,
 IORING_OP_URING_CMD = 46,
 IORING_OP_SEND_ZC = 47,
 IORING_OP_SENDMSG_ZC = 48,
-IORING_OP_LAST = 49,
+IORING_OP_READ_MULTISHOT = 49,
+IORING_OP_WAITID = 50,
+IORING_OP_FUTEX_WAIT = 51,
+IORING_OP_FUTEX_WAKE = 52,
+IORING_OP_FUTEX_WAITV = 53,
+IORING_OP_FIXED_FD_INSTALL = 54,
+IORING_OP_LAST = 55,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -927,7 +1034,8 @@ IORING_REGISTER_PBUF_RING = 22,
 IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
-IORING_REGISTER_LAST = 26,
+IORING_REGISTER_PBUF_STATUS = 26,
+IORING_REGISTER_LAST = 27,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
@@ -952,6 +1060,15 @@ IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
 IORING_RESTRICTION_SQE_FLAGS_REQUIRED = 3,
 IORING_RESTRICTION_LAST = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_8 {
+SOCKET_URING_OP_SIOCINQ = 0,
+SOCKET_URING_OP_SIOCOUTQ = 1,
+SOCKET_URING_OP_GETSOCKOPT = 2,
+SOCKET_URING_OP_SETSOCKOPT = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -979,6 +1096,7 @@ pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_1__bindgen_ty_1,
 pub union io_uring_sqe__bindgen_ty_2 {
 pub addr: __u64,
 pub splice_off_in: __u64,
+pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_2__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -1002,6 +1120,9 @@ pub hardlink_flags: __u32,
 pub xattr_flags: __u32,
 pub msg_ring_flags: __u32,
 pub uring_cmd_flags: __u32,
+pub waitid_flags: __u32,
+pub futex_flags: __u32,
+pub install_fd_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]
@@ -1014,6 +1135,7 @@ pub buf_group: __u16,
 pub union io_uring_sqe__bindgen_ty_5 {
 pub splice_fd_in: __s32,
 pub file_index: __u32,
+pub optlen: __u32,
 pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]

--- a/src/mips32r6/net.rs
+++ b/src/mips32r6/net.rs
@@ -427,6 +427,9 @@ pub tcpi_rcv_ooopack: __u32,
 pub tcpi_snd_wnd: __u32,
 pub tcpi_rcv_wnd: __u32,
 pub tcpi_rehash: __u32,
+pub tcpi_total_rto: __u16,
+pub tcpi_total_rto_recoveries: __u16,
+pub tcpi_total_rto_time: __u32,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -446,6 +449,82 @@ pub tcpm_prefixlen: __u8,
 pub tcpm_keylen: __u16,
 pub tcpm_addr: [__be32; 4usize],
 pub tcpm_key: [__u8; 80usize],
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_add {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub key: [__u8; 80usize],
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_del {
+pub addr: __kernel_sockaddr_storage,
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub current_key: __u8,
+pub rnext: __u8,
+pub keyflags: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_info_opt {
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub current_key: __u8,
+pub rnext: __u8,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+pub pkt_key_not_found: __u64,
+pub pkt_ao_required: __u64,
+pub pkt_dropped_icmp: __u64,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_getsockopt {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub key: [__u8; 80usize],
+pub nkeys: __u32,
+pub _bitfield_align_1: [u16; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub prefix: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub ifindex: __s32,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_repair {
+pub snt_isn: __be32,
+pub rcv_isn: __be32,
+pub snd_sne: __u32,
+pub rcv_sne: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1206,6 +1285,11 @@ pub const TCP_ZEROCOPY_RECEIVE: u32 = 35;
 pub const TCP_INQ: u32 = 36;
 pub const TCP_CM_INQ: u32 = 36;
 pub const TCP_TX_DELAY: u32 = 37;
+pub const TCP_AO_ADD_KEY: u32 = 38;
+pub const TCP_AO_DEL_KEY: u32 = 39;
+pub const TCP_AO_INFO: u32 = 40;
+pub const TCP_AO_GET_KEYS: u32 = 41;
+pub const TCP_AO_REPAIR: u32 = 42;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1215,9 +1299,13 @@ pub const TCPI_OPT_WSCALE: u32 = 4;
 pub const TCPI_OPT_ECN: u32 = 8;
 pub const TCPI_OPT_ECN_SEEN: u32 = 16;
 pub const TCPI_OPT_SYN_DATA: u32 = 32;
+pub const TCPI_OPT_USEC_TS: u32 = 64;
 pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
+pub const TCP_AO_MAXKEYLEN: u32 = 80;
+pub const TCP_AO_KEYF_IFINDEX: u32 = 1;
+pub const TCP_AO_KEYF_EXCLUDE_OPT: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
@@ -1582,6 +1670,7 @@ pub const DEVCONF_IOAM6_ID: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID;
 pub const DEVCONF_IOAM6_ID_WIDE: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID_WIDE;
 pub const DEVCONF_NDISC_EVICT_NOCARRIER: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_NDISC_EVICT_NOCARRIER;
 pub const DEVCONF_ACCEPT_UNTRACKED_NA: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_UNTRACKED_NA;
+pub const DEVCONF_ACCEPT_RA_MIN_LFT: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_RA_MIN_LFT;
 pub const DEVCONF_MAX: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_MAX;
 pub const TCP_FLAG_CWR: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_CWR;
 pub const TCP_FLAG_ECE: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_ECE;
@@ -1779,7 +1868,8 @@ DEVCONF_IOAM6_ID = 54,
 DEVCONF_IOAM6_ID_WIDE = 55,
 DEVCONF_NDISC_EVICT_NOCARRIER = 56,
 DEVCONF_ACCEPT_UNTRACKED_NA = 57,
-DEVCONF_MAX = 58,
+DEVCONF_ACCEPT_RA_MIN_LFT = 58,
+DEVCONF_MAX = 59,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2497,6 +2587,289 @@ tcpi_delivery_rate_app_limited as u64
 __bindgen_bitfield_unit.set(9usize, 2u8, {
 let tcpi_fastopen_client_fail: u8 = unsafe { ::core::mem::transmute(tcpi_fastopen_client_fail) };
 tcpi_fastopen_client_fail as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_add {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 30u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 30u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_del {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn del_async(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_del_async(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 29u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 29u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, del_async: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let del_async: u32 = unsafe { ::core::mem::transmute(del_async) };
+del_async as u64
+});
+__bindgen_bitfield_unit.set(3usize, 29u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_info_opt {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn ao_required(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_ao_required(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_counters(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_counters(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn accept_icmps(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_accept_icmps(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(4usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(5usize, 27u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(5usize, 27u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, ao_required: __u32, set_counters: __u32, accept_icmps: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let ao_required: u32 = unsafe { ::core::mem::transmute(ao_required) };
+ao_required as u64
+});
+__bindgen_bitfield_unit.set(3usize, 1u8, {
+let set_counters: u32 = unsafe { ::core::mem::transmute(set_counters) };
+set_counters as u64
+});
+__bindgen_bitfield_unit.set(4usize, 1u8, {
+let accept_icmps: u32 = unsafe { ::core::mem::transmute(accept_icmps) };
+accept_icmps as u64
+});
+__bindgen_bitfield_unit.set(5usize, 27u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_getsockopt {
+#[inline]
+pub fn is_current(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_current(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn is_rnext(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_rnext(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn get_all(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_get_all(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 13u8) as u16) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 13u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(is_current: __u16, is_rnext: __u16, get_all: __u16, reserved: __u16) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let is_current: u16 = unsafe { ::core::mem::transmute(is_current) };
+is_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let is_rnext: u16 = unsafe { ::core::mem::transmute(is_rnext) };
+is_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let get_all: u16 = unsafe { ::core::mem::transmute(get_all) };
+get_all as u64
+});
+__bindgen_bitfield_unit.set(3usize, 13u8, {
+let reserved: u16 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
 });
 __bindgen_bitfield_unit
 }

--- a/src/mips32r6/netlink.rs
+++ b/src/mips32r6/netlink.rs
@@ -732,7 +732,8 @@ pub const RTAX_FEATURE_ECN: u32 = 1;
 pub const RTAX_FEATURE_SACK: u32 = 2;
 pub const RTAX_FEATURE_TIMESTAMP: u32 = 4;
 pub const RTAX_FEATURE_ALLFRAG: u32 = 8;
-pub const RTAX_FEATURE_MASK: u32 = 15;
+pub const RTAX_FEATURE_TCP_USEC_TS: u32 = 16;
+pub const RTAX_FEATURE_MASK: u32 = 31;
 pub const TCM_IFINDEX_MAGIC_BLOCK: u32 = 4294967295;
 pub const TCA_DUMP_FLAGS_TERSE: u32 = 1;
 pub const RTMGRP_LINK: u32 = 1;
@@ -829,6 +830,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_2 = _bindgen_ty_2::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_2 = _bindgen_ty_2::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_MASK;
@@ -897,6 +899,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_6 = _bindgen_ty_6::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_HAIRPIN;
@@ -944,6 +948,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_KIND;
@@ -1005,501 +1010,510 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_17 = _bindgen_ty_17::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_18 = _bindgen_ty_18::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_21 = _bindgen_ty_21::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_44 = _bindgen_ty_44::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_DSA_MAX;
-pub const IFA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFA_UNSPEC;
-pub const IFA_ADDRESS: _bindgen_ty_54 = _bindgen_ty_54::IFA_ADDRESS;
-pub const IFA_LOCAL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LOCAL;
-pub const IFA_LABEL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LABEL;
-pub const IFA_BROADCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_BROADCAST;
-pub const IFA_ANYCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_ANYCAST;
-pub const IFA_CACHEINFO: _bindgen_ty_54 = _bindgen_ty_54::IFA_CACHEINFO;
-pub const IFA_MULTICAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_MULTICAST;
-pub const IFA_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFA_FLAGS;
-pub const IFA_RT_PRIORITY: _bindgen_ty_54 = _bindgen_ty_54::IFA_RT_PRIORITY;
-pub const IFA_TARGET_NETNSID: _bindgen_ty_54 = _bindgen_ty_54::IFA_TARGET_NETNSID;
-pub const IFA_PROTO: _bindgen_ty_54 = _bindgen_ty_54::IFA_PROTO;
-pub const __IFA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFA_MAX;
-pub const NDA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::NDA_UNSPEC;
-pub const NDA_DST: _bindgen_ty_55 = _bindgen_ty_55::NDA_DST;
-pub const NDA_LLADDR: _bindgen_ty_55 = _bindgen_ty_55::NDA_LLADDR;
-pub const NDA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::NDA_CACHEINFO;
-pub const NDA_PROBES: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROBES;
-pub const NDA_VLAN: _bindgen_ty_55 = _bindgen_ty_55::NDA_VLAN;
-pub const NDA_PORT: _bindgen_ty_55 = _bindgen_ty_55::NDA_PORT;
-pub const NDA_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_VNI;
-pub const NDA_IFINDEX: _bindgen_ty_55 = _bindgen_ty_55::NDA_IFINDEX;
-pub const NDA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::NDA_MASTER;
-pub const NDA_LINK_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::NDA_LINK_NETNSID;
-pub const NDA_SRC_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_SRC_VNI;
-pub const NDA_PROTOCOL: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROTOCOL;
-pub const NDA_NH_ID: _bindgen_ty_55 = _bindgen_ty_55::NDA_NH_ID;
-pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_55 = _bindgen_ty_55::NDA_FDB_EXT_ATTRS;
-pub const NDA_FLAGS_EXT: _bindgen_ty_55 = _bindgen_ty_55::NDA_FLAGS_EXT;
-pub const NDA_NDM_STATE_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_STATE_MASK;
-pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_FLAGS_MASK;
-pub const __NDA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__NDA_MAX;
-pub const NDTPA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UNSPEC;
-pub const NDTPA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_IFINDEX;
-pub const NDTPA_REFCNT: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REFCNT;
-pub const NDTPA_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REACHABLE_TIME;
-pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_BASE_REACHABLE_TIME;
-pub const NDTPA_RETRANS_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_RETRANS_TIME;
-pub const NDTPA_GC_STALETIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_GC_STALETIME;
-pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_DELAY_PROBE_TIME;
-pub const NDTPA_QUEUE_LEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LEN;
-pub const NDTPA_APP_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_APP_PROBES;
-pub const NDTPA_UCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UCAST_PROBES;
-pub const NDTPA_MCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_PROBES;
-pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_ANYCAST_DELAY;
-pub const NDTPA_PROXY_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_DELAY;
-pub const NDTPA_PROXY_QLEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_QLEN;
-pub const NDTPA_LOCKTIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_LOCKTIME;
-pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LENBYTES;
-pub const NDTPA_MCAST_REPROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_REPROBES;
-pub const NDTPA_PAD: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PAD;
-pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_INTERVAL_PROBE_TIME_MS;
-pub const __NDTPA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDTPA_MAX;
-pub const NDTA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTA_UNSPEC;
-pub const NDTA_NAME: _bindgen_ty_57 = _bindgen_ty_57::NDTA_NAME;
-pub const NDTA_THRESH1: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH1;
-pub const NDTA_THRESH2: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH2;
-pub const NDTA_THRESH3: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH3;
-pub const NDTA_CONFIG: _bindgen_ty_57 = _bindgen_ty_57::NDTA_CONFIG;
-pub const NDTA_PARMS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PARMS;
-pub const NDTA_STATS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_STATS;
-pub const NDTA_GC_INTERVAL: _bindgen_ty_57 = _bindgen_ty_57::NDTA_GC_INTERVAL;
-pub const NDTA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PAD;
-pub const __NDTA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTA_MAX;
-pub const FDB_NOTIFY_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_BIT;
-pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_INACTIVE_BIT;
-pub const NFEA_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::NFEA_UNSPEC;
-pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_59 = _bindgen_ty_59::NFEA_ACTIVITY_NOTIFY;
-pub const NFEA_DONT_REFRESH: _bindgen_ty_59 = _bindgen_ty_59::NFEA_DONT_REFRESH;
-pub const __NFEA_MAX: _bindgen_ty_59 = _bindgen_ty_59::__NFEA_MAX;
-pub const RTM_BASE: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_NEWLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_DELLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINK;
-pub const RTM_GETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINK;
-pub const RTM_SETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETLINK;
-pub const RTM_NEWADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDR;
-pub const RTM_DELADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDR;
-pub const RTM_GETADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDR;
-pub const RTM_NEWROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWROUTE;
-pub const RTM_DELROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELROUTE;
-pub const RTM_GETROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETROUTE;
-pub const RTM_NEWNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGH;
-pub const RTM_DELNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEIGH;
-pub const RTM_GETNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGH;
-pub const RTM_NEWRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWRULE;
-pub const RTM_DELRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELRULE;
-pub const RTM_GETRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETRULE;
-pub const RTM_NEWQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWQDISC;
-pub const RTM_DELQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELQDISC;
-pub const RTM_GETQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETQDISC;
-pub const RTM_NEWTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTCLASS;
-pub const RTM_DELTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTCLASS;
-pub const RTM_GETTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTCLASS;
-pub const RTM_NEWTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTFILTER;
-pub const RTM_DELTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTFILTER;
-pub const RTM_GETTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTFILTER;
-pub const RTM_NEWACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWACTION;
-pub const RTM_DELACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELACTION;
-pub const RTM_GETACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETACTION;
-pub const RTM_NEWPREFIX: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWPREFIX;
-pub const RTM_GETMULTICAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMULTICAST;
-pub const RTM_GETANYCAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETANYCAST;
-pub const RTM_NEWNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGHTBL;
-pub const RTM_GETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGHTBL;
-pub const RTM_SETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETNEIGHTBL;
-pub const RTM_NEWNDUSEROPT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNDUSEROPT;
-pub const RTM_NEWADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDRLABEL;
-pub const RTM_DELADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDRLABEL;
-pub const RTM_GETADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDRLABEL;
-pub const RTM_GETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETDCB;
-pub const RTM_SETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETDCB;
-pub const RTM_NEWNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNETCONF;
-pub const RTM_DELNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNETCONF;
-pub const RTM_GETNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNETCONF;
-pub const RTM_NEWMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWMDB;
-pub const RTM_DELMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELMDB;
-pub const RTM_GETMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMDB;
-pub const RTM_NEWNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNSID;
-pub const RTM_DELNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNSID;
-pub const RTM_GETNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNSID;
-pub const RTM_NEWSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWSTATS;
-pub const RTM_GETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETSTATS;
-pub const RTM_SETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETSTATS;
-pub const RTM_NEWCACHEREPORT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCACHEREPORT;
-pub const RTM_NEWCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCHAIN;
-pub const RTM_DELCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELCHAIN;
-pub const RTM_GETCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETCHAIN;
-pub const RTM_NEWNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOP;
-pub const RTM_DELNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOP;
-pub const RTM_GETNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOP;
-pub const RTM_NEWLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWLINKPROP;
-pub const RTM_DELLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINKPROP;
-pub const RTM_GETLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINKPROP;
-pub const RTM_NEWVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWVLAN;
-pub const RTM_DELVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELVLAN;
-pub const RTM_GETVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETVLAN;
-pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOPBUCKET;
-pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOPBUCKET;
-pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOPBUCKET;
-pub const RTM_NEWTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTUNNEL;
-pub const RTM_DELTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTUNNEL;
-pub const RTM_GETTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTUNNEL;
-pub const __RTM_MAX: _bindgen_ty_60 = _bindgen_ty_60::__RTM_MAX;
-pub const RTN_UNSPEC: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNSPEC;
-pub const RTN_UNICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNICAST;
-pub const RTN_LOCAL: _bindgen_ty_61 = _bindgen_ty_61::RTN_LOCAL;
-pub const RTN_BROADCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_BROADCAST;
-pub const RTN_ANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_ANYCAST;
-pub const RTN_MULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_MULTICAST;
-pub const RTN_BLACKHOLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_BLACKHOLE;
-pub const RTN_UNREACHABLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNREACHABLE;
-pub const RTN_PROHIBIT: _bindgen_ty_61 = _bindgen_ty_61::RTN_PROHIBIT;
-pub const RTN_THROW: _bindgen_ty_61 = _bindgen_ty_61::RTN_THROW;
-pub const RTN_NAT: _bindgen_ty_61 = _bindgen_ty_61::RTN_NAT;
-pub const RTN_XRESOLVE: _bindgen_ty_61 = _bindgen_ty_61::RTN_XRESOLVE;
-pub const __RTN_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTN_MAX;
-pub const RTAX_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTAX_UNSPEC;
-pub const RTAX_LOCK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_LOCK;
-pub const RTAX_MTU: _bindgen_ty_62 = _bindgen_ty_62::RTAX_MTU;
-pub const RTAX_WINDOW: _bindgen_ty_62 = _bindgen_ty_62::RTAX_WINDOW;
-pub const RTAX_RTT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTT;
-pub const RTAX_RTTVAR: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTTVAR;
-pub const RTAX_SSTHRESH: _bindgen_ty_62 = _bindgen_ty_62::RTAX_SSTHRESH;
-pub const RTAX_CWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CWND;
-pub const RTAX_ADVMSS: _bindgen_ty_62 = _bindgen_ty_62::RTAX_ADVMSS;
-pub const RTAX_REORDERING: _bindgen_ty_62 = _bindgen_ty_62::RTAX_REORDERING;
-pub const RTAX_HOPLIMIT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_HOPLIMIT;
-pub const RTAX_INITCWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITCWND;
-pub const RTAX_FEATURES: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FEATURES;
-pub const RTAX_RTO_MIN: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTO_MIN;
-pub const RTAX_INITRWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITRWND;
-pub const RTAX_QUICKACK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_QUICKACK;
-pub const RTAX_CC_ALGO: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CC_ALGO;
-pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FASTOPEN_NO_COOKIE;
-pub const __RTAX_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTAX_MAX;
-pub const PREFIX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_UNSPEC;
-pub const PREFIX_ADDRESS: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_ADDRESS;
-pub const PREFIX_CACHEINFO: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_CACHEINFO;
-pub const __PREFIX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__PREFIX_MAX;
-pub const TCA_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::TCA_UNSPEC;
-pub const TCA_KIND: _bindgen_ty_64 = _bindgen_ty_64::TCA_KIND;
-pub const TCA_OPTIONS: _bindgen_ty_64 = _bindgen_ty_64::TCA_OPTIONS;
-pub const TCA_STATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS;
-pub const TCA_XSTATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_XSTATS;
-pub const TCA_RATE: _bindgen_ty_64 = _bindgen_ty_64::TCA_RATE;
-pub const TCA_FCNT: _bindgen_ty_64 = _bindgen_ty_64::TCA_FCNT;
-pub const TCA_STATS2: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS2;
-pub const TCA_STAB: _bindgen_ty_64 = _bindgen_ty_64::TCA_STAB;
-pub const TCA_PAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_PAD;
-pub const TCA_DUMP_INVISIBLE: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_INVISIBLE;
-pub const TCA_CHAIN: _bindgen_ty_64 = _bindgen_ty_64::TCA_CHAIN;
-pub const TCA_HW_OFFLOAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_HW_OFFLOAD;
-pub const TCA_INGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_INGRESS_BLOCK;
-pub const TCA_EGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_EGRESS_BLOCK;
-pub const TCA_DUMP_FLAGS: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_FLAGS;
-pub const TCA_EXT_WARN_MSG: _bindgen_ty_64 = _bindgen_ty_64::TCA_EXT_WARN_MSG;
-pub const __TCA_MAX: _bindgen_ty_64 = _bindgen_ty_64::__TCA_MAX;
-pub const NDUSEROPT_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_UNSPEC;
-pub const NDUSEROPT_SRCADDR: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_SRCADDR;
-pub const __NDUSEROPT_MAX: _bindgen_ty_65 = _bindgen_ty_65::__NDUSEROPT_MAX;
-pub const TCA_ROOT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_UNSPEC;
-pub const TCA_ROOT_TAB: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TAB;
-pub const TCA_ROOT_FLAGS: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_FLAGS;
-pub const TCA_ROOT_COUNT: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_COUNT;
-pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TIME_DELTA;
-pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_EXT_WARN_MSG;
-pub const __TCA_ROOT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__TCA_ROOT_MAX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_18 = _bindgen_ty_18::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_39 = _bindgen_ty_39::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_45 = _bindgen_ty_45::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_DSA_MAX;
+pub const IFA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFA_UNSPEC;
+pub const IFA_ADDRESS: _bindgen_ty_55 = _bindgen_ty_55::IFA_ADDRESS;
+pub const IFA_LOCAL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LOCAL;
+pub const IFA_LABEL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LABEL;
+pub const IFA_BROADCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_BROADCAST;
+pub const IFA_ANYCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_ANYCAST;
+pub const IFA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::IFA_CACHEINFO;
+pub const IFA_MULTICAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_MULTICAST;
+pub const IFA_FLAGS: _bindgen_ty_55 = _bindgen_ty_55::IFA_FLAGS;
+pub const IFA_RT_PRIORITY: _bindgen_ty_55 = _bindgen_ty_55::IFA_RT_PRIORITY;
+pub const IFA_TARGET_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::IFA_TARGET_NETNSID;
+pub const IFA_PROTO: _bindgen_ty_55 = _bindgen_ty_55::IFA_PROTO;
+pub const __IFA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFA_MAX;
+pub const NDA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDA_UNSPEC;
+pub const NDA_DST: _bindgen_ty_56 = _bindgen_ty_56::NDA_DST;
+pub const NDA_LLADDR: _bindgen_ty_56 = _bindgen_ty_56::NDA_LLADDR;
+pub const NDA_CACHEINFO: _bindgen_ty_56 = _bindgen_ty_56::NDA_CACHEINFO;
+pub const NDA_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROBES;
+pub const NDA_VLAN: _bindgen_ty_56 = _bindgen_ty_56::NDA_VLAN;
+pub const NDA_PORT: _bindgen_ty_56 = _bindgen_ty_56::NDA_PORT;
+pub const NDA_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_VNI;
+pub const NDA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDA_IFINDEX;
+pub const NDA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::NDA_MASTER;
+pub const NDA_LINK_NETNSID: _bindgen_ty_56 = _bindgen_ty_56::NDA_LINK_NETNSID;
+pub const NDA_SRC_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_SRC_VNI;
+pub const NDA_PROTOCOL: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROTOCOL;
+pub const NDA_NH_ID: _bindgen_ty_56 = _bindgen_ty_56::NDA_NH_ID;
+pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_56 = _bindgen_ty_56::NDA_FDB_EXT_ATTRS;
+pub const NDA_FLAGS_EXT: _bindgen_ty_56 = _bindgen_ty_56::NDA_FLAGS_EXT;
+pub const NDA_NDM_STATE_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_STATE_MASK;
+pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_FLAGS_MASK;
+pub const __NDA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDA_MAX;
+pub const NDTPA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UNSPEC;
+pub const NDTPA_IFINDEX: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_IFINDEX;
+pub const NDTPA_REFCNT: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REFCNT;
+pub const NDTPA_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REACHABLE_TIME;
+pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_BASE_REACHABLE_TIME;
+pub const NDTPA_RETRANS_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_RETRANS_TIME;
+pub const NDTPA_GC_STALETIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_GC_STALETIME;
+pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_DELAY_PROBE_TIME;
+pub const NDTPA_QUEUE_LEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LEN;
+pub const NDTPA_APP_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_APP_PROBES;
+pub const NDTPA_UCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UCAST_PROBES;
+pub const NDTPA_MCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_PROBES;
+pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_ANYCAST_DELAY;
+pub const NDTPA_PROXY_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_DELAY;
+pub const NDTPA_PROXY_QLEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_QLEN;
+pub const NDTPA_LOCKTIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_LOCKTIME;
+pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LENBYTES;
+pub const NDTPA_MCAST_REPROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_REPROBES;
+pub const NDTPA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PAD;
+pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_INTERVAL_PROBE_TIME_MS;
+pub const __NDTPA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTPA_MAX;
+pub const NDTA_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDTA_UNSPEC;
+pub const NDTA_NAME: _bindgen_ty_58 = _bindgen_ty_58::NDTA_NAME;
+pub const NDTA_THRESH1: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH1;
+pub const NDTA_THRESH2: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH2;
+pub const NDTA_THRESH3: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH3;
+pub const NDTA_CONFIG: _bindgen_ty_58 = _bindgen_ty_58::NDTA_CONFIG;
+pub const NDTA_PARMS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PARMS;
+pub const NDTA_STATS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_STATS;
+pub const NDTA_GC_INTERVAL: _bindgen_ty_58 = _bindgen_ty_58::NDTA_GC_INTERVAL;
+pub const NDTA_PAD: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PAD;
+pub const __NDTA_MAX: _bindgen_ty_58 = _bindgen_ty_58::__NDTA_MAX;
+pub const FDB_NOTIFY_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_BIT;
+pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_INACTIVE_BIT;
+pub const NFEA_UNSPEC: _bindgen_ty_60 = _bindgen_ty_60::NFEA_UNSPEC;
+pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_60 = _bindgen_ty_60::NFEA_ACTIVITY_NOTIFY;
+pub const NFEA_DONT_REFRESH: _bindgen_ty_60 = _bindgen_ty_60::NFEA_DONT_REFRESH;
+pub const __NFEA_MAX: _bindgen_ty_60 = _bindgen_ty_60::__NFEA_MAX;
+pub const RTM_BASE: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_NEWLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_DELLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINK;
+pub const RTM_GETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINK;
+pub const RTM_SETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETLINK;
+pub const RTM_NEWADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDR;
+pub const RTM_DELADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDR;
+pub const RTM_GETADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDR;
+pub const RTM_NEWROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWROUTE;
+pub const RTM_DELROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELROUTE;
+pub const RTM_GETROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETROUTE;
+pub const RTM_NEWNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGH;
+pub const RTM_DELNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEIGH;
+pub const RTM_GETNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGH;
+pub const RTM_NEWRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWRULE;
+pub const RTM_DELRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELRULE;
+pub const RTM_GETRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETRULE;
+pub const RTM_NEWQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWQDISC;
+pub const RTM_DELQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELQDISC;
+pub const RTM_GETQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETQDISC;
+pub const RTM_NEWTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTCLASS;
+pub const RTM_DELTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTCLASS;
+pub const RTM_GETTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTCLASS;
+pub const RTM_NEWTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTFILTER;
+pub const RTM_DELTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTFILTER;
+pub const RTM_GETTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTFILTER;
+pub const RTM_NEWACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWACTION;
+pub const RTM_DELACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELACTION;
+pub const RTM_GETACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETACTION;
+pub const RTM_NEWPREFIX: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWPREFIX;
+pub const RTM_GETMULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMULTICAST;
+pub const RTM_GETANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETANYCAST;
+pub const RTM_NEWNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGHTBL;
+pub const RTM_GETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGHTBL;
+pub const RTM_SETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETNEIGHTBL;
+pub const RTM_NEWNDUSEROPT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNDUSEROPT;
+pub const RTM_NEWADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDRLABEL;
+pub const RTM_DELADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDRLABEL;
+pub const RTM_GETADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDRLABEL;
+pub const RTM_GETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETDCB;
+pub const RTM_SETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETDCB;
+pub const RTM_NEWNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNETCONF;
+pub const RTM_DELNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNETCONF;
+pub const RTM_GETNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNETCONF;
+pub const RTM_NEWMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWMDB;
+pub const RTM_DELMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELMDB;
+pub const RTM_GETMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMDB;
+pub const RTM_NEWNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNSID;
+pub const RTM_DELNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNSID;
+pub const RTM_GETNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNSID;
+pub const RTM_NEWSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWSTATS;
+pub const RTM_GETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETSTATS;
+pub const RTM_SETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETSTATS;
+pub const RTM_NEWCACHEREPORT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCACHEREPORT;
+pub const RTM_NEWCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCHAIN;
+pub const RTM_DELCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELCHAIN;
+pub const RTM_GETCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETCHAIN;
+pub const RTM_NEWNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOP;
+pub const RTM_DELNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOP;
+pub const RTM_GETNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOP;
+pub const RTM_NEWLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWLINKPROP;
+pub const RTM_DELLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINKPROP;
+pub const RTM_GETLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINKPROP;
+pub const RTM_NEWVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWVLAN;
+pub const RTM_DELVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELVLAN;
+pub const RTM_GETVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETVLAN;
+pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOPBUCKET;
+pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOPBUCKET;
+pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOPBUCKET;
+pub const RTM_NEWTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTUNNEL;
+pub const RTM_DELTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTUNNEL;
+pub const RTM_GETTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTUNNEL;
+pub const __RTM_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTM_MAX;
+pub const RTN_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNSPEC;
+pub const RTN_UNICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNICAST;
+pub const RTN_LOCAL: _bindgen_ty_62 = _bindgen_ty_62::RTN_LOCAL;
+pub const RTN_BROADCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_BROADCAST;
+pub const RTN_ANYCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_ANYCAST;
+pub const RTN_MULTICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_MULTICAST;
+pub const RTN_BLACKHOLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_BLACKHOLE;
+pub const RTN_UNREACHABLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNREACHABLE;
+pub const RTN_PROHIBIT: _bindgen_ty_62 = _bindgen_ty_62::RTN_PROHIBIT;
+pub const RTN_THROW: _bindgen_ty_62 = _bindgen_ty_62::RTN_THROW;
+pub const RTN_NAT: _bindgen_ty_62 = _bindgen_ty_62::RTN_NAT;
+pub const RTN_XRESOLVE: _bindgen_ty_62 = _bindgen_ty_62::RTN_XRESOLVE;
+pub const __RTN_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTN_MAX;
+pub const RTAX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::RTAX_UNSPEC;
+pub const RTAX_LOCK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_LOCK;
+pub const RTAX_MTU: _bindgen_ty_63 = _bindgen_ty_63::RTAX_MTU;
+pub const RTAX_WINDOW: _bindgen_ty_63 = _bindgen_ty_63::RTAX_WINDOW;
+pub const RTAX_RTT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTT;
+pub const RTAX_RTTVAR: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTTVAR;
+pub const RTAX_SSTHRESH: _bindgen_ty_63 = _bindgen_ty_63::RTAX_SSTHRESH;
+pub const RTAX_CWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CWND;
+pub const RTAX_ADVMSS: _bindgen_ty_63 = _bindgen_ty_63::RTAX_ADVMSS;
+pub const RTAX_REORDERING: _bindgen_ty_63 = _bindgen_ty_63::RTAX_REORDERING;
+pub const RTAX_HOPLIMIT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_HOPLIMIT;
+pub const RTAX_INITCWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITCWND;
+pub const RTAX_FEATURES: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FEATURES;
+pub const RTAX_RTO_MIN: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTO_MIN;
+pub const RTAX_INITRWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITRWND;
+pub const RTAX_QUICKACK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_QUICKACK;
+pub const RTAX_CC_ALGO: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CC_ALGO;
+pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FASTOPEN_NO_COOKIE;
+pub const __RTAX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__RTAX_MAX;
+pub const PREFIX_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_UNSPEC;
+pub const PREFIX_ADDRESS: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_ADDRESS;
+pub const PREFIX_CACHEINFO: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_CACHEINFO;
+pub const __PREFIX_MAX: _bindgen_ty_64 = _bindgen_ty_64::__PREFIX_MAX;
+pub const TCA_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::TCA_UNSPEC;
+pub const TCA_KIND: _bindgen_ty_65 = _bindgen_ty_65::TCA_KIND;
+pub const TCA_OPTIONS: _bindgen_ty_65 = _bindgen_ty_65::TCA_OPTIONS;
+pub const TCA_STATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS;
+pub const TCA_XSTATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_XSTATS;
+pub const TCA_RATE: _bindgen_ty_65 = _bindgen_ty_65::TCA_RATE;
+pub const TCA_FCNT: _bindgen_ty_65 = _bindgen_ty_65::TCA_FCNT;
+pub const TCA_STATS2: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS2;
+pub const TCA_STAB: _bindgen_ty_65 = _bindgen_ty_65::TCA_STAB;
+pub const TCA_PAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_PAD;
+pub const TCA_DUMP_INVISIBLE: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_INVISIBLE;
+pub const TCA_CHAIN: _bindgen_ty_65 = _bindgen_ty_65::TCA_CHAIN;
+pub const TCA_HW_OFFLOAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_HW_OFFLOAD;
+pub const TCA_INGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_INGRESS_BLOCK;
+pub const TCA_EGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_EGRESS_BLOCK;
+pub const TCA_DUMP_FLAGS: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_FLAGS;
+pub const TCA_EXT_WARN_MSG: _bindgen_ty_65 = _bindgen_ty_65::TCA_EXT_WARN_MSG;
+pub const __TCA_MAX: _bindgen_ty_65 = _bindgen_ty_65::__TCA_MAX;
+pub const NDUSEROPT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_UNSPEC;
+pub const NDUSEROPT_SRCADDR: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_SRCADDR;
+pub const __NDUSEROPT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__NDUSEROPT_MAX;
+pub const TCA_ROOT_UNSPEC: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_UNSPEC;
+pub const TCA_ROOT_TAB: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TAB;
+pub const TCA_ROOT_FLAGS: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_FLAGS;
+pub const TCA_ROOT_COUNT: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_COUNT;
+pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TIME_DELTA;
+pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_EXT_WARN_MSG;
+pub const __TCA_ROOT_MAX: _bindgen_ty_67 = _bindgen_ty_67::__TCA_ROOT_MAX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1550,6 +1564,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1639,7 +1655,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1735,7 +1752,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1792,7 +1811,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1945,10 +1965,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_18 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_19 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -1964,7 +2012,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_19 {
+pub enum _bindgen_ty_20 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -1976,7 +2024,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_20 {
+pub enum _bindgen_ty_21 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -1984,7 +2032,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2017,7 +2065,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2031,7 +2080,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_23 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2061,7 +2118,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2072,7 +2129,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum _bindgen_ty_25 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2087,7 +2144,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2100,7 +2157,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2138,7 +2195,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2150,7 +2207,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2166,7 +2223,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2174,7 +2231,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2194,7 +2251,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2202,7 +2259,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2211,7 +2268,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2226,7 +2283,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2234,7 +2291,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2248,7 +2305,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2257,7 +2314,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2275,7 +2332,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2285,14 +2342,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2300,7 +2357,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2314,7 +2371,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2326,7 +2383,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2335,7 +2392,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2344,7 +2401,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2354,7 +2411,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2363,7 +2420,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2373,7 +2430,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2388,7 +2445,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2400,7 +2457,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2416,7 +2473,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2425,7 +2482,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2433,15 +2490,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFA_UNSPEC = 0,
 IFA_ADDRESS = 1,
 IFA_LOCAL = 2,
@@ -2459,7 +2516,7 @@ __IFA_MAX = 12,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 NDA_UNSPEC = 0,
 NDA_DST = 1,
 NDA_LLADDR = 2,
@@ -2483,7 +2540,7 @@ __NDA_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 NDTPA_UNSPEC = 0,
 NDTPA_IFINDEX = 1,
 NDTPA_REFCNT = 2,
@@ -2509,7 +2566,7 @@ __NDTPA_MAX = 20,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_57 {
+pub enum _bindgen_ty_58 {
 NDTA_UNSPEC = 0,
 NDTA_NAME = 1,
 NDTA_THRESH1 = 2,
@@ -2525,14 +2582,14 @@ __NDTA_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_58 {
+pub enum _bindgen_ty_59 {
 FDB_NOTIFY_BIT = 1,
 FDB_NOTIFY_INACTIVE_BIT = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_59 {
+pub enum _bindgen_ty_60 {
 NFEA_UNSPEC = 0,
 NFEA_ACTIVITY_NOTIFY = 1,
 NFEA_DONT_REFRESH = 2,
@@ -2541,7 +2598,7 @@ __NFEA_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_60 {
+pub enum _bindgen_ty_61 {
 RTM_BASE = 16,
 RTM_DELLINK = 17,
 RTM_GETLINK = 18,
@@ -2618,7 +2675,7 @@ __RTM_MAX = 123,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_61 {
+pub enum _bindgen_ty_62 {
 RTN_UNSPEC = 0,
 RTN_UNICAST = 1,
 RTN_LOCAL = 2,
@@ -2694,7 +2751,7 @@ __RTA_MAX = 31,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_62 {
+pub enum _bindgen_ty_63 {
 RTAX_UNSPEC = 0,
 RTAX_LOCK = 1,
 RTAX_MTU = 2,
@@ -2718,7 +2775,7 @@ __RTAX_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_63 {
+pub enum _bindgen_ty_64 {
 PREFIX_UNSPEC = 0,
 PREFIX_ADDRESS = 1,
 PREFIX_CACHEINFO = 2,
@@ -2727,7 +2784,7 @@ __PREFIX_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_64 {
+pub enum _bindgen_ty_65 {
 TCA_UNSPEC = 0,
 TCA_KIND = 1,
 TCA_OPTIONS = 2,
@@ -2750,7 +2807,7 @@ __TCA_MAX = 17,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_65 {
+pub enum _bindgen_ty_66 {
 NDUSEROPT_UNSPEC = 0,
 NDUSEROPT_SRCADDR = 1,
 __NDUSEROPT_MAX = 2,
@@ -2801,7 +2858,7 @@ __RTNLGRP_MAX = 37,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_66 {
+pub enum _bindgen_ty_67 {
 TCA_ROOT_UNSPEC = 0,
 TCA_ROOT_TAB = 1,
 TCA_ROOT_FLAGS = 2,
@@ -2864,6 +2921,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/mips32r6/prctl.rs
+++ b/src/mips32r6/prctl.rs
@@ -226,6 +226,7 @@ pub const PR_SME_VL_LEN_MASK: u32 = 65535;
 pub const PR_SME_VL_INHERIT: u32 = 131072;
 pub const PR_SET_MDWE: u32 = 65;
 pub const PR_MDWE_REFUSE_EXEC_GAIN: u32 = 1;
+pub const PR_MDWE_NO_INHERIT: u32 = 2;
 pub const PR_GET_MDWE: u32 = 66;
 pub const PR_SET_VMA: u32 = 1398164801;
 pub const PR_SET_VMA_ANON_NAME: u32 = 0;

--- a/src/mips32r6/xdp.rs
+++ b/src/mips32r6/xdp.rs
@@ -81,6 +81,7 @@ pub len: __u64,
 pub chunk_size: __u32,
 pub headroom: __u32,
 pub flags: __u32,
+pub tx_metadata_len: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -96,6 +97,23 @@ pub tx_ring_empty_descs: __u64,
 #[derive(Debug, Copy, Clone)]
 pub struct xdp_options {
 pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct xsk_tx_metadata {
+pub flags: __u64,
+pub __bindgen_anon_1: xsk_tx_metadata__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1 {
+pub csum_start: __u16,
+pub csum_offset: __u16,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2 {
+pub tx_timestamp: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -148,7 +166,9 @@ pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
 pub const XDP_USE_NEED_WAKEUP: u32 = 8;
+pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
+pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;
@@ -165,5 +185,13 @@ pub const XDP_UMEM_PGOFF_FILL_RING: u64 = 4294967296;
 pub const XDP_UMEM_PGOFF_COMPLETION_RING: u64 = 6442450944;
 pub const XSK_UNALIGNED_BUF_OFFSET_SHIFT: u32 = 48;
 pub const XSK_UNALIGNED_BUF_ADDR_MASK: u64 = 281474976710655;
-pub const XDP_USE_SG: u32 = 16;
+pub const XDP_TXMD_FLAGS_TIMESTAMP: u32 = 1;
+pub const XDP_TXMD_FLAGS_CHECKSUM: u32 = 2;
 pub const XDP_PKT_CONTD: u32 = 1;
+pub const XDP_TX_METADATA: u32 = 2;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union xsk_tx_metadata__bindgen_ty_1 {
+pub request: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1,
+pub completion: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2,
+}

--- a/src/mips64/general.rs
+++ b/src/mips64/general.rs
@@ -184,7 +184,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -239,6 +240,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -297,6 +331,29 @@ pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
 pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -391,36 +448,6 @@ pub it_value: __kernel_old_timeval,
 pub struct __kernel_sock_timeval {
 pub tv_sec: __s64,
 pub tv_usec: __s64,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timespec {
-pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: crate::ctypes::c_long,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timeval {
-pub tv_sec: __kernel_old_time_t,
-pub tv_usec: __kernel_suseconds_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerspec {
-pub it_interval: timespec,
-pub it_value: timespec,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerval {
-pub it_interval: timeval,
-pub it_value: timeval,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timezone {
-pub tz_minuteswest: crate::ctypes::c_int,
-pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -702,6 +729,36 @@ pub c_cc: [crate::ctypes::c_uchar; 23usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct timespec {
+pub tv_sec: __kernel_old_time_t,
+pub tv_nsec: crate::ctypes::c_long,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timeval {
+pub tv_sec: __kernel_old_time_t,
+pub tv_usec: __kernel_suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerspec {
+pub it_interval: timespec,
+pub it_value: timespec,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerval {
+pub it_interval: timeval,
+pub it_value: timeval,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timezone {
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct iovec {
 pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
@@ -795,6 +852,22 @@ pub struct uffdio_continue {
 pub range: uffdio_range,
 pub mode: __u64,
 pub mapped: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_poison {
+pub range: uffdio_range,
+pub mode: __u64,
+pub updated: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_move {
+pub dst: __u64,
+pub src: __u64,
+pub len: __u64,
+pub mode: __u64,
+pub move_: __s64,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -899,9 +972,9 @@ pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 394496;
+pub const LINUX_VERSION_CODE: u32 = 395264;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 5;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_VECTOR_SIZE_ARCH: u32 = 1;
@@ -1280,6 +1353,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1351,6 +1432,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const FUTEX_WAIT: u32 = 0;
 pub const FUTEX_WAKE: u32 = 1;
 pub const FUTEX_FD: u32 = 2;
@@ -1381,6 +1472,13 @@ pub const FUTEX_WAIT_BITSET_PRIVATE: u32 = 137;
 pub const FUTEX_WAKE_BITSET_PRIVATE: u32 = 138;
 pub const FUTEX_WAIT_REQUEUE_PI_PRIVATE: u32 = 139;
 pub const FUTEX_CMP_REQUEUE_PI_PRIVATE: u32 = 140;
+pub const FUTEX2_SIZE_U8: u32 = 0;
+pub const FUTEX2_SIZE_U16: u32 = 1;
+pub const FUTEX2_SIZE_U32: u32 = 2;
+pub const FUTEX2_SIZE_U64: u32 = 3;
+pub const FUTEX2_NUMA: u32 = 4;
+pub const FUTEX2_PRIVATE: u32 = 128;
+pub const FUTEX2_SIZE_MASK: u32 = 3;
 pub const FUTEX_32: u32 = 2;
 pub const FUTEX_WAITV_MAX: u32 = 128;
 pub const FUTEX_WAITERS: u32 = 2147483648;
@@ -1637,25 +1735,6 @@ pub const LINUX_REBOOT_CMD_POWER_OFF: u32 = 1126301404;
 pub const LINUX_REBOOT_CMD_RESTART2: u32 = 2712847316;
 pub const LINUX_REBOOT_CMD_SW_SUSPEND: u32 = 3489725666;
 pub const LINUX_REBOOT_CMD_KEXEC: u32 = 1163412803;
-pub const ITIMER_REAL: u32 = 0;
-pub const ITIMER_VIRTUAL: u32 = 1;
-pub const ITIMER_PROF: u32 = 2;
-pub const CLOCK_REALTIME: u32 = 0;
-pub const CLOCK_MONOTONIC: u32 = 1;
-pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
-pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
-pub const CLOCK_MONOTONIC_RAW: u32 = 4;
-pub const CLOCK_REALTIME_COARSE: u32 = 5;
-pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
-pub const CLOCK_BOOTTIME: u32 = 7;
-pub const CLOCK_REALTIME_ALARM: u32 = 8;
-pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
-pub const CLOCK_SGI_CYCLE: u32 = 10;
-pub const CLOCK_TAI: u32 = 11;
-pub const MAX_CLOCKS: u32 = 16;
-pub const CLOCKS_MASK: u32 = 1;
-pub const CLOCKS_MONO: u32 = 1;
-pub const TIMER_ABSTIME: u32 = 1;
 pub const RUSAGE_SELF: u32 = 0;
 pub const RUSAGE_CHILDREN: i32 = -1;
 pub const RUSAGE_BOTH: i32 = -2;
@@ -1835,7 +1914,8 @@ pub const SEGV_ADIDERR: u32 = 6;
 pub const SEGV_ADIPERR: u32 = 7;
 pub const SEGV_MTEAERR: u32 = 8;
 pub const SEGV_MTESERR: u32 = 9;
-pub const NSIGSEGV: u32 = 9;
+pub const SEGV_CPERR: u32 = 10;
+pub const NSIGSEGV: u32 = 10;
 pub const BUS_ADRALN: u32 = 1;
 pub const BUS_ADRERR: u32 = 2;
 pub const BUS_OBJERR: u32 = 3;
@@ -1916,6 +1996,7 @@ pub const STATX_BASIC_STATS: u32 = 2047;
 pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
+pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2232,6 +2313,25 @@ pub const TIOCM_DSR: u32 = 1024;
 pub const TIOCM_OUT1: u32 = 8192;
 pub const TIOCM_OUT2: u32 = 16384;
 pub const TIOCM_LOOP: u32 = 32768;
+pub const ITIMER_REAL: u32 = 0;
+pub const ITIMER_VIRTUAL: u32 = 1;
+pub const ITIMER_PROF: u32 = 2;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_SGI_CYCLE: u32 = 10;
+pub const CLOCK_TAI: u32 = 11;
+pub const MAX_CLOCKS: u32 = 16;
+pub const CLOCKS_MASK: u32 = 1;
+pub const CLOCKS_MONO: u32 = 1;
+pub const TIMER_ABSTIME: u32 = 1;
 pub const UIO_FASTIOV: u32 = 8;
 pub const UIO_MAXIOV: u32 = 1024;
 pub const __NR_Linux: u32 = 5000;
@@ -2590,6 +2690,16 @@ pub const __NR_process_mrelease: u32 = 5448;
 pub const __NR_futex_waitv: u32 = 5449;
 pub const __NR_set_mempolicy_home_node: u32 = 5450;
 pub const __NR_cachestat: u32 = 5451;
+pub const __NR_fchmodat2: u32 = 5452;
+pub const __NR_map_shadow_stack: u32 = 5453;
+pub const __NR_futex_wake: u32 = 5454;
+pub const __NR_futex_wait: u32 = 5455;
+pub const __NR_futex_requeue: u32 = 5456;
+pub const __NR_statmount: u32 = 5457;
+pub const __NR_listmount: u32 = 5458;
+pub const __NR_lsm_get_self_attr: u32 = 5459;
+pub const __NR_lsm_set_self_attr: u32 = 5460;
+pub const __NR_lsm_list_modules: u32 = 5461;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
 pub const WSTOPPED: u32 = 2;
@@ -2668,8 +2778,10 @@ pub const _UFFDIO_UNREGISTER: u32 = 1;
 pub const _UFFDIO_WAKE: u32 = 2;
 pub const _UFFDIO_COPY: u32 = 3;
 pub const _UFFDIO_ZEROPAGE: u32 = 4;
+pub const _UFFDIO_MOVE: u32 = 5;
 pub const _UFFDIO_WRITEPROTECT: u32 = 6;
 pub const _UFFDIO_CONTINUE: u32 = 7;
+pub const _UFFDIO_POISON: u32 = 8;
 pub const _UFFDIO_API: u32 = 63;
 pub const UFFDIO: u32 = 170;
 pub const UFFD_EVENT_PAGEFAULT: u32 = 18;
@@ -2694,6 +2806,9 @@ pub const UFFD_FEATURE_MINOR_SHMEM: u32 = 1024;
 pub const UFFD_FEATURE_EXACT_ADDRESS: u32 = 2048;
 pub const UFFD_FEATURE_WP_HUGETLBFS_SHMEM: u32 = 4096;
 pub const UFFD_FEATURE_WP_UNPOPULATED: u32 = 8192;
+pub const UFFD_FEATURE_POISON: u32 = 16384;
+pub const UFFD_FEATURE_WP_ASYNC: u32 = 32768;
+pub const UFFD_FEATURE_MOVE: u32 = 65536;
 pub const UFFD_USER_MODE_ONLY: u32 = 1;
 pub const DT_UNKNOWN: u32 = 0;
 pub const DT_FIFO: u32 = 1;
@@ -2772,6 +2887,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/mips64/if_arp.rs
+++ b/src/mips64/if_arp.rs
@@ -52,11 +52,6 @@ pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
@@ -175,6 +170,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -182,23 +178,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -1136,6 +1117,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_4 = _bindgen_ty_4::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_4 = _bindgen_ty_4::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_MASK;
@@ -1204,6 +1186,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_HAIRPIN;
@@ -1251,6 +1235,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_10 = _bindgen_ty_10::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_KIND;
@@ -1312,301 +1297,310 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_19 = _bindgen_ty_19::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_40 = _bindgen_ty_40::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_46 = _bindgen_ty_46::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_DSA_MAX;
-pub const IF_PORT_UNKNOWN: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_UNKNOWN;
-pub const IF_PORT_10BASE2: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASE2;
-pub const IF_PORT_10BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASET;
-pub const IF_PORT_AUI: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_AUI;
-pub const IF_PORT_100BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASET;
-pub const IF_PORT_100BASETX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASETX;
-pub const IF_PORT_100BASEFX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASEFX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_20 = _bindgen_ty_20::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_23 = _bindgen_ty_23::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_47 = _bindgen_ty_47::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__IFLA_DSA_MAX;
+pub const IF_PORT_UNKNOWN: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_UNKNOWN;
+pub const IF_PORT_10BASE2: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASE2;
+pub const IF_PORT_10BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASET;
+pub const IF_PORT_AUI: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_AUI;
+pub const IF_PORT_100BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASET;
+pub const IF_PORT_100BASETX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASETX;
+pub const IF_PORT_100BASEFX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASEFX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1709,6 +1703,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1798,7 +1794,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1894,7 +1891,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1951,7 +1950,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2104,10 +2104,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_20 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_21 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -2123,7 +2151,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -2135,7 +2163,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum _bindgen_ty_23 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -2143,7 +2171,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2176,7 +2204,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2190,7 +2219,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_25 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2220,7 +2257,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2231,7 +2268,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2246,7 +2283,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2259,7 +2296,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2297,7 +2334,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2309,7 +2346,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2325,7 +2362,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2333,7 +2370,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2353,7 +2390,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2361,7 +2398,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2370,7 +2407,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2385,7 +2422,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2393,7 +2430,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2407,7 +2444,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2416,7 +2453,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2434,7 +2471,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2444,14 +2481,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2459,7 +2496,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2473,7 +2510,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2485,7 +2522,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2494,7 +2531,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2503,7 +2540,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2513,7 +2550,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2522,7 +2559,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2532,7 +2569,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2547,7 +2584,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2559,7 +2596,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2575,7 +2612,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2584,7 +2621,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2592,15 +2629,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 IF_PORT_UNKNOWN = 0,
 IF_PORT_10BASE2 = 1,
 IF_PORT_10BASET = 2,
@@ -2683,74 +2720,6 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 impl nlmsgerr_attrs {
 pub const NLMSGERR_ATTR_MAX: nlmsgerr_attrs = nlmsgerr_attrs::NLMSGERR_ATTR_MISS_NEST;
 }
@@ -2765,6 +2734,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/mips64/if_packet.rs
+++ b/src/mips64/if_packet.rs
@@ -51,11 +51,6 @@ pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_pkt {
 pub spkt_family: crate::ctypes::c_ushort,
@@ -63,6 +58,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -70,23 +66,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -337,71 +318,3 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}

--- a/src/mips64/io_uring.rs
+++ b/src/mips64/io_uring.rs
@@ -79,7 +79,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -134,6 +135,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -195,6 +229,29 @@ pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
 pub tv_nsec: crate::ctypes::c_longlong,
@@ -253,6 +310,12 @@ pub __pad1: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_sqe__bindgen_ty_2__bindgen_ty_1 {
+pub level: __u32,
+pub optname: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_sqe__bindgen_ty_5__bindgen_ty_1 {
 pub addr_len: __u16,
 pub __pad3: [__u16; 1usize],
@@ -260,6 +323,7 @@ pub __pad3: [__u16; 1usize],
 #[repr(C)]
 pub struct io_uring_sqe__bindgen_ty_6 {
 pub __bindgen_anon_1: __BindgenUnionField<io_uring_sqe__bindgen_ty_6__bindgen_ty_1>,
+pub optval: __BindgenUnionField<__u64>,
 pub cmd: __BindgenUnionField<[__u8; 0usize]>,
 pub bindgen_union_field: [u64; 2usize],
 }
@@ -421,6 +485,13 @@ pub resv: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_buf_status {
+pub buf_group: __u32,
+pub head: __u32,
+pub resv: [__u32; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -434,7 +505,9 @@ pub addr: __u64,
 pub fd: __s32,
 pub flags: __u32,
 pub timeout: __kernel_timespec,
-pub pad: [__u64; 4usize],
+pub opcode: __u8,
+pub pad: [__u8; 7usize],
+pub pad2: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -607,6 +680,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -678,6 +759,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const IORING_FILE_INDEX_ALLOC: i32 = -1;
 pub const IORING_SETUP_IOPOLL: u32 = 1;
 pub const IORING_SETUP_SQPOLL: u32 = 2;
@@ -695,8 +786,9 @@ pub const IORING_SETUP_SINGLE_ISSUER: u32 = 4096;
 pub const IORING_SETUP_DEFER_TASKRUN: u32 = 8192;
 pub const IORING_SETUP_NO_MMAP: u32 = 16384;
 pub const IORING_SETUP_REGISTERED_FD_ONLY: u32 = 32768;
+pub const IORING_SETUP_NO_SQARRAY: u32 = 65536;
 pub const IORING_URING_CMD_FIXED: u32 = 1;
-pub const IORING_URING_CMD_POLLED: u32 = 2147483648;
+pub const IORING_URING_CMD_MASK: u32 = 1;
 pub const IORING_FSYNC_DATASYNC: u32 = 1;
 pub const IORING_TIMEOUT_ABS: u32 = 1;
 pub const IORING_TIMEOUT_UPDATE: u32 = 2;
@@ -716,6 +808,8 @@ pub const IORING_ASYNC_CANCEL_ALL: u32 = 1;
 pub const IORING_ASYNC_CANCEL_FD: u32 = 2;
 pub const IORING_ASYNC_CANCEL_ANY: u32 = 4;
 pub const IORING_ASYNC_CANCEL_FD_FIXED: u32 = 8;
+pub const IORING_ASYNC_CANCEL_USERDATA: u32 = 16;
+pub const IORING_ASYNC_CANCEL_OP: u32 = 32;
 pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
@@ -724,6 +818,7 @@ pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
+pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
@@ -796,6 +891,7 @@ pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGIS
 pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
 pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
 pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
+pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
 pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
 pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
 pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
@@ -806,6 +902,10 @@ pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTR
 pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
 pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
 pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
+pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
+pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
+pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
+pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -818,6 +918,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -884,7 +985,13 @@ IORING_OP_SOCKET = 45,
 IORING_OP_URING_CMD = 46,
 IORING_OP_SEND_ZC = 47,
 IORING_OP_SENDMSG_ZC = 48,
-IORING_OP_LAST = 49,
+IORING_OP_READ_MULTISHOT = 49,
+IORING_OP_WAITID = 50,
+IORING_OP_FUTEX_WAIT = 51,
+IORING_OP_FUTEX_WAKE = 52,
+IORING_OP_FUTEX_WAITV = 53,
+IORING_OP_FIXED_FD_INSTALL = 54,
+IORING_OP_LAST = 55,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -929,7 +1036,8 @@ IORING_REGISTER_PBUF_RING = 22,
 IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
-IORING_REGISTER_LAST = 26,
+IORING_REGISTER_PBUF_STATUS = 26,
+IORING_REGISTER_LAST = 27,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
@@ -954,6 +1062,15 @@ IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
 IORING_RESTRICTION_SQE_FLAGS_REQUIRED = 3,
 IORING_RESTRICTION_LAST = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_8 {
+SOCKET_URING_OP_SIOCINQ = 0,
+SOCKET_URING_OP_SIOCOUTQ = 1,
+SOCKET_URING_OP_GETSOCKOPT = 2,
+SOCKET_URING_OP_SETSOCKOPT = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -981,6 +1098,7 @@ pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_1__bindgen_ty_1,
 pub union io_uring_sqe__bindgen_ty_2 {
 pub addr: __u64,
 pub splice_off_in: __u64,
+pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_2__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -1004,6 +1122,9 @@ pub hardlink_flags: __u32,
 pub xattr_flags: __u32,
 pub msg_ring_flags: __u32,
 pub uring_cmd_flags: __u32,
+pub waitid_flags: __u32,
+pub futex_flags: __u32,
+pub install_fd_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]
@@ -1016,6 +1137,7 @@ pub buf_group: __u16,
 pub union io_uring_sqe__bindgen_ty_5 {
 pub splice_fd_in: __s32,
 pub file_index: __u32,
+pub optlen: __u32,
 pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]

--- a/src/mips64/net.rs
+++ b/src/mips64/net.rs
@@ -429,6 +429,9 @@ pub tcpi_rcv_ooopack: __u32,
 pub tcpi_snd_wnd: __u32,
 pub tcpi_rcv_wnd: __u32,
 pub tcpi_rehash: __u32,
+pub tcpi_total_rto: __u16,
+pub tcpi_total_rto_recoveries: __u16,
+pub tcpi_total_rto_time: __u32,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -448,6 +451,80 @@ pub tcpm_prefixlen: __u8,
 pub tcpm_keylen: __u16,
 pub tcpm_addr: [__be32; 4usize],
 pub tcpm_key: [__u8; 80usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_add {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub key: [__u8; 80usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_del {
+pub addr: __kernel_sockaddr_storage,
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub current_key: __u8,
+pub rnext: __u8,
+pub keyflags: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_info_opt {
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub current_key: __u8,
+pub rnext: __u8,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+pub pkt_key_not_found: __u64,
+pub pkt_ao_required: __u64,
+pub pkt_dropped_icmp: __u64,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_getsockopt {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub key: [__u8; 80usize],
+pub nkeys: __u32,
+pub _bitfield_align_1: [u16; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub prefix: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub ifindex: __s32,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_repair {
+pub snt_isn: __be32,
+pub rcv_isn: __be32,
+pub snd_sne: __u32,
+pub rcv_sne: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1216,6 +1293,11 @@ pub const TCP_ZEROCOPY_RECEIVE: u32 = 35;
 pub const TCP_INQ: u32 = 36;
 pub const TCP_CM_INQ: u32 = 36;
 pub const TCP_TX_DELAY: u32 = 37;
+pub const TCP_AO_ADD_KEY: u32 = 38;
+pub const TCP_AO_DEL_KEY: u32 = 39;
+pub const TCP_AO_INFO: u32 = 40;
+pub const TCP_AO_GET_KEYS: u32 = 41;
+pub const TCP_AO_REPAIR: u32 = 42;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1225,9 +1307,13 @@ pub const TCPI_OPT_WSCALE: u32 = 4;
 pub const TCPI_OPT_ECN: u32 = 8;
 pub const TCPI_OPT_ECN_SEEN: u32 = 16;
 pub const TCPI_OPT_SYN_DATA: u32 = 32;
+pub const TCPI_OPT_USEC_TS: u32 = 64;
 pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
+pub const TCP_AO_MAXKEYLEN: u32 = 80;
+pub const TCP_AO_KEYF_IFINDEX: u32 = 1;
+pub const TCP_AO_KEYF_EXCLUDE_OPT: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
@@ -1592,6 +1678,7 @@ pub const DEVCONF_IOAM6_ID: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID;
 pub const DEVCONF_IOAM6_ID_WIDE: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID_WIDE;
 pub const DEVCONF_NDISC_EVICT_NOCARRIER: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_NDISC_EVICT_NOCARRIER;
 pub const DEVCONF_ACCEPT_UNTRACKED_NA: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_UNTRACKED_NA;
+pub const DEVCONF_ACCEPT_RA_MIN_LFT: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_RA_MIN_LFT;
 pub const DEVCONF_MAX: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_MAX;
 pub const TCP_FLAG_CWR: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_CWR;
 pub const TCP_FLAG_ECE: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_ECE;
@@ -1789,7 +1876,8 @@ DEVCONF_IOAM6_ID = 54,
 DEVCONF_IOAM6_ID_WIDE = 55,
 DEVCONF_NDISC_EVICT_NOCARRIER = 56,
 DEVCONF_ACCEPT_UNTRACKED_NA = 57,
-DEVCONF_MAX = 58,
+DEVCONF_ACCEPT_RA_MIN_LFT = 58,
+DEVCONF_MAX = 59,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2507,6 +2595,289 @@ tcpi_delivery_rate_app_limited as u64
 __bindgen_bitfield_unit.set(9usize, 2u8, {
 let tcpi_fastopen_client_fail: u8 = unsafe { ::core::mem::transmute(tcpi_fastopen_client_fail) };
 tcpi_fastopen_client_fail as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_add {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 30u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 30u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_del {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn del_async(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_del_async(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 29u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 29u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, del_async: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let del_async: u32 = unsafe { ::core::mem::transmute(del_async) };
+del_async as u64
+});
+__bindgen_bitfield_unit.set(3usize, 29u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_info_opt {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn ao_required(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_ao_required(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_counters(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_counters(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn accept_icmps(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_accept_icmps(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(4usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(5usize, 27u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(5usize, 27u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, ao_required: __u32, set_counters: __u32, accept_icmps: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let ao_required: u32 = unsafe { ::core::mem::transmute(ao_required) };
+ao_required as u64
+});
+__bindgen_bitfield_unit.set(3usize, 1u8, {
+let set_counters: u32 = unsafe { ::core::mem::transmute(set_counters) };
+set_counters as u64
+});
+__bindgen_bitfield_unit.set(4usize, 1u8, {
+let accept_icmps: u32 = unsafe { ::core::mem::transmute(accept_icmps) };
+accept_icmps as u64
+});
+__bindgen_bitfield_unit.set(5usize, 27u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_getsockopt {
+#[inline]
+pub fn is_current(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_current(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn is_rnext(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_rnext(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn get_all(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_get_all(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 13u8) as u16) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 13u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(is_current: __u16, is_rnext: __u16, get_all: __u16, reserved: __u16) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let is_current: u16 = unsafe { ::core::mem::transmute(is_current) };
+is_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let is_rnext: u16 = unsafe { ::core::mem::transmute(is_rnext) };
+is_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let get_all: u16 = unsafe { ::core::mem::transmute(get_all) };
+get_all as u64
+});
+__bindgen_bitfield_unit.set(3usize, 13u8, {
+let reserved: u16 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
 });
 __bindgen_bitfield_unit
 }

--- a/src/mips64/netlink.rs
+++ b/src/mips64/netlink.rs
@@ -734,7 +734,8 @@ pub const RTAX_FEATURE_ECN: u32 = 1;
 pub const RTAX_FEATURE_SACK: u32 = 2;
 pub const RTAX_FEATURE_TIMESTAMP: u32 = 4;
 pub const RTAX_FEATURE_ALLFRAG: u32 = 8;
-pub const RTAX_FEATURE_MASK: u32 = 15;
+pub const RTAX_FEATURE_TCP_USEC_TS: u32 = 16;
+pub const RTAX_FEATURE_MASK: u32 = 31;
 pub const TCM_IFINDEX_MAGIC_BLOCK: u32 = 4294967295;
 pub const TCA_DUMP_FLAGS_TERSE: u32 = 1;
 pub const RTMGRP_LINK: u32 = 1;
@@ -831,6 +832,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_2 = _bindgen_ty_2::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_2 = _bindgen_ty_2::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_MASK;
@@ -899,6 +901,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_6 = _bindgen_ty_6::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_HAIRPIN;
@@ -946,6 +950,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_KIND;
@@ -1007,501 +1012,510 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_17 = _bindgen_ty_17::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_18 = _bindgen_ty_18::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_21 = _bindgen_ty_21::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_44 = _bindgen_ty_44::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_DSA_MAX;
-pub const IFA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFA_UNSPEC;
-pub const IFA_ADDRESS: _bindgen_ty_54 = _bindgen_ty_54::IFA_ADDRESS;
-pub const IFA_LOCAL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LOCAL;
-pub const IFA_LABEL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LABEL;
-pub const IFA_BROADCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_BROADCAST;
-pub const IFA_ANYCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_ANYCAST;
-pub const IFA_CACHEINFO: _bindgen_ty_54 = _bindgen_ty_54::IFA_CACHEINFO;
-pub const IFA_MULTICAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_MULTICAST;
-pub const IFA_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFA_FLAGS;
-pub const IFA_RT_PRIORITY: _bindgen_ty_54 = _bindgen_ty_54::IFA_RT_PRIORITY;
-pub const IFA_TARGET_NETNSID: _bindgen_ty_54 = _bindgen_ty_54::IFA_TARGET_NETNSID;
-pub const IFA_PROTO: _bindgen_ty_54 = _bindgen_ty_54::IFA_PROTO;
-pub const __IFA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFA_MAX;
-pub const NDA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::NDA_UNSPEC;
-pub const NDA_DST: _bindgen_ty_55 = _bindgen_ty_55::NDA_DST;
-pub const NDA_LLADDR: _bindgen_ty_55 = _bindgen_ty_55::NDA_LLADDR;
-pub const NDA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::NDA_CACHEINFO;
-pub const NDA_PROBES: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROBES;
-pub const NDA_VLAN: _bindgen_ty_55 = _bindgen_ty_55::NDA_VLAN;
-pub const NDA_PORT: _bindgen_ty_55 = _bindgen_ty_55::NDA_PORT;
-pub const NDA_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_VNI;
-pub const NDA_IFINDEX: _bindgen_ty_55 = _bindgen_ty_55::NDA_IFINDEX;
-pub const NDA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::NDA_MASTER;
-pub const NDA_LINK_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::NDA_LINK_NETNSID;
-pub const NDA_SRC_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_SRC_VNI;
-pub const NDA_PROTOCOL: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROTOCOL;
-pub const NDA_NH_ID: _bindgen_ty_55 = _bindgen_ty_55::NDA_NH_ID;
-pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_55 = _bindgen_ty_55::NDA_FDB_EXT_ATTRS;
-pub const NDA_FLAGS_EXT: _bindgen_ty_55 = _bindgen_ty_55::NDA_FLAGS_EXT;
-pub const NDA_NDM_STATE_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_STATE_MASK;
-pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_FLAGS_MASK;
-pub const __NDA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__NDA_MAX;
-pub const NDTPA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UNSPEC;
-pub const NDTPA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_IFINDEX;
-pub const NDTPA_REFCNT: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REFCNT;
-pub const NDTPA_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REACHABLE_TIME;
-pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_BASE_REACHABLE_TIME;
-pub const NDTPA_RETRANS_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_RETRANS_TIME;
-pub const NDTPA_GC_STALETIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_GC_STALETIME;
-pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_DELAY_PROBE_TIME;
-pub const NDTPA_QUEUE_LEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LEN;
-pub const NDTPA_APP_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_APP_PROBES;
-pub const NDTPA_UCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UCAST_PROBES;
-pub const NDTPA_MCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_PROBES;
-pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_ANYCAST_DELAY;
-pub const NDTPA_PROXY_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_DELAY;
-pub const NDTPA_PROXY_QLEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_QLEN;
-pub const NDTPA_LOCKTIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_LOCKTIME;
-pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LENBYTES;
-pub const NDTPA_MCAST_REPROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_REPROBES;
-pub const NDTPA_PAD: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PAD;
-pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_INTERVAL_PROBE_TIME_MS;
-pub const __NDTPA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDTPA_MAX;
-pub const NDTA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTA_UNSPEC;
-pub const NDTA_NAME: _bindgen_ty_57 = _bindgen_ty_57::NDTA_NAME;
-pub const NDTA_THRESH1: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH1;
-pub const NDTA_THRESH2: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH2;
-pub const NDTA_THRESH3: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH3;
-pub const NDTA_CONFIG: _bindgen_ty_57 = _bindgen_ty_57::NDTA_CONFIG;
-pub const NDTA_PARMS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PARMS;
-pub const NDTA_STATS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_STATS;
-pub const NDTA_GC_INTERVAL: _bindgen_ty_57 = _bindgen_ty_57::NDTA_GC_INTERVAL;
-pub const NDTA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PAD;
-pub const __NDTA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTA_MAX;
-pub const FDB_NOTIFY_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_BIT;
-pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_INACTIVE_BIT;
-pub const NFEA_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::NFEA_UNSPEC;
-pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_59 = _bindgen_ty_59::NFEA_ACTIVITY_NOTIFY;
-pub const NFEA_DONT_REFRESH: _bindgen_ty_59 = _bindgen_ty_59::NFEA_DONT_REFRESH;
-pub const __NFEA_MAX: _bindgen_ty_59 = _bindgen_ty_59::__NFEA_MAX;
-pub const RTM_BASE: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_NEWLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_DELLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINK;
-pub const RTM_GETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINK;
-pub const RTM_SETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETLINK;
-pub const RTM_NEWADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDR;
-pub const RTM_DELADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDR;
-pub const RTM_GETADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDR;
-pub const RTM_NEWROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWROUTE;
-pub const RTM_DELROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELROUTE;
-pub const RTM_GETROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETROUTE;
-pub const RTM_NEWNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGH;
-pub const RTM_DELNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEIGH;
-pub const RTM_GETNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGH;
-pub const RTM_NEWRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWRULE;
-pub const RTM_DELRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELRULE;
-pub const RTM_GETRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETRULE;
-pub const RTM_NEWQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWQDISC;
-pub const RTM_DELQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELQDISC;
-pub const RTM_GETQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETQDISC;
-pub const RTM_NEWTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTCLASS;
-pub const RTM_DELTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTCLASS;
-pub const RTM_GETTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTCLASS;
-pub const RTM_NEWTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTFILTER;
-pub const RTM_DELTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTFILTER;
-pub const RTM_GETTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTFILTER;
-pub const RTM_NEWACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWACTION;
-pub const RTM_DELACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELACTION;
-pub const RTM_GETACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETACTION;
-pub const RTM_NEWPREFIX: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWPREFIX;
-pub const RTM_GETMULTICAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMULTICAST;
-pub const RTM_GETANYCAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETANYCAST;
-pub const RTM_NEWNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGHTBL;
-pub const RTM_GETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGHTBL;
-pub const RTM_SETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETNEIGHTBL;
-pub const RTM_NEWNDUSEROPT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNDUSEROPT;
-pub const RTM_NEWADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDRLABEL;
-pub const RTM_DELADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDRLABEL;
-pub const RTM_GETADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDRLABEL;
-pub const RTM_GETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETDCB;
-pub const RTM_SETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETDCB;
-pub const RTM_NEWNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNETCONF;
-pub const RTM_DELNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNETCONF;
-pub const RTM_GETNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNETCONF;
-pub const RTM_NEWMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWMDB;
-pub const RTM_DELMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELMDB;
-pub const RTM_GETMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMDB;
-pub const RTM_NEWNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNSID;
-pub const RTM_DELNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNSID;
-pub const RTM_GETNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNSID;
-pub const RTM_NEWSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWSTATS;
-pub const RTM_GETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETSTATS;
-pub const RTM_SETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETSTATS;
-pub const RTM_NEWCACHEREPORT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCACHEREPORT;
-pub const RTM_NEWCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCHAIN;
-pub const RTM_DELCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELCHAIN;
-pub const RTM_GETCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETCHAIN;
-pub const RTM_NEWNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOP;
-pub const RTM_DELNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOP;
-pub const RTM_GETNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOP;
-pub const RTM_NEWLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWLINKPROP;
-pub const RTM_DELLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINKPROP;
-pub const RTM_GETLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINKPROP;
-pub const RTM_NEWVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWVLAN;
-pub const RTM_DELVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELVLAN;
-pub const RTM_GETVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETVLAN;
-pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOPBUCKET;
-pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOPBUCKET;
-pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOPBUCKET;
-pub const RTM_NEWTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTUNNEL;
-pub const RTM_DELTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTUNNEL;
-pub const RTM_GETTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTUNNEL;
-pub const __RTM_MAX: _bindgen_ty_60 = _bindgen_ty_60::__RTM_MAX;
-pub const RTN_UNSPEC: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNSPEC;
-pub const RTN_UNICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNICAST;
-pub const RTN_LOCAL: _bindgen_ty_61 = _bindgen_ty_61::RTN_LOCAL;
-pub const RTN_BROADCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_BROADCAST;
-pub const RTN_ANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_ANYCAST;
-pub const RTN_MULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_MULTICAST;
-pub const RTN_BLACKHOLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_BLACKHOLE;
-pub const RTN_UNREACHABLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNREACHABLE;
-pub const RTN_PROHIBIT: _bindgen_ty_61 = _bindgen_ty_61::RTN_PROHIBIT;
-pub const RTN_THROW: _bindgen_ty_61 = _bindgen_ty_61::RTN_THROW;
-pub const RTN_NAT: _bindgen_ty_61 = _bindgen_ty_61::RTN_NAT;
-pub const RTN_XRESOLVE: _bindgen_ty_61 = _bindgen_ty_61::RTN_XRESOLVE;
-pub const __RTN_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTN_MAX;
-pub const RTAX_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTAX_UNSPEC;
-pub const RTAX_LOCK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_LOCK;
-pub const RTAX_MTU: _bindgen_ty_62 = _bindgen_ty_62::RTAX_MTU;
-pub const RTAX_WINDOW: _bindgen_ty_62 = _bindgen_ty_62::RTAX_WINDOW;
-pub const RTAX_RTT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTT;
-pub const RTAX_RTTVAR: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTTVAR;
-pub const RTAX_SSTHRESH: _bindgen_ty_62 = _bindgen_ty_62::RTAX_SSTHRESH;
-pub const RTAX_CWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CWND;
-pub const RTAX_ADVMSS: _bindgen_ty_62 = _bindgen_ty_62::RTAX_ADVMSS;
-pub const RTAX_REORDERING: _bindgen_ty_62 = _bindgen_ty_62::RTAX_REORDERING;
-pub const RTAX_HOPLIMIT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_HOPLIMIT;
-pub const RTAX_INITCWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITCWND;
-pub const RTAX_FEATURES: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FEATURES;
-pub const RTAX_RTO_MIN: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTO_MIN;
-pub const RTAX_INITRWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITRWND;
-pub const RTAX_QUICKACK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_QUICKACK;
-pub const RTAX_CC_ALGO: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CC_ALGO;
-pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FASTOPEN_NO_COOKIE;
-pub const __RTAX_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTAX_MAX;
-pub const PREFIX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_UNSPEC;
-pub const PREFIX_ADDRESS: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_ADDRESS;
-pub const PREFIX_CACHEINFO: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_CACHEINFO;
-pub const __PREFIX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__PREFIX_MAX;
-pub const TCA_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::TCA_UNSPEC;
-pub const TCA_KIND: _bindgen_ty_64 = _bindgen_ty_64::TCA_KIND;
-pub const TCA_OPTIONS: _bindgen_ty_64 = _bindgen_ty_64::TCA_OPTIONS;
-pub const TCA_STATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS;
-pub const TCA_XSTATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_XSTATS;
-pub const TCA_RATE: _bindgen_ty_64 = _bindgen_ty_64::TCA_RATE;
-pub const TCA_FCNT: _bindgen_ty_64 = _bindgen_ty_64::TCA_FCNT;
-pub const TCA_STATS2: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS2;
-pub const TCA_STAB: _bindgen_ty_64 = _bindgen_ty_64::TCA_STAB;
-pub const TCA_PAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_PAD;
-pub const TCA_DUMP_INVISIBLE: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_INVISIBLE;
-pub const TCA_CHAIN: _bindgen_ty_64 = _bindgen_ty_64::TCA_CHAIN;
-pub const TCA_HW_OFFLOAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_HW_OFFLOAD;
-pub const TCA_INGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_INGRESS_BLOCK;
-pub const TCA_EGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_EGRESS_BLOCK;
-pub const TCA_DUMP_FLAGS: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_FLAGS;
-pub const TCA_EXT_WARN_MSG: _bindgen_ty_64 = _bindgen_ty_64::TCA_EXT_WARN_MSG;
-pub const __TCA_MAX: _bindgen_ty_64 = _bindgen_ty_64::__TCA_MAX;
-pub const NDUSEROPT_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_UNSPEC;
-pub const NDUSEROPT_SRCADDR: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_SRCADDR;
-pub const __NDUSEROPT_MAX: _bindgen_ty_65 = _bindgen_ty_65::__NDUSEROPT_MAX;
-pub const TCA_ROOT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_UNSPEC;
-pub const TCA_ROOT_TAB: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TAB;
-pub const TCA_ROOT_FLAGS: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_FLAGS;
-pub const TCA_ROOT_COUNT: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_COUNT;
-pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TIME_DELTA;
-pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_EXT_WARN_MSG;
-pub const __TCA_ROOT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__TCA_ROOT_MAX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_18 = _bindgen_ty_18::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_39 = _bindgen_ty_39::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_45 = _bindgen_ty_45::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_DSA_MAX;
+pub const IFA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFA_UNSPEC;
+pub const IFA_ADDRESS: _bindgen_ty_55 = _bindgen_ty_55::IFA_ADDRESS;
+pub const IFA_LOCAL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LOCAL;
+pub const IFA_LABEL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LABEL;
+pub const IFA_BROADCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_BROADCAST;
+pub const IFA_ANYCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_ANYCAST;
+pub const IFA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::IFA_CACHEINFO;
+pub const IFA_MULTICAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_MULTICAST;
+pub const IFA_FLAGS: _bindgen_ty_55 = _bindgen_ty_55::IFA_FLAGS;
+pub const IFA_RT_PRIORITY: _bindgen_ty_55 = _bindgen_ty_55::IFA_RT_PRIORITY;
+pub const IFA_TARGET_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::IFA_TARGET_NETNSID;
+pub const IFA_PROTO: _bindgen_ty_55 = _bindgen_ty_55::IFA_PROTO;
+pub const __IFA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFA_MAX;
+pub const NDA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDA_UNSPEC;
+pub const NDA_DST: _bindgen_ty_56 = _bindgen_ty_56::NDA_DST;
+pub const NDA_LLADDR: _bindgen_ty_56 = _bindgen_ty_56::NDA_LLADDR;
+pub const NDA_CACHEINFO: _bindgen_ty_56 = _bindgen_ty_56::NDA_CACHEINFO;
+pub const NDA_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROBES;
+pub const NDA_VLAN: _bindgen_ty_56 = _bindgen_ty_56::NDA_VLAN;
+pub const NDA_PORT: _bindgen_ty_56 = _bindgen_ty_56::NDA_PORT;
+pub const NDA_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_VNI;
+pub const NDA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDA_IFINDEX;
+pub const NDA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::NDA_MASTER;
+pub const NDA_LINK_NETNSID: _bindgen_ty_56 = _bindgen_ty_56::NDA_LINK_NETNSID;
+pub const NDA_SRC_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_SRC_VNI;
+pub const NDA_PROTOCOL: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROTOCOL;
+pub const NDA_NH_ID: _bindgen_ty_56 = _bindgen_ty_56::NDA_NH_ID;
+pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_56 = _bindgen_ty_56::NDA_FDB_EXT_ATTRS;
+pub const NDA_FLAGS_EXT: _bindgen_ty_56 = _bindgen_ty_56::NDA_FLAGS_EXT;
+pub const NDA_NDM_STATE_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_STATE_MASK;
+pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_FLAGS_MASK;
+pub const __NDA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDA_MAX;
+pub const NDTPA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UNSPEC;
+pub const NDTPA_IFINDEX: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_IFINDEX;
+pub const NDTPA_REFCNT: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REFCNT;
+pub const NDTPA_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REACHABLE_TIME;
+pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_BASE_REACHABLE_TIME;
+pub const NDTPA_RETRANS_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_RETRANS_TIME;
+pub const NDTPA_GC_STALETIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_GC_STALETIME;
+pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_DELAY_PROBE_TIME;
+pub const NDTPA_QUEUE_LEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LEN;
+pub const NDTPA_APP_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_APP_PROBES;
+pub const NDTPA_UCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UCAST_PROBES;
+pub const NDTPA_MCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_PROBES;
+pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_ANYCAST_DELAY;
+pub const NDTPA_PROXY_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_DELAY;
+pub const NDTPA_PROXY_QLEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_QLEN;
+pub const NDTPA_LOCKTIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_LOCKTIME;
+pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LENBYTES;
+pub const NDTPA_MCAST_REPROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_REPROBES;
+pub const NDTPA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PAD;
+pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_INTERVAL_PROBE_TIME_MS;
+pub const __NDTPA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTPA_MAX;
+pub const NDTA_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDTA_UNSPEC;
+pub const NDTA_NAME: _bindgen_ty_58 = _bindgen_ty_58::NDTA_NAME;
+pub const NDTA_THRESH1: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH1;
+pub const NDTA_THRESH2: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH2;
+pub const NDTA_THRESH3: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH3;
+pub const NDTA_CONFIG: _bindgen_ty_58 = _bindgen_ty_58::NDTA_CONFIG;
+pub const NDTA_PARMS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PARMS;
+pub const NDTA_STATS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_STATS;
+pub const NDTA_GC_INTERVAL: _bindgen_ty_58 = _bindgen_ty_58::NDTA_GC_INTERVAL;
+pub const NDTA_PAD: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PAD;
+pub const __NDTA_MAX: _bindgen_ty_58 = _bindgen_ty_58::__NDTA_MAX;
+pub const FDB_NOTIFY_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_BIT;
+pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_INACTIVE_BIT;
+pub const NFEA_UNSPEC: _bindgen_ty_60 = _bindgen_ty_60::NFEA_UNSPEC;
+pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_60 = _bindgen_ty_60::NFEA_ACTIVITY_NOTIFY;
+pub const NFEA_DONT_REFRESH: _bindgen_ty_60 = _bindgen_ty_60::NFEA_DONT_REFRESH;
+pub const __NFEA_MAX: _bindgen_ty_60 = _bindgen_ty_60::__NFEA_MAX;
+pub const RTM_BASE: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_NEWLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_DELLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINK;
+pub const RTM_GETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINK;
+pub const RTM_SETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETLINK;
+pub const RTM_NEWADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDR;
+pub const RTM_DELADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDR;
+pub const RTM_GETADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDR;
+pub const RTM_NEWROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWROUTE;
+pub const RTM_DELROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELROUTE;
+pub const RTM_GETROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETROUTE;
+pub const RTM_NEWNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGH;
+pub const RTM_DELNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEIGH;
+pub const RTM_GETNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGH;
+pub const RTM_NEWRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWRULE;
+pub const RTM_DELRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELRULE;
+pub const RTM_GETRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETRULE;
+pub const RTM_NEWQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWQDISC;
+pub const RTM_DELQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELQDISC;
+pub const RTM_GETQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETQDISC;
+pub const RTM_NEWTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTCLASS;
+pub const RTM_DELTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTCLASS;
+pub const RTM_GETTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTCLASS;
+pub const RTM_NEWTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTFILTER;
+pub const RTM_DELTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTFILTER;
+pub const RTM_GETTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTFILTER;
+pub const RTM_NEWACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWACTION;
+pub const RTM_DELACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELACTION;
+pub const RTM_GETACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETACTION;
+pub const RTM_NEWPREFIX: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWPREFIX;
+pub const RTM_GETMULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMULTICAST;
+pub const RTM_GETANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETANYCAST;
+pub const RTM_NEWNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGHTBL;
+pub const RTM_GETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGHTBL;
+pub const RTM_SETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETNEIGHTBL;
+pub const RTM_NEWNDUSEROPT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNDUSEROPT;
+pub const RTM_NEWADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDRLABEL;
+pub const RTM_DELADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDRLABEL;
+pub const RTM_GETADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDRLABEL;
+pub const RTM_GETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETDCB;
+pub const RTM_SETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETDCB;
+pub const RTM_NEWNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNETCONF;
+pub const RTM_DELNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNETCONF;
+pub const RTM_GETNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNETCONF;
+pub const RTM_NEWMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWMDB;
+pub const RTM_DELMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELMDB;
+pub const RTM_GETMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMDB;
+pub const RTM_NEWNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNSID;
+pub const RTM_DELNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNSID;
+pub const RTM_GETNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNSID;
+pub const RTM_NEWSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWSTATS;
+pub const RTM_GETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETSTATS;
+pub const RTM_SETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETSTATS;
+pub const RTM_NEWCACHEREPORT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCACHEREPORT;
+pub const RTM_NEWCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCHAIN;
+pub const RTM_DELCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELCHAIN;
+pub const RTM_GETCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETCHAIN;
+pub const RTM_NEWNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOP;
+pub const RTM_DELNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOP;
+pub const RTM_GETNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOP;
+pub const RTM_NEWLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWLINKPROP;
+pub const RTM_DELLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINKPROP;
+pub const RTM_GETLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINKPROP;
+pub const RTM_NEWVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWVLAN;
+pub const RTM_DELVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELVLAN;
+pub const RTM_GETVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETVLAN;
+pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOPBUCKET;
+pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOPBUCKET;
+pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOPBUCKET;
+pub const RTM_NEWTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTUNNEL;
+pub const RTM_DELTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTUNNEL;
+pub const RTM_GETTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTUNNEL;
+pub const __RTM_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTM_MAX;
+pub const RTN_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNSPEC;
+pub const RTN_UNICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNICAST;
+pub const RTN_LOCAL: _bindgen_ty_62 = _bindgen_ty_62::RTN_LOCAL;
+pub const RTN_BROADCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_BROADCAST;
+pub const RTN_ANYCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_ANYCAST;
+pub const RTN_MULTICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_MULTICAST;
+pub const RTN_BLACKHOLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_BLACKHOLE;
+pub const RTN_UNREACHABLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNREACHABLE;
+pub const RTN_PROHIBIT: _bindgen_ty_62 = _bindgen_ty_62::RTN_PROHIBIT;
+pub const RTN_THROW: _bindgen_ty_62 = _bindgen_ty_62::RTN_THROW;
+pub const RTN_NAT: _bindgen_ty_62 = _bindgen_ty_62::RTN_NAT;
+pub const RTN_XRESOLVE: _bindgen_ty_62 = _bindgen_ty_62::RTN_XRESOLVE;
+pub const __RTN_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTN_MAX;
+pub const RTAX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::RTAX_UNSPEC;
+pub const RTAX_LOCK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_LOCK;
+pub const RTAX_MTU: _bindgen_ty_63 = _bindgen_ty_63::RTAX_MTU;
+pub const RTAX_WINDOW: _bindgen_ty_63 = _bindgen_ty_63::RTAX_WINDOW;
+pub const RTAX_RTT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTT;
+pub const RTAX_RTTVAR: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTTVAR;
+pub const RTAX_SSTHRESH: _bindgen_ty_63 = _bindgen_ty_63::RTAX_SSTHRESH;
+pub const RTAX_CWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CWND;
+pub const RTAX_ADVMSS: _bindgen_ty_63 = _bindgen_ty_63::RTAX_ADVMSS;
+pub const RTAX_REORDERING: _bindgen_ty_63 = _bindgen_ty_63::RTAX_REORDERING;
+pub const RTAX_HOPLIMIT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_HOPLIMIT;
+pub const RTAX_INITCWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITCWND;
+pub const RTAX_FEATURES: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FEATURES;
+pub const RTAX_RTO_MIN: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTO_MIN;
+pub const RTAX_INITRWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITRWND;
+pub const RTAX_QUICKACK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_QUICKACK;
+pub const RTAX_CC_ALGO: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CC_ALGO;
+pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FASTOPEN_NO_COOKIE;
+pub const __RTAX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__RTAX_MAX;
+pub const PREFIX_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_UNSPEC;
+pub const PREFIX_ADDRESS: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_ADDRESS;
+pub const PREFIX_CACHEINFO: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_CACHEINFO;
+pub const __PREFIX_MAX: _bindgen_ty_64 = _bindgen_ty_64::__PREFIX_MAX;
+pub const TCA_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::TCA_UNSPEC;
+pub const TCA_KIND: _bindgen_ty_65 = _bindgen_ty_65::TCA_KIND;
+pub const TCA_OPTIONS: _bindgen_ty_65 = _bindgen_ty_65::TCA_OPTIONS;
+pub const TCA_STATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS;
+pub const TCA_XSTATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_XSTATS;
+pub const TCA_RATE: _bindgen_ty_65 = _bindgen_ty_65::TCA_RATE;
+pub const TCA_FCNT: _bindgen_ty_65 = _bindgen_ty_65::TCA_FCNT;
+pub const TCA_STATS2: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS2;
+pub const TCA_STAB: _bindgen_ty_65 = _bindgen_ty_65::TCA_STAB;
+pub const TCA_PAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_PAD;
+pub const TCA_DUMP_INVISIBLE: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_INVISIBLE;
+pub const TCA_CHAIN: _bindgen_ty_65 = _bindgen_ty_65::TCA_CHAIN;
+pub const TCA_HW_OFFLOAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_HW_OFFLOAD;
+pub const TCA_INGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_INGRESS_BLOCK;
+pub const TCA_EGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_EGRESS_BLOCK;
+pub const TCA_DUMP_FLAGS: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_FLAGS;
+pub const TCA_EXT_WARN_MSG: _bindgen_ty_65 = _bindgen_ty_65::TCA_EXT_WARN_MSG;
+pub const __TCA_MAX: _bindgen_ty_65 = _bindgen_ty_65::__TCA_MAX;
+pub const NDUSEROPT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_UNSPEC;
+pub const NDUSEROPT_SRCADDR: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_SRCADDR;
+pub const __NDUSEROPT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__NDUSEROPT_MAX;
+pub const TCA_ROOT_UNSPEC: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_UNSPEC;
+pub const TCA_ROOT_TAB: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TAB;
+pub const TCA_ROOT_FLAGS: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_FLAGS;
+pub const TCA_ROOT_COUNT: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_COUNT;
+pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TIME_DELTA;
+pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_EXT_WARN_MSG;
+pub const __TCA_ROOT_MAX: _bindgen_ty_67 = _bindgen_ty_67::__TCA_ROOT_MAX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1552,6 +1566,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1641,7 +1657,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1737,7 +1754,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1794,7 +1813,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1947,10 +1967,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_18 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_19 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -1966,7 +2014,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_19 {
+pub enum _bindgen_ty_20 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -1978,7 +2026,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_20 {
+pub enum _bindgen_ty_21 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -1986,7 +2034,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2019,7 +2067,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2033,7 +2082,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_23 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2063,7 +2120,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2074,7 +2131,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum _bindgen_ty_25 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2089,7 +2146,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2102,7 +2159,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2140,7 +2197,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2152,7 +2209,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2168,7 +2225,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2176,7 +2233,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2196,7 +2253,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2204,7 +2261,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2213,7 +2270,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2228,7 +2285,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2236,7 +2293,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2250,7 +2307,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2259,7 +2316,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2277,7 +2334,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2287,14 +2344,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2302,7 +2359,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2316,7 +2373,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2328,7 +2385,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2337,7 +2394,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2346,7 +2403,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2356,7 +2413,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2365,7 +2422,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2375,7 +2432,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2390,7 +2447,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2402,7 +2459,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2418,7 +2475,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2427,7 +2484,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2435,15 +2492,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFA_UNSPEC = 0,
 IFA_ADDRESS = 1,
 IFA_LOCAL = 2,
@@ -2461,7 +2518,7 @@ __IFA_MAX = 12,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 NDA_UNSPEC = 0,
 NDA_DST = 1,
 NDA_LLADDR = 2,
@@ -2485,7 +2542,7 @@ __NDA_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 NDTPA_UNSPEC = 0,
 NDTPA_IFINDEX = 1,
 NDTPA_REFCNT = 2,
@@ -2511,7 +2568,7 @@ __NDTPA_MAX = 20,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_57 {
+pub enum _bindgen_ty_58 {
 NDTA_UNSPEC = 0,
 NDTA_NAME = 1,
 NDTA_THRESH1 = 2,
@@ -2527,14 +2584,14 @@ __NDTA_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_58 {
+pub enum _bindgen_ty_59 {
 FDB_NOTIFY_BIT = 1,
 FDB_NOTIFY_INACTIVE_BIT = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_59 {
+pub enum _bindgen_ty_60 {
 NFEA_UNSPEC = 0,
 NFEA_ACTIVITY_NOTIFY = 1,
 NFEA_DONT_REFRESH = 2,
@@ -2543,7 +2600,7 @@ __NFEA_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_60 {
+pub enum _bindgen_ty_61 {
 RTM_BASE = 16,
 RTM_DELLINK = 17,
 RTM_GETLINK = 18,
@@ -2620,7 +2677,7 @@ __RTM_MAX = 123,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_61 {
+pub enum _bindgen_ty_62 {
 RTN_UNSPEC = 0,
 RTN_UNICAST = 1,
 RTN_LOCAL = 2,
@@ -2696,7 +2753,7 @@ __RTA_MAX = 31,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_62 {
+pub enum _bindgen_ty_63 {
 RTAX_UNSPEC = 0,
 RTAX_LOCK = 1,
 RTAX_MTU = 2,
@@ -2720,7 +2777,7 @@ __RTAX_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_63 {
+pub enum _bindgen_ty_64 {
 PREFIX_UNSPEC = 0,
 PREFIX_ADDRESS = 1,
 PREFIX_CACHEINFO = 2,
@@ -2729,7 +2786,7 @@ __PREFIX_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_64 {
+pub enum _bindgen_ty_65 {
 TCA_UNSPEC = 0,
 TCA_KIND = 1,
 TCA_OPTIONS = 2,
@@ -2752,7 +2809,7 @@ __TCA_MAX = 17,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_65 {
+pub enum _bindgen_ty_66 {
 NDUSEROPT_UNSPEC = 0,
 NDUSEROPT_SRCADDR = 1,
 __NDUSEROPT_MAX = 2,
@@ -2803,7 +2860,7 @@ __RTNLGRP_MAX = 37,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_66 {
+pub enum _bindgen_ty_67 {
 TCA_ROOT_UNSPEC = 0,
 TCA_ROOT_TAB = 1,
 TCA_ROOT_FLAGS = 2,
@@ -2866,6 +2923,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/mips64/prctl.rs
+++ b/src/mips64/prctl.rs
@@ -228,6 +228,7 @@ pub const PR_SME_VL_LEN_MASK: u32 = 65535;
 pub const PR_SME_VL_INHERIT: u32 = 131072;
 pub const PR_SET_MDWE: u32 = 65;
 pub const PR_MDWE_REFUSE_EXEC_GAIN: u32 = 1;
+pub const PR_MDWE_NO_INHERIT: u32 = 2;
 pub const PR_GET_MDWE: u32 = 66;
 pub const PR_SET_VMA: u32 = 1398164801;
 pub const PR_SET_VMA_ANON_NAME: u32 = 0;

--- a/src/mips64/xdp.rs
+++ b/src/mips64/xdp.rs
@@ -83,6 +83,7 @@ pub len: __u64,
 pub chunk_size: __u32,
 pub headroom: __u32,
 pub flags: __u32,
+pub tx_metadata_len: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -98,6 +99,23 @@ pub tx_ring_empty_descs: __u64,
 #[derive(Debug, Copy, Clone)]
 pub struct xdp_options {
 pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct xsk_tx_metadata {
+pub flags: __u64,
+pub __bindgen_anon_1: xsk_tx_metadata__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1 {
+pub csum_start: __u16,
+pub csum_offset: __u16,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2 {
+pub tx_timestamp: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -150,7 +168,9 @@ pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
 pub const XDP_USE_NEED_WAKEUP: u32 = 8;
+pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
+pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;
@@ -167,5 +187,13 @@ pub const XDP_UMEM_PGOFF_FILL_RING: u64 = 4294967296;
 pub const XDP_UMEM_PGOFF_COMPLETION_RING: u64 = 6442450944;
 pub const XSK_UNALIGNED_BUF_OFFSET_SHIFT: u32 = 48;
 pub const XSK_UNALIGNED_BUF_ADDR_MASK: u64 = 281474976710655;
-pub const XDP_USE_SG: u32 = 16;
+pub const XDP_TXMD_FLAGS_TIMESTAMP: u32 = 1;
+pub const XDP_TXMD_FLAGS_CHECKSUM: u32 = 2;
 pub const XDP_PKT_CONTD: u32 = 1;
+pub const XDP_TX_METADATA: u32 = 2;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union xsk_tx_metadata__bindgen_ty_1 {
+pub request: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1,
+pub completion: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2,
+}

--- a/src/mips64r6/general.rs
+++ b/src/mips64r6/general.rs
@@ -184,7 +184,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -239,6 +240,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -297,6 +331,29 @@ pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
 pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -391,36 +448,6 @@ pub it_value: __kernel_old_timeval,
 pub struct __kernel_sock_timeval {
 pub tv_sec: __s64,
 pub tv_usec: __s64,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timespec {
-pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: crate::ctypes::c_long,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timeval {
-pub tv_sec: __kernel_old_time_t,
-pub tv_usec: __kernel_suseconds_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerspec {
-pub it_interval: timespec,
-pub it_value: timespec,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerval {
-pub it_interval: timeval,
-pub it_value: timeval,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timezone {
-pub tz_minuteswest: crate::ctypes::c_int,
-pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -702,6 +729,36 @@ pub c_cc: [crate::ctypes::c_uchar; 23usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct timespec {
+pub tv_sec: __kernel_old_time_t,
+pub tv_nsec: crate::ctypes::c_long,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timeval {
+pub tv_sec: __kernel_old_time_t,
+pub tv_usec: __kernel_suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerspec {
+pub it_interval: timespec,
+pub it_value: timespec,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerval {
+pub it_interval: timeval,
+pub it_value: timeval,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timezone {
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct iovec {
 pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
@@ -795,6 +852,22 @@ pub struct uffdio_continue {
 pub range: uffdio_range,
 pub mode: __u64,
 pub mapped: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_poison {
+pub range: uffdio_range,
+pub mode: __u64,
+pub updated: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_move {
+pub dst: __u64,
+pub src: __u64,
+pub len: __u64,
+pub mode: __u64,
+pub move_: __s64,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -899,9 +972,9 @@ pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 394496;
+pub const LINUX_VERSION_CODE: u32 = 395264;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 5;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_VECTOR_SIZE_ARCH: u32 = 1;
@@ -1280,6 +1353,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1351,6 +1432,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const FUTEX_WAIT: u32 = 0;
 pub const FUTEX_WAKE: u32 = 1;
 pub const FUTEX_FD: u32 = 2;
@@ -1381,6 +1472,13 @@ pub const FUTEX_WAIT_BITSET_PRIVATE: u32 = 137;
 pub const FUTEX_WAKE_BITSET_PRIVATE: u32 = 138;
 pub const FUTEX_WAIT_REQUEUE_PI_PRIVATE: u32 = 139;
 pub const FUTEX_CMP_REQUEUE_PI_PRIVATE: u32 = 140;
+pub const FUTEX2_SIZE_U8: u32 = 0;
+pub const FUTEX2_SIZE_U16: u32 = 1;
+pub const FUTEX2_SIZE_U32: u32 = 2;
+pub const FUTEX2_SIZE_U64: u32 = 3;
+pub const FUTEX2_NUMA: u32 = 4;
+pub const FUTEX2_PRIVATE: u32 = 128;
+pub const FUTEX2_SIZE_MASK: u32 = 3;
 pub const FUTEX_32: u32 = 2;
 pub const FUTEX_WAITV_MAX: u32 = 128;
 pub const FUTEX_WAITERS: u32 = 2147483648;
@@ -1637,25 +1735,6 @@ pub const LINUX_REBOOT_CMD_POWER_OFF: u32 = 1126301404;
 pub const LINUX_REBOOT_CMD_RESTART2: u32 = 2712847316;
 pub const LINUX_REBOOT_CMD_SW_SUSPEND: u32 = 3489725666;
 pub const LINUX_REBOOT_CMD_KEXEC: u32 = 1163412803;
-pub const ITIMER_REAL: u32 = 0;
-pub const ITIMER_VIRTUAL: u32 = 1;
-pub const ITIMER_PROF: u32 = 2;
-pub const CLOCK_REALTIME: u32 = 0;
-pub const CLOCK_MONOTONIC: u32 = 1;
-pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
-pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
-pub const CLOCK_MONOTONIC_RAW: u32 = 4;
-pub const CLOCK_REALTIME_COARSE: u32 = 5;
-pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
-pub const CLOCK_BOOTTIME: u32 = 7;
-pub const CLOCK_REALTIME_ALARM: u32 = 8;
-pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
-pub const CLOCK_SGI_CYCLE: u32 = 10;
-pub const CLOCK_TAI: u32 = 11;
-pub const MAX_CLOCKS: u32 = 16;
-pub const CLOCKS_MASK: u32 = 1;
-pub const CLOCKS_MONO: u32 = 1;
-pub const TIMER_ABSTIME: u32 = 1;
 pub const RUSAGE_SELF: u32 = 0;
 pub const RUSAGE_CHILDREN: i32 = -1;
 pub const RUSAGE_BOTH: i32 = -2;
@@ -1835,7 +1914,8 @@ pub const SEGV_ADIDERR: u32 = 6;
 pub const SEGV_ADIPERR: u32 = 7;
 pub const SEGV_MTEAERR: u32 = 8;
 pub const SEGV_MTESERR: u32 = 9;
-pub const NSIGSEGV: u32 = 9;
+pub const SEGV_CPERR: u32 = 10;
+pub const NSIGSEGV: u32 = 10;
 pub const BUS_ADRALN: u32 = 1;
 pub const BUS_ADRERR: u32 = 2;
 pub const BUS_OBJERR: u32 = 3;
@@ -1916,6 +1996,7 @@ pub const STATX_BASIC_STATS: u32 = 2047;
 pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
+pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2232,6 +2313,25 @@ pub const TIOCM_DSR: u32 = 1024;
 pub const TIOCM_OUT1: u32 = 8192;
 pub const TIOCM_OUT2: u32 = 16384;
 pub const TIOCM_LOOP: u32 = 32768;
+pub const ITIMER_REAL: u32 = 0;
+pub const ITIMER_VIRTUAL: u32 = 1;
+pub const ITIMER_PROF: u32 = 2;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_SGI_CYCLE: u32 = 10;
+pub const CLOCK_TAI: u32 = 11;
+pub const MAX_CLOCKS: u32 = 16;
+pub const CLOCKS_MASK: u32 = 1;
+pub const CLOCKS_MONO: u32 = 1;
+pub const TIMER_ABSTIME: u32 = 1;
 pub const UIO_FASTIOV: u32 = 8;
 pub const UIO_MAXIOV: u32 = 1024;
 pub const __NR_Linux: u32 = 5000;
@@ -2590,6 +2690,16 @@ pub const __NR_process_mrelease: u32 = 5448;
 pub const __NR_futex_waitv: u32 = 5449;
 pub const __NR_set_mempolicy_home_node: u32 = 5450;
 pub const __NR_cachestat: u32 = 5451;
+pub const __NR_fchmodat2: u32 = 5452;
+pub const __NR_map_shadow_stack: u32 = 5453;
+pub const __NR_futex_wake: u32 = 5454;
+pub const __NR_futex_wait: u32 = 5455;
+pub const __NR_futex_requeue: u32 = 5456;
+pub const __NR_statmount: u32 = 5457;
+pub const __NR_listmount: u32 = 5458;
+pub const __NR_lsm_get_self_attr: u32 = 5459;
+pub const __NR_lsm_set_self_attr: u32 = 5460;
+pub const __NR_lsm_list_modules: u32 = 5461;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
 pub const WSTOPPED: u32 = 2;
@@ -2668,8 +2778,10 @@ pub const _UFFDIO_UNREGISTER: u32 = 1;
 pub const _UFFDIO_WAKE: u32 = 2;
 pub const _UFFDIO_COPY: u32 = 3;
 pub const _UFFDIO_ZEROPAGE: u32 = 4;
+pub const _UFFDIO_MOVE: u32 = 5;
 pub const _UFFDIO_WRITEPROTECT: u32 = 6;
 pub const _UFFDIO_CONTINUE: u32 = 7;
+pub const _UFFDIO_POISON: u32 = 8;
 pub const _UFFDIO_API: u32 = 63;
 pub const UFFDIO: u32 = 170;
 pub const UFFD_EVENT_PAGEFAULT: u32 = 18;
@@ -2694,6 +2806,9 @@ pub const UFFD_FEATURE_MINOR_SHMEM: u32 = 1024;
 pub const UFFD_FEATURE_EXACT_ADDRESS: u32 = 2048;
 pub const UFFD_FEATURE_WP_HUGETLBFS_SHMEM: u32 = 4096;
 pub const UFFD_FEATURE_WP_UNPOPULATED: u32 = 8192;
+pub const UFFD_FEATURE_POISON: u32 = 16384;
+pub const UFFD_FEATURE_WP_ASYNC: u32 = 32768;
+pub const UFFD_FEATURE_MOVE: u32 = 65536;
 pub const UFFD_USER_MODE_ONLY: u32 = 1;
 pub const DT_UNKNOWN: u32 = 0;
 pub const DT_FIFO: u32 = 1;
@@ -2772,6 +2887,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/mips64r6/if_arp.rs
+++ b/src/mips64r6/if_arp.rs
@@ -52,11 +52,6 @@ pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
@@ -175,6 +170,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -182,23 +178,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -1136,6 +1117,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_4 = _bindgen_ty_4::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_4 = _bindgen_ty_4::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_MASK;
@@ -1204,6 +1186,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_HAIRPIN;
@@ -1251,6 +1235,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_10 = _bindgen_ty_10::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_KIND;
@@ -1312,301 +1297,310 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_19 = _bindgen_ty_19::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_40 = _bindgen_ty_40::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_46 = _bindgen_ty_46::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_DSA_MAX;
-pub const IF_PORT_UNKNOWN: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_UNKNOWN;
-pub const IF_PORT_10BASE2: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASE2;
-pub const IF_PORT_10BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASET;
-pub const IF_PORT_AUI: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_AUI;
-pub const IF_PORT_100BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASET;
-pub const IF_PORT_100BASETX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASETX;
-pub const IF_PORT_100BASEFX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASEFX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_20 = _bindgen_ty_20::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_23 = _bindgen_ty_23::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_47 = _bindgen_ty_47::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__IFLA_DSA_MAX;
+pub const IF_PORT_UNKNOWN: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_UNKNOWN;
+pub const IF_PORT_10BASE2: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASE2;
+pub const IF_PORT_10BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASET;
+pub const IF_PORT_AUI: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_AUI;
+pub const IF_PORT_100BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASET;
+pub const IF_PORT_100BASETX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASETX;
+pub const IF_PORT_100BASEFX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASEFX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1709,6 +1703,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1798,7 +1794,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1894,7 +1891,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1951,7 +1950,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2104,10 +2104,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_20 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_21 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -2123,7 +2151,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -2135,7 +2163,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum _bindgen_ty_23 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -2143,7 +2171,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2176,7 +2204,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2190,7 +2219,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_25 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2220,7 +2257,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2231,7 +2268,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2246,7 +2283,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2259,7 +2296,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2297,7 +2334,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2309,7 +2346,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2325,7 +2362,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2333,7 +2370,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2353,7 +2390,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2361,7 +2398,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2370,7 +2407,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2385,7 +2422,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2393,7 +2430,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2407,7 +2444,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2416,7 +2453,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2434,7 +2471,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2444,14 +2481,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2459,7 +2496,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2473,7 +2510,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2485,7 +2522,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2494,7 +2531,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2503,7 +2540,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2513,7 +2550,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2522,7 +2559,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2532,7 +2569,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2547,7 +2584,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2559,7 +2596,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2575,7 +2612,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2584,7 +2621,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2592,15 +2629,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 IF_PORT_UNKNOWN = 0,
 IF_PORT_10BASE2 = 1,
 IF_PORT_10BASET = 2,
@@ -2683,74 +2720,6 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 impl nlmsgerr_attrs {
 pub const NLMSGERR_ATTR_MAX: nlmsgerr_attrs = nlmsgerr_attrs::NLMSGERR_ATTR_MISS_NEST;
 }
@@ -2765,6 +2734,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/mips64r6/if_packet.rs
+++ b/src/mips64r6/if_packet.rs
@@ -51,11 +51,6 @@ pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_pkt {
 pub spkt_family: crate::ctypes::c_ushort,
@@ -63,6 +58,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -70,23 +66,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -337,71 +318,3 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}

--- a/src/mips64r6/io_uring.rs
+++ b/src/mips64r6/io_uring.rs
@@ -79,7 +79,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -134,6 +135,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -195,6 +229,29 @@ pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
 pub tv_nsec: crate::ctypes::c_longlong,
@@ -253,6 +310,12 @@ pub __pad1: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_sqe__bindgen_ty_2__bindgen_ty_1 {
+pub level: __u32,
+pub optname: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_sqe__bindgen_ty_5__bindgen_ty_1 {
 pub addr_len: __u16,
 pub __pad3: [__u16; 1usize],
@@ -260,6 +323,7 @@ pub __pad3: [__u16; 1usize],
 #[repr(C)]
 pub struct io_uring_sqe__bindgen_ty_6 {
 pub __bindgen_anon_1: __BindgenUnionField<io_uring_sqe__bindgen_ty_6__bindgen_ty_1>,
+pub optval: __BindgenUnionField<__u64>,
 pub cmd: __BindgenUnionField<[__u8; 0usize]>,
 pub bindgen_union_field: [u64; 2usize],
 }
@@ -421,6 +485,13 @@ pub resv: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_buf_status {
+pub buf_group: __u32,
+pub head: __u32,
+pub resv: [__u32; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -434,7 +505,9 @@ pub addr: __u64,
 pub fd: __s32,
 pub flags: __u32,
 pub timeout: __kernel_timespec,
-pub pad: [__u64; 4usize],
+pub opcode: __u8,
+pub pad: [__u8; 7usize],
+pub pad2: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -607,6 +680,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -678,6 +759,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const IORING_FILE_INDEX_ALLOC: i32 = -1;
 pub const IORING_SETUP_IOPOLL: u32 = 1;
 pub const IORING_SETUP_SQPOLL: u32 = 2;
@@ -695,8 +786,9 @@ pub const IORING_SETUP_SINGLE_ISSUER: u32 = 4096;
 pub const IORING_SETUP_DEFER_TASKRUN: u32 = 8192;
 pub const IORING_SETUP_NO_MMAP: u32 = 16384;
 pub const IORING_SETUP_REGISTERED_FD_ONLY: u32 = 32768;
+pub const IORING_SETUP_NO_SQARRAY: u32 = 65536;
 pub const IORING_URING_CMD_FIXED: u32 = 1;
-pub const IORING_URING_CMD_POLLED: u32 = 2147483648;
+pub const IORING_URING_CMD_MASK: u32 = 1;
 pub const IORING_FSYNC_DATASYNC: u32 = 1;
 pub const IORING_TIMEOUT_ABS: u32 = 1;
 pub const IORING_TIMEOUT_UPDATE: u32 = 2;
@@ -716,6 +808,8 @@ pub const IORING_ASYNC_CANCEL_ALL: u32 = 1;
 pub const IORING_ASYNC_CANCEL_FD: u32 = 2;
 pub const IORING_ASYNC_CANCEL_ANY: u32 = 4;
 pub const IORING_ASYNC_CANCEL_FD_FIXED: u32 = 8;
+pub const IORING_ASYNC_CANCEL_USERDATA: u32 = 16;
+pub const IORING_ASYNC_CANCEL_OP: u32 = 32;
 pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
@@ -724,6 +818,7 @@ pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
+pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
@@ -796,6 +891,7 @@ pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGIS
 pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
 pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
 pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
+pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
 pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
 pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
 pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
@@ -806,6 +902,10 @@ pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTR
 pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
 pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
 pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
+pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
+pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
+pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
+pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -818,6 +918,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -884,7 +985,13 @@ IORING_OP_SOCKET = 45,
 IORING_OP_URING_CMD = 46,
 IORING_OP_SEND_ZC = 47,
 IORING_OP_SENDMSG_ZC = 48,
-IORING_OP_LAST = 49,
+IORING_OP_READ_MULTISHOT = 49,
+IORING_OP_WAITID = 50,
+IORING_OP_FUTEX_WAIT = 51,
+IORING_OP_FUTEX_WAKE = 52,
+IORING_OP_FUTEX_WAITV = 53,
+IORING_OP_FIXED_FD_INSTALL = 54,
+IORING_OP_LAST = 55,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -929,7 +1036,8 @@ IORING_REGISTER_PBUF_RING = 22,
 IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
-IORING_REGISTER_LAST = 26,
+IORING_REGISTER_PBUF_STATUS = 26,
+IORING_REGISTER_LAST = 27,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
@@ -954,6 +1062,15 @@ IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
 IORING_RESTRICTION_SQE_FLAGS_REQUIRED = 3,
 IORING_RESTRICTION_LAST = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_8 {
+SOCKET_URING_OP_SIOCINQ = 0,
+SOCKET_URING_OP_SIOCOUTQ = 1,
+SOCKET_URING_OP_GETSOCKOPT = 2,
+SOCKET_URING_OP_SETSOCKOPT = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -981,6 +1098,7 @@ pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_1__bindgen_ty_1,
 pub union io_uring_sqe__bindgen_ty_2 {
 pub addr: __u64,
 pub splice_off_in: __u64,
+pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_2__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -1004,6 +1122,9 @@ pub hardlink_flags: __u32,
 pub xattr_flags: __u32,
 pub msg_ring_flags: __u32,
 pub uring_cmd_flags: __u32,
+pub waitid_flags: __u32,
+pub futex_flags: __u32,
+pub install_fd_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]
@@ -1016,6 +1137,7 @@ pub buf_group: __u16,
 pub union io_uring_sqe__bindgen_ty_5 {
 pub splice_fd_in: __s32,
 pub file_index: __u32,
+pub optlen: __u32,
 pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]

--- a/src/mips64r6/net.rs
+++ b/src/mips64r6/net.rs
@@ -429,6 +429,9 @@ pub tcpi_rcv_ooopack: __u32,
 pub tcpi_snd_wnd: __u32,
 pub tcpi_rcv_wnd: __u32,
 pub tcpi_rehash: __u32,
+pub tcpi_total_rto: __u16,
+pub tcpi_total_rto_recoveries: __u16,
+pub tcpi_total_rto_time: __u32,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -448,6 +451,80 @@ pub tcpm_prefixlen: __u8,
 pub tcpm_keylen: __u16,
 pub tcpm_addr: [__be32; 4usize],
 pub tcpm_key: [__u8; 80usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_add {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub key: [__u8; 80usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_del {
+pub addr: __kernel_sockaddr_storage,
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub current_key: __u8,
+pub rnext: __u8,
+pub keyflags: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_info_opt {
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub current_key: __u8,
+pub rnext: __u8,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+pub pkt_key_not_found: __u64,
+pub pkt_ao_required: __u64,
+pub pkt_dropped_icmp: __u64,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_getsockopt {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub key: [__u8; 80usize],
+pub nkeys: __u32,
+pub _bitfield_align_1: [u16; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub prefix: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub ifindex: __s32,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_repair {
+pub snt_isn: __be32,
+pub rcv_isn: __be32,
+pub snd_sne: __u32,
+pub rcv_sne: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1216,6 +1293,11 @@ pub const TCP_ZEROCOPY_RECEIVE: u32 = 35;
 pub const TCP_INQ: u32 = 36;
 pub const TCP_CM_INQ: u32 = 36;
 pub const TCP_TX_DELAY: u32 = 37;
+pub const TCP_AO_ADD_KEY: u32 = 38;
+pub const TCP_AO_DEL_KEY: u32 = 39;
+pub const TCP_AO_INFO: u32 = 40;
+pub const TCP_AO_GET_KEYS: u32 = 41;
+pub const TCP_AO_REPAIR: u32 = 42;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1225,9 +1307,13 @@ pub const TCPI_OPT_WSCALE: u32 = 4;
 pub const TCPI_OPT_ECN: u32 = 8;
 pub const TCPI_OPT_ECN_SEEN: u32 = 16;
 pub const TCPI_OPT_SYN_DATA: u32 = 32;
+pub const TCPI_OPT_USEC_TS: u32 = 64;
 pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
+pub const TCP_AO_MAXKEYLEN: u32 = 80;
+pub const TCP_AO_KEYF_IFINDEX: u32 = 1;
+pub const TCP_AO_KEYF_EXCLUDE_OPT: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
@@ -1592,6 +1678,7 @@ pub const DEVCONF_IOAM6_ID: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID;
 pub const DEVCONF_IOAM6_ID_WIDE: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID_WIDE;
 pub const DEVCONF_NDISC_EVICT_NOCARRIER: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_NDISC_EVICT_NOCARRIER;
 pub const DEVCONF_ACCEPT_UNTRACKED_NA: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_UNTRACKED_NA;
+pub const DEVCONF_ACCEPT_RA_MIN_LFT: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_RA_MIN_LFT;
 pub const DEVCONF_MAX: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_MAX;
 pub const TCP_FLAG_CWR: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_CWR;
 pub const TCP_FLAG_ECE: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_ECE;
@@ -1789,7 +1876,8 @@ DEVCONF_IOAM6_ID = 54,
 DEVCONF_IOAM6_ID_WIDE = 55,
 DEVCONF_NDISC_EVICT_NOCARRIER = 56,
 DEVCONF_ACCEPT_UNTRACKED_NA = 57,
-DEVCONF_MAX = 58,
+DEVCONF_ACCEPT_RA_MIN_LFT = 58,
+DEVCONF_MAX = 59,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2507,6 +2595,289 @@ tcpi_delivery_rate_app_limited as u64
 __bindgen_bitfield_unit.set(9usize, 2u8, {
 let tcpi_fastopen_client_fail: u8 = unsafe { ::core::mem::transmute(tcpi_fastopen_client_fail) };
 tcpi_fastopen_client_fail as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_add {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 30u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 30u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_del {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn del_async(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_del_async(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 29u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 29u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, del_async: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let del_async: u32 = unsafe { ::core::mem::transmute(del_async) };
+del_async as u64
+});
+__bindgen_bitfield_unit.set(3usize, 29u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_info_opt {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn ao_required(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_ao_required(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_counters(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_counters(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn accept_icmps(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_accept_icmps(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(4usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(5usize, 27u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(5usize, 27u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, ao_required: __u32, set_counters: __u32, accept_icmps: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let ao_required: u32 = unsafe { ::core::mem::transmute(ao_required) };
+ao_required as u64
+});
+__bindgen_bitfield_unit.set(3usize, 1u8, {
+let set_counters: u32 = unsafe { ::core::mem::transmute(set_counters) };
+set_counters as u64
+});
+__bindgen_bitfield_unit.set(4usize, 1u8, {
+let accept_icmps: u32 = unsafe { ::core::mem::transmute(accept_icmps) };
+accept_icmps as u64
+});
+__bindgen_bitfield_unit.set(5usize, 27u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_getsockopt {
+#[inline]
+pub fn is_current(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_current(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn is_rnext(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_rnext(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn get_all(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_get_all(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 13u8) as u16) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 13u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(is_current: __u16, is_rnext: __u16, get_all: __u16, reserved: __u16) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let is_current: u16 = unsafe { ::core::mem::transmute(is_current) };
+is_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let is_rnext: u16 = unsafe { ::core::mem::transmute(is_rnext) };
+is_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let get_all: u16 = unsafe { ::core::mem::transmute(get_all) };
+get_all as u64
+});
+__bindgen_bitfield_unit.set(3usize, 13u8, {
+let reserved: u16 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
 });
 __bindgen_bitfield_unit
 }

--- a/src/mips64r6/netlink.rs
+++ b/src/mips64r6/netlink.rs
@@ -734,7 +734,8 @@ pub const RTAX_FEATURE_ECN: u32 = 1;
 pub const RTAX_FEATURE_SACK: u32 = 2;
 pub const RTAX_FEATURE_TIMESTAMP: u32 = 4;
 pub const RTAX_FEATURE_ALLFRAG: u32 = 8;
-pub const RTAX_FEATURE_MASK: u32 = 15;
+pub const RTAX_FEATURE_TCP_USEC_TS: u32 = 16;
+pub const RTAX_FEATURE_MASK: u32 = 31;
 pub const TCM_IFINDEX_MAGIC_BLOCK: u32 = 4294967295;
 pub const TCA_DUMP_FLAGS_TERSE: u32 = 1;
 pub const RTMGRP_LINK: u32 = 1;
@@ -831,6 +832,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_2 = _bindgen_ty_2::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_2 = _bindgen_ty_2::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_MASK;
@@ -899,6 +901,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_6 = _bindgen_ty_6::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_HAIRPIN;
@@ -946,6 +950,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_KIND;
@@ -1007,501 +1012,510 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_17 = _bindgen_ty_17::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_18 = _bindgen_ty_18::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_21 = _bindgen_ty_21::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_44 = _bindgen_ty_44::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_DSA_MAX;
-pub const IFA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFA_UNSPEC;
-pub const IFA_ADDRESS: _bindgen_ty_54 = _bindgen_ty_54::IFA_ADDRESS;
-pub const IFA_LOCAL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LOCAL;
-pub const IFA_LABEL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LABEL;
-pub const IFA_BROADCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_BROADCAST;
-pub const IFA_ANYCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_ANYCAST;
-pub const IFA_CACHEINFO: _bindgen_ty_54 = _bindgen_ty_54::IFA_CACHEINFO;
-pub const IFA_MULTICAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_MULTICAST;
-pub const IFA_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFA_FLAGS;
-pub const IFA_RT_PRIORITY: _bindgen_ty_54 = _bindgen_ty_54::IFA_RT_PRIORITY;
-pub const IFA_TARGET_NETNSID: _bindgen_ty_54 = _bindgen_ty_54::IFA_TARGET_NETNSID;
-pub const IFA_PROTO: _bindgen_ty_54 = _bindgen_ty_54::IFA_PROTO;
-pub const __IFA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFA_MAX;
-pub const NDA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::NDA_UNSPEC;
-pub const NDA_DST: _bindgen_ty_55 = _bindgen_ty_55::NDA_DST;
-pub const NDA_LLADDR: _bindgen_ty_55 = _bindgen_ty_55::NDA_LLADDR;
-pub const NDA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::NDA_CACHEINFO;
-pub const NDA_PROBES: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROBES;
-pub const NDA_VLAN: _bindgen_ty_55 = _bindgen_ty_55::NDA_VLAN;
-pub const NDA_PORT: _bindgen_ty_55 = _bindgen_ty_55::NDA_PORT;
-pub const NDA_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_VNI;
-pub const NDA_IFINDEX: _bindgen_ty_55 = _bindgen_ty_55::NDA_IFINDEX;
-pub const NDA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::NDA_MASTER;
-pub const NDA_LINK_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::NDA_LINK_NETNSID;
-pub const NDA_SRC_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_SRC_VNI;
-pub const NDA_PROTOCOL: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROTOCOL;
-pub const NDA_NH_ID: _bindgen_ty_55 = _bindgen_ty_55::NDA_NH_ID;
-pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_55 = _bindgen_ty_55::NDA_FDB_EXT_ATTRS;
-pub const NDA_FLAGS_EXT: _bindgen_ty_55 = _bindgen_ty_55::NDA_FLAGS_EXT;
-pub const NDA_NDM_STATE_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_STATE_MASK;
-pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_FLAGS_MASK;
-pub const __NDA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__NDA_MAX;
-pub const NDTPA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UNSPEC;
-pub const NDTPA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_IFINDEX;
-pub const NDTPA_REFCNT: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REFCNT;
-pub const NDTPA_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REACHABLE_TIME;
-pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_BASE_REACHABLE_TIME;
-pub const NDTPA_RETRANS_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_RETRANS_TIME;
-pub const NDTPA_GC_STALETIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_GC_STALETIME;
-pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_DELAY_PROBE_TIME;
-pub const NDTPA_QUEUE_LEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LEN;
-pub const NDTPA_APP_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_APP_PROBES;
-pub const NDTPA_UCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UCAST_PROBES;
-pub const NDTPA_MCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_PROBES;
-pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_ANYCAST_DELAY;
-pub const NDTPA_PROXY_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_DELAY;
-pub const NDTPA_PROXY_QLEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_QLEN;
-pub const NDTPA_LOCKTIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_LOCKTIME;
-pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LENBYTES;
-pub const NDTPA_MCAST_REPROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_REPROBES;
-pub const NDTPA_PAD: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PAD;
-pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_INTERVAL_PROBE_TIME_MS;
-pub const __NDTPA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDTPA_MAX;
-pub const NDTA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTA_UNSPEC;
-pub const NDTA_NAME: _bindgen_ty_57 = _bindgen_ty_57::NDTA_NAME;
-pub const NDTA_THRESH1: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH1;
-pub const NDTA_THRESH2: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH2;
-pub const NDTA_THRESH3: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH3;
-pub const NDTA_CONFIG: _bindgen_ty_57 = _bindgen_ty_57::NDTA_CONFIG;
-pub const NDTA_PARMS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PARMS;
-pub const NDTA_STATS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_STATS;
-pub const NDTA_GC_INTERVAL: _bindgen_ty_57 = _bindgen_ty_57::NDTA_GC_INTERVAL;
-pub const NDTA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PAD;
-pub const __NDTA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTA_MAX;
-pub const FDB_NOTIFY_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_BIT;
-pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_INACTIVE_BIT;
-pub const NFEA_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::NFEA_UNSPEC;
-pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_59 = _bindgen_ty_59::NFEA_ACTIVITY_NOTIFY;
-pub const NFEA_DONT_REFRESH: _bindgen_ty_59 = _bindgen_ty_59::NFEA_DONT_REFRESH;
-pub const __NFEA_MAX: _bindgen_ty_59 = _bindgen_ty_59::__NFEA_MAX;
-pub const RTM_BASE: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_NEWLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_DELLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINK;
-pub const RTM_GETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINK;
-pub const RTM_SETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETLINK;
-pub const RTM_NEWADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDR;
-pub const RTM_DELADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDR;
-pub const RTM_GETADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDR;
-pub const RTM_NEWROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWROUTE;
-pub const RTM_DELROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELROUTE;
-pub const RTM_GETROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETROUTE;
-pub const RTM_NEWNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGH;
-pub const RTM_DELNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEIGH;
-pub const RTM_GETNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGH;
-pub const RTM_NEWRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWRULE;
-pub const RTM_DELRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELRULE;
-pub const RTM_GETRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETRULE;
-pub const RTM_NEWQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWQDISC;
-pub const RTM_DELQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELQDISC;
-pub const RTM_GETQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETQDISC;
-pub const RTM_NEWTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTCLASS;
-pub const RTM_DELTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTCLASS;
-pub const RTM_GETTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTCLASS;
-pub const RTM_NEWTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTFILTER;
-pub const RTM_DELTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTFILTER;
-pub const RTM_GETTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTFILTER;
-pub const RTM_NEWACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWACTION;
-pub const RTM_DELACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELACTION;
-pub const RTM_GETACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETACTION;
-pub const RTM_NEWPREFIX: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWPREFIX;
-pub const RTM_GETMULTICAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMULTICAST;
-pub const RTM_GETANYCAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETANYCAST;
-pub const RTM_NEWNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGHTBL;
-pub const RTM_GETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGHTBL;
-pub const RTM_SETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETNEIGHTBL;
-pub const RTM_NEWNDUSEROPT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNDUSEROPT;
-pub const RTM_NEWADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDRLABEL;
-pub const RTM_DELADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDRLABEL;
-pub const RTM_GETADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDRLABEL;
-pub const RTM_GETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETDCB;
-pub const RTM_SETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETDCB;
-pub const RTM_NEWNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNETCONF;
-pub const RTM_DELNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNETCONF;
-pub const RTM_GETNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNETCONF;
-pub const RTM_NEWMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWMDB;
-pub const RTM_DELMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELMDB;
-pub const RTM_GETMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMDB;
-pub const RTM_NEWNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNSID;
-pub const RTM_DELNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNSID;
-pub const RTM_GETNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNSID;
-pub const RTM_NEWSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWSTATS;
-pub const RTM_GETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETSTATS;
-pub const RTM_SETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETSTATS;
-pub const RTM_NEWCACHEREPORT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCACHEREPORT;
-pub const RTM_NEWCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCHAIN;
-pub const RTM_DELCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELCHAIN;
-pub const RTM_GETCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETCHAIN;
-pub const RTM_NEWNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOP;
-pub const RTM_DELNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOP;
-pub const RTM_GETNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOP;
-pub const RTM_NEWLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWLINKPROP;
-pub const RTM_DELLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINKPROP;
-pub const RTM_GETLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINKPROP;
-pub const RTM_NEWVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWVLAN;
-pub const RTM_DELVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELVLAN;
-pub const RTM_GETVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETVLAN;
-pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOPBUCKET;
-pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOPBUCKET;
-pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOPBUCKET;
-pub const RTM_NEWTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTUNNEL;
-pub const RTM_DELTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTUNNEL;
-pub const RTM_GETTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTUNNEL;
-pub const __RTM_MAX: _bindgen_ty_60 = _bindgen_ty_60::__RTM_MAX;
-pub const RTN_UNSPEC: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNSPEC;
-pub const RTN_UNICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNICAST;
-pub const RTN_LOCAL: _bindgen_ty_61 = _bindgen_ty_61::RTN_LOCAL;
-pub const RTN_BROADCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_BROADCAST;
-pub const RTN_ANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_ANYCAST;
-pub const RTN_MULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_MULTICAST;
-pub const RTN_BLACKHOLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_BLACKHOLE;
-pub const RTN_UNREACHABLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNREACHABLE;
-pub const RTN_PROHIBIT: _bindgen_ty_61 = _bindgen_ty_61::RTN_PROHIBIT;
-pub const RTN_THROW: _bindgen_ty_61 = _bindgen_ty_61::RTN_THROW;
-pub const RTN_NAT: _bindgen_ty_61 = _bindgen_ty_61::RTN_NAT;
-pub const RTN_XRESOLVE: _bindgen_ty_61 = _bindgen_ty_61::RTN_XRESOLVE;
-pub const __RTN_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTN_MAX;
-pub const RTAX_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTAX_UNSPEC;
-pub const RTAX_LOCK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_LOCK;
-pub const RTAX_MTU: _bindgen_ty_62 = _bindgen_ty_62::RTAX_MTU;
-pub const RTAX_WINDOW: _bindgen_ty_62 = _bindgen_ty_62::RTAX_WINDOW;
-pub const RTAX_RTT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTT;
-pub const RTAX_RTTVAR: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTTVAR;
-pub const RTAX_SSTHRESH: _bindgen_ty_62 = _bindgen_ty_62::RTAX_SSTHRESH;
-pub const RTAX_CWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CWND;
-pub const RTAX_ADVMSS: _bindgen_ty_62 = _bindgen_ty_62::RTAX_ADVMSS;
-pub const RTAX_REORDERING: _bindgen_ty_62 = _bindgen_ty_62::RTAX_REORDERING;
-pub const RTAX_HOPLIMIT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_HOPLIMIT;
-pub const RTAX_INITCWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITCWND;
-pub const RTAX_FEATURES: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FEATURES;
-pub const RTAX_RTO_MIN: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTO_MIN;
-pub const RTAX_INITRWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITRWND;
-pub const RTAX_QUICKACK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_QUICKACK;
-pub const RTAX_CC_ALGO: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CC_ALGO;
-pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FASTOPEN_NO_COOKIE;
-pub const __RTAX_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTAX_MAX;
-pub const PREFIX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_UNSPEC;
-pub const PREFIX_ADDRESS: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_ADDRESS;
-pub const PREFIX_CACHEINFO: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_CACHEINFO;
-pub const __PREFIX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__PREFIX_MAX;
-pub const TCA_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::TCA_UNSPEC;
-pub const TCA_KIND: _bindgen_ty_64 = _bindgen_ty_64::TCA_KIND;
-pub const TCA_OPTIONS: _bindgen_ty_64 = _bindgen_ty_64::TCA_OPTIONS;
-pub const TCA_STATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS;
-pub const TCA_XSTATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_XSTATS;
-pub const TCA_RATE: _bindgen_ty_64 = _bindgen_ty_64::TCA_RATE;
-pub const TCA_FCNT: _bindgen_ty_64 = _bindgen_ty_64::TCA_FCNT;
-pub const TCA_STATS2: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS2;
-pub const TCA_STAB: _bindgen_ty_64 = _bindgen_ty_64::TCA_STAB;
-pub const TCA_PAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_PAD;
-pub const TCA_DUMP_INVISIBLE: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_INVISIBLE;
-pub const TCA_CHAIN: _bindgen_ty_64 = _bindgen_ty_64::TCA_CHAIN;
-pub const TCA_HW_OFFLOAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_HW_OFFLOAD;
-pub const TCA_INGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_INGRESS_BLOCK;
-pub const TCA_EGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_EGRESS_BLOCK;
-pub const TCA_DUMP_FLAGS: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_FLAGS;
-pub const TCA_EXT_WARN_MSG: _bindgen_ty_64 = _bindgen_ty_64::TCA_EXT_WARN_MSG;
-pub const __TCA_MAX: _bindgen_ty_64 = _bindgen_ty_64::__TCA_MAX;
-pub const NDUSEROPT_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_UNSPEC;
-pub const NDUSEROPT_SRCADDR: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_SRCADDR;
-pub const __NDUSEROPT_MAX: _bindgen_ty_65 = _bindgen_ty_65::__NDUSEROPT_MAX;
-pub const TCA_ROOT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_UNSPEC;
-pub const TCA_ROOT_TAB: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TAB;
-pub const TCA_ROOT_FLAGS: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_FLAGS;
-pub const TCA_ROOT_COUNT: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_COUNT;
-pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TIME_DELTA;
-pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_EXT_WARN_MSG;
-pub const __TCA_ROOT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__TCA_ROOT_MAX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_18 = _bindgen_ty_18::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_39 = _bindgen_ty_39::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_45 = _bindgen_ty_45::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_DSA_MAX;
+pub const IFA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFA_UNSPEC;
+pub const IFA_ADDRESS: _bindgen_ty_55 = _bindgen_ty_55::IFA_ADDRESS;
+pub const IFA_LOCAL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LOCAL;
+pub const IFA_LABEL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LABEL;
+pub const IFA_BROADCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_BROADCAST;
+pub const IFA_ANYCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_ANYCAST;
+pub const IFA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::IFA_CACHEINFO;
+pub const IFA_MULTICAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_MULTICAST;
+pub const IFA_FLAGS: _bindgen_ty_55 = _bindgen_ty_55::IFA_FLAGS;
+pub const IFA_RT_PRIORITY: _bindgen_ty_55 = _bindgen_ty_55::IFA_RT_PRIORITY;
+pub const IFA_TARGET_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::IFA_TARGET_NETNSID;
+pub const IFA_PROTO: _bindgen_ty_55 = _bindgen_ty_55::IFA_PROTO;
+pub const __IFA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFA_MAX;
+pub const NDA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDA_UNSPEC;
+pub const NDA_DST: _bindgen_ty_56 = _bindgen_ty_56::NDA_DST;
+pub const NDA_LLADDR: _bindgen_ty_56 = _bindgen_ty_56::NDA_LLADDR;
+pub const NDA_CACHEINFO: _bindgen_ty_56 = _bindgen_ty_56::NDA_CACHEINFO;
+pub const NDA_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROBES;
+pub const NDA_VLAN: _bindgen_ty_56 = _bindgen_ty_56::NDA_VLAN;
+pub const NDA_PORT: _bindgen_ty_56 = _bindgen_ty_56::NDA_PORT;
+pub const NDA_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_VNI;
+pub const NDA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDA_IFINDEX;
+pub const NDA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::NDA_MASTER;
+pub const NDA_LINK_NETNSID: _bindgen_ty_56 = _bindgen_ty_56::NDA_LINK_NETNSID;
+pub const NDA_SRC_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_SRC_VNI;
+pub const NDA_PROTOCOL: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROTOCOL;
+pub const NDA_NH_ID: _bindgen_ty_56 = _bindgen_ty_56::NDA_NH_ID;
+pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_56 = _bindgen_ty_56::NDA_FDB_EXT_ATTRS;
+pub const NDA_FLAGS_EXT: _bindgen_ty_56 = _bindgen_ty_56::NDA_FLAGS_EXT;
+pub const NDA_NDM_STATE_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_STATE_MASK;
+pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_FLAGS_MASK;
+pub const __NDA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDA_MAX;
+pub const NDTPA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UNSPEC;
+pub const NDTPA_IFINDEX: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_IFINDEX;
+pub const NDTPA_REFCNT: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REFCNT;
+pub const NDTPA_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REACHABLE_TIME;
+pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_BASE_REACHABLE_TIME;
+pub const NDTPA_RETRANS_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_RETRANS_TIME;
+pub const NDTPA_GC_STALETIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_GC_STALETIME;
+pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_DELAY_PROBE_TIME;
+pub const NDTPA_QUEUE_LEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LEN;
+pub const NDTPA_APP_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_APP_PROBES;
+pub const NDTPA_UCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UCAST_PROBES;
+pub const NDTPA_MCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_PROBES;
+pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_ANYCAST_DELAY;
+pub const NDTPA_PROXY_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_DELAY;
+pub const NDTPA_PROXY_QLEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_QLEN;
+pub const NDTPA_LOCKTIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_LOCKTIME;
+pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LENBYTES;
+pub const NDTPA_MCAST_REPROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_REPROBES;
+pub const NDTPA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PAD;
+pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_INTERVAL_PROBE_TIME_MS;
+pub const __NDTPA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTPA_MAX;
+pub const NDTA_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDTA_UNSPEC;
+pub const NDTA_NAME: _bindgen_ty_58 = _bindgen_ty_58::NDTA_NAME;
+pub const NDTA_THRESH1: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH1;
+pub const NDTA_THRESH2: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH2;
+pub const NDTA_THRESH3: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH3;
+pub const NDTA_CONFIG: _bindgen_ty_58 = _bindgen_ty_58::NDTA_CONFIG;
+pub const NDTA_PARMS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PARMS;
+pub const NDTA_STATS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_STATS;
+pub const NDTA_GC_INTERVAL: _bindgen_ty_58 = _bindgen_ty_58::NDTA_GC_INTERVAL;
+pub const NDTA_PAD: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PAD;
+pub const __NDTA_MAX: _bindgen_ty_58 = _bindgen_ty_58::__NDTA_MAX;
+pub const FDB_NOTIFY_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_BIT;
+pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_INACTIVE_BIT;
+pub const NFEA_UNSPEC: _bindgen_ty_60 = _bindgen_ty_60::NFEA_UNSPEC;
+pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_60 = _bindgen_ty_60::NFEA_ACTIVITY_NOTIFY;
+pub const NFEA_DONT_REFRESH: _bindgen_ty_60 = _bindgen_ty_60::NFEA_DONT_REFRESH;
+pub const __NFEA_MAX: _bindgen_ty_60 = _bindgen_ty_60::__NFEA_MAX;
+pub const RTM_BASE: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_NEWLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_DELLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINK;
+pub const RTM_GETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINK;
+pub const RTM_SETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETLINK;
+pub const RTM_NEWADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDR;
+pub const RTM_DELADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDR;
+pub const RTM_GETADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDR;
+pub const RTM_NEWROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWROUTE;
+pub const RTM_DELROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELROUTE;
+pub const RTM_GETROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETROUTE;
+pub const RTM_NEWNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGH;
+pub const RTM_DELNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEIGH;
+pub const RTM_GETNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGH;
+pub const RTM_NEWRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWRULE;
+pub const RTM_DELRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELRULE;
+pub const RTM_GETRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETRULE;
+pub const RTM_NEWQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWQDISC;
+pub const RTM_DELQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELQDISC;
+pub const RTM_GETQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETQDISC;
+pub const RTM_NEWTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTCLASS;
+pub const RTM_DELTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTCLASS;
+pub const RTM_GETTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTCLASS;
+pub const RTM_NEWTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTFILTER;
+pub const RTM_DELTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTFILTER;
+pub const RTM_GETTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTFILTER;
+pub const RTM_NEWACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWACTION;
+pub const RTM_DELACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELACTION;
+pub const RTM_GETACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETACTION;
+pub const RTM_NEWPREFIX: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWPREFIX;
+pub const RTM_GETMULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMULTICAST;
+pub const RTM_GETANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETANYCAST;
+pub const RTM_NEWNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGHTBL;
+pub const RTM_GETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGHTBL;
+pub const RTM_SETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETNEIGHTBL;
+pub const RTM_NEWNDUSEROPT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNDUSEROPT;
+pub const RTM_NEWADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDRLABEL;
+pub const RTM_DELADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDRLABEL;
+pub const RTM_GETADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDRLABEL;
+pub const RTM_GETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETDCB;
+pub const RTM_SETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETDCB;
+pub const RTM_NEWNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNETCONF;
+pub const RTM_DELNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNETCONF;
+pub const RTM_GETNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNETCONF;
+pub const RTM_NEWMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWMDB;
+pub const RTM_DELMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELMDB;
+pub const RTM_GETMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMDB;
+pub const RTM_NEWNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNSID;
+pub const RTM_DELNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNSID;
+pub const RTM_GETNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNSID;
+pub const RTM_NEWSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWSTATS;
+pub const RTM_GETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETSTATS;
+pub const RTM_SETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETSTATS;
+pub const RTM_NEWCACHEREPORT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCACHEREPORT;
+pub const RTM_NEWCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCHAIN;
+pub const RTM_DELCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELCHAIN;
+pub const RTM_GETCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETCHAIN;
+pub const RTM_NEWNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOP;
+pub const RTM_DELNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOP;
+pub const RTM_GETNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOP;
+pub const RTM_NEWLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWLINKPROP;
+pub const RTM_DELLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINKPROP;
+pub const RTM_GETLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINKPROP;
+pub const RTM_NEWVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWVLAN;
+pub const RTM_DELVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELVLAN;
+pub const RTM_GETVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETVLAN;
+pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOPBUCKET;
+pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOPBUCKET;
+pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOPBUCKET;
+pub const RTM_NEWTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTUNNEL;
+pub const RTM_DELTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTUNNEL;
+pub const RTM_GETTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTUNNEL;
+pub const __RTM_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTM_MAX;
+pub const RTN_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNSPEC;
+pub const RTN_UNICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNICAST;
+pub const RTN_LOCAL: _bindgen_ty_62 = _bindgen_ty_62::RTN_LOCAL;
+pub const RTN_BROADCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_BROADCAST;
+pub const RTN_ANYCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_ANYCAST;
+pub const RTN_MULTICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_MULTICAST;
+pub const RTN_BLACKHOLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_BLACKHOLE;
+pub const RTN_UNREACHABLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNREACHABLE;
+pub const RTN_PROHIBIT: _bindgen_ty_62 = _bindgen_ty_62::RTN_PROHIBIT;
+pub const RTN_THROW: _bindgen_ty_62 = _bindgen_ty_62::RTN_THROW;
+pub const RTN_NAT: _bindgen_ty_62 = _bindgen_ty_62::RTN_NAT;
+pub const RTN_XRESOLVE: _bindgen_ty_62 = _bindgen_ty_62::RTN_XRESOLVE;
+pub const __RTN_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTN_MAX;
+pub const RTAX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::RTAX_UNSPEC;
+pub const RTAX_LOCK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_LOCK;
+pub const RTAX_MTU: _bindgen_ty_63 = _bindgen_ty_63::RTAX_MTU;
+pub const RTAX_WINDOW: _bindgen_ty_63 = _bindgen_ty_63::RTAX_WINDOW;
+pub const RTAX_RTT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTT;
+pub const RTAX_RTTVAR: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTTVAR;
+pub const RTAX_SSTHRESH: _bindgen_ty_63 = _bindgen_ty_63::RTAX_SSTHRESH;
+pub const RTAX_CWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CWND;
+pub const RTAX_ADVMSS: _bindgen_ty_63 = _bindgen_ty_63::RTAX_ADVMSS;
+pub const RTAX_REORDERING: _bindgen_ty_63 = _bindgen_ty_63::RTAX_REORDERING;
+pub const RTAX_HOPLIMIT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_HOPLIMIT;
+pub const RTAX_INITCWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITCWND;
+pub const RTAX_FEATURES: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FEATURES;
+pub const RTAX_RTO_MIN: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTO_MIN;
+pub const RTAX_INITRWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITRWND;
+pub const RTAX_QUICKACK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_QUICKACK;
+pub const RTAX_CC_ALGO: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CC_ALGO;
+pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FASTOPEN_NO_COOKIE;
+pub const __RTAX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__RTAX_MAX;
+pub const PREFIX_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_UNSPEC;
+pub const PREFIX_ADDRESS: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_ADDRESS;
+pub const PREFIX_CACHEINFO: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_CACHEINFO;
+pub const __PREFIX_MAX: _bindgen_ty_64 = _bindgen_ty_64::__PREFIX_MAX;
+pub const TCA_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::TCA_UNSPEC;
+pub const TCA_KIND: _bindgen_ty_65 = _bindgen_ty_65::TCA_KIND;
+pub const TCA_OPTIONS: _bindgen_ty_65 = _bindgen_ty_65::TCA_OPTIONS;
+pub const TCA_STATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS;
+pub const TCA_XSTATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_XSTATS;
+pub const TCA_RATE: _bindgen_ty_65 = _bindgen_ty_65::TCA_RATE;
+pub const TCA_FCNT: _bindgen_ty_65 = _bindgen_ty_65::TCA_FCNT;
+pub const TCA_STATS2: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS2;
+pub const TCA_STAB: _bindgen_ty_65 = _bindgen_ty_65::TCA_STAB;
+pub const TCA_PAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_PAD;
+pub const TCA_DUMP_INVISIBLE: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_INVISIBLE;
+pub const TCA_CHAIN: _bindgen_ty_65 = _bindgen_ty_65::TCA_CHAIN;
+pub const TCA_HW_OFFLOAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_HW_OFFLOAD;
+pub const TCA_INGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_INGRESS_BLOCK;
+pub const TCA_EGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_EGRESS_BLOCK;
+pub const TCA_DUMP_FLAGS: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_FLAGS;
+pub const TCA_EXT_WARN_MSG: _bindgen_ty_65 = _bindgen_ty_65::TCA_EXT_WARN_MSG;
+pub const __TCA_MAX: _bindgen_ty_65 = _bindgen_ty_65::__TCA_MAX;
+pub const NDUSEROPT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_UNSPEC;
+pub const NDUSEROPT_SRCADDR: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_SRCADDR;
+pub const __NDUSEROPT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__NDUSEROPT_MAX;
+pub const TCA_ROOT_UNSPEC: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_UNSPEC;
+pub const TCA_ROOT_TAB: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TAB;
+pub const TCA_ROOT_FLAGS: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_FLAGS;
+pub const TCA_ROOT_COUNT: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_COUNT;
+pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TIME_DELTA;
+pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_EXT_WARN_MSG;
+pub const __TCA_ROOT_MAX: _bindgen_ty_67 = _bindgen_ty_67::__TCA_ROOT_MAX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1552,6 +1566,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1641,7 +1657,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1737,7 +1754,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1794,7 +1813,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1947,10 +1967,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_18 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_19 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -1966,7 +2014,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_19 {
+pub enum _bindgen_ty_20 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -1978,7 +2026,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_20 {
+pub enum _bindgen_ty_21 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -1986,7 +2034,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2019,7 +2067,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2033,7 +2082,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_23 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2063,7 +2120,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2074,7 +2131,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum _bindgen_ty_25 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2089,7 +2146,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2102,7 +2159,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2140,7 +2197,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2152,7 +2209,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2168,7 +2225,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2176,7 +2233,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2196,7 +2253,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2204,7 +2261,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2213,7 +2270,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2228,7 +2285,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2236,7 +2293,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2250,7 +2307,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2259,7 +2316,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2277,7 +2334,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2287,14 +2344,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2302,7 +2359,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2316,7 +2373,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2328,7 +2385,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2337,7 +2394,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2346,7 +2403,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2356,7 +2413,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2365,7 +2422,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2375,7 +2432,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2390,7 +2447,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2402,7 +2459,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2418,7 +2475,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2427,7 +2484,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2435,15 +2492,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFA_UNSPEC = 0,
 IFA_ADDRESS = 1,
 IFA_LOCAL = 2,
@@ -2461,7 +2518,7 @@ __IFA_MAX = 12,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 NDA_UNSPEC = 0,
 NDA_DST = 1,
 NDA_LLADDR = 2,
@@ -2485,7 +2542,7 @@ __NDA_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 NDTPA_UNSPEC = 0,
 NDTPA_IFINDEX = 1,
 NDTPA_REFCNT = 2,
@@ -2511,7 +2568,7 @@ __NDTPA_MAX = 20,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_57 {
+pub enum _bindgen_ty_58 {
 NDTA_UNSPEC = 0,
 NDTA_NAME = 1,
 NDTA_THRESH1 = 2,
@@ -2527,14 +2584,14 @@ __NDTA_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_58 {
+pub enum _bindgen_ty_59 {
 FDB_NOTIFY_BIT = 1,
 FDB_NOTIFY_INACTIVE_BIT = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_59 {
+pub enum _bindgen_ty_60 {
 NFEA_UNSPEC = 0,
 NFEA_ACTIVITY_NOTIFY = 1,
 NFEA_DONT_REFRESH = 2,
@@ -2543,7 +2600,7 @@ __NFEA_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_60 {
+pub enum _bindgen_ty_61 {
 RTM_BASE = 16,
 RTM_DELLINK = 17,
 RTM_GETLINK = 18,
@@ -2620,7 +2677,7 @@ __RTM_MAX = 123,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_61 {
+pub enum _bindgen_ty_62 {
 RTN_UNSPEC = 0,
 RTN_UNICAST = 1,
 RTN_LOCAL = 2,
@@ -2696,7 +2753,7 @@ __RTA_MAX = 31,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_62 {
+pub enum _bindgen_ty_63 {
 RTAX_UNSPEC = 0,
 RTAX_LOCK = 1,
 RTAX_MTU = 2,
@@ -2720,7 +2777,7 @@ __RTAX_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_63 {
+pub enum _bindgen_ty_64 {
 PREFIX_UNSPEC = 0,
 PREFIX_ADDRESS = 1,
 PREFIX_CACHEINFO = 2,
@@ -2729,7 +2786,7 @@ __PREFIX_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_64 {
+pub enum _bindgen_ty_65 {
 TCA_UNSPEC = 0,
 TCA_KIND = 1,
 TCA_OPTIONS = 2,
@@ -2752,7 +2809,7 @@ __TCA_MAX = 17,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_65 {
+pub enum _bindgen_ty_66 {
 NDUSEROPT_UNSPEC = 0,
 NDUSEROPT_SRCADDR = 1,
 __NDUSEROPT_MAX = 2,
@@ -2803,7 +2860,7 @@ __RTNLGRP_MAX = 37,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_66 {
+pub enum _bindgen_ty_67 {
 TCA_ROOT_UNSPEC = 0,
 TCA_ROOT_TAB = 1,
 TCA_ROOT_FLAGS = 2,
@@ -2866,6 +2923,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/mips64r6/prctl.rs
+++ b/src/mips64r6/prctl.rs
@@ -228,6 +228,7 @@ pub const PR_SME_VL_LEN_MASK: u32 = 65535;
 pub const PR_SME_VL_INHERIT: u32 = 131072;
 pub const PR_SET_MDWE: u32 = 65;
 pub const PR_MDWE_REFUSE_EXEC_GAIN: u32 = 1;
+pub const PR_MDWE_NO_INHERIT: u32 = 2;
 pub const PR_GET_MDWE: u32 = 66;
 pub const PR_SET_VMA: u32 = 1398164801;
 pub const PR_SET_VMA_ANON_NAME: u32 = 0;

--- a/src/mips64r6/xdp.rs
+++ b/src/mips64r6/xdp.rs
@@ -83,6 +83,7 @@ pub len: __u64,
 pub chunk_size: __u32,
 pub headroom: __u32,
 pub flags: __u32,
+pub tx_metadata_len: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -98,6 +99,23 @@ pub tx_ring_empty_descs: __u64,
 #[derive(Debug, Copy, Clone)]
 pub struct xdp_options {
 pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct xsk_tx_metadata {
+pub flags: __u64,
+pub __bindgen_anon_1: xsk_tx_metadata__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1 {
+pub csum_start: __u16,
+pub csum_offset: __u16,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2 {
+pub tx_timestamp: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -150,7 +168,9 @@ pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
 pub const XDP_USE_NEED_WAKEUP: u32 = 8;
+pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
+pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;
@@ -167,5 +187,13 @@ pub const XDP_UMEM_PGOFF_FILL_RING: u64 = 4294967296;
 pub const XDP_UMEM_PGOFF_COMPLETION_RING: u64 = 6442450944;
 pub const XSK_UNALIGNED_BUF_OFFSET_SHIFT: u32 = 48;
 pub const XSK_UNALIGNED_BUF_ADDR_MASK: u64 = 281474976710655;
-pub const XDP_USE_SG: u32 = 16;
+pub const XDP_TXMD_FLAGS_TIMESTAMP: u32 = 1;
+pub const XDP_TXMD_FLAGS_CHECKSUM: u32 = 2;
 pub const XDP_PKT_CONTD: u32 = 1;
+pub const XDP_TX_METADATA: u32 = 2;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union xsk_tx_metadata__bindgen_ty_1 {
+pub request: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1,
+pub completion: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2,
+}

--- a/src/powerpc/general.rs
+++ b/src/powerpc/general.rs
@@ -188,7 +188,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -243,6 +244,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -301,6 +335,29 @@ pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
 pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -395,36 +452,6 @@ pub it_value: __kernel_old_timeval,
 pub struct __kernel_sock_timeval {
 pub tv_sec: __s64,
 pub tv_usec: __s64,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timespec {
-pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: crate::ctypes::c_long,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timeval {
-pub tv_sec: __kernel_old_time_t,
-pub tv_usec: __kernel_suseconds_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerspec {
-pub it_interval: timespec,
-pub it_value: timespec,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerval {
-pub it_interval: timeval,
-pub it_value: timeval,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timezone {
-pub tz_minuteswest: crate::ctypes::c_int,
-pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -711,6 +738,36 @@ pub c_cc: [crate::ctypes::c_uchar; 10usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct timespec {
+pub tv_sec: __kernel_old_time_t,
+pub tv_nsec: crate::ctypes::c_long,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timeval {
+pub tv_sec: __kernel_old_time_t,
+pub tv_usec: __kernel_suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerspec {
+pub it_interval: timespec,
+pub it_value: timespec,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerval {
+pub it_interval: timeval,
+pub it_value: timeval,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timezone {
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct iovec {
 pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
@@ -804,6 +861,22 @@ pub struct uffdio_continue {
 pub range: uffdio_range,
 pub mode: __u64,
 pub mapped: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_poison {
+pub range: uffdio_range,
+pub mode: __u64,
+pub updated: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_move {
+pub dst: __u64,
+pub src: __u64,
+pub len: __u64,
+pub mode: __u64,
+pub move_: __s64,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -945,9 +1018,9 @@ pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 394496;
+pub const LINUX_VERSION_CODE: u32 = 395264;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 5;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_DCACHEBSIZE: u32 = 19;
 pub const AT_ICACHEBSIZE: u32 = 20;
@@ -1331,6 +1404,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1402,6 +1483,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const FUTEX_WAIT: u32 = 0;
 pub const FUTEX_WAKE: u32 = 1;
 pub const FUTEX_FD: u32 = 2;
@@ -1432,6 +1523,13 @@ pub const FUTEX_WAIT_BITSET_PRIVATE: u32 = 137;
 pub const FUTEX_WAKE_BITSET_PRIVATE: u32 = 138;
 pub const FUTEX_WAIT_REQUEUE_PI_PRIVATE: u32 = 139;
 pub const FUTEX_CMP_REQUEUE_PI_PRIVATE: u32 = 140;
+pub const FUTEX2_SIZE_U8: u32 = 0;
+pub const FUTEX2_SIZE_U16: u32 = 1;
+pub const FUTEX2_SIZE_U32: u32 = 2;
+pub const FUTEX2_SIZE_U64: u32 = 3;
+pub const FUTEX2_NUMA: u32 = 4;
+pub const FUTEX2_PRIVATE: u32 = 128;
+pub const FUTEX2_SIZE_MASK: u32 = 3;
 pub const FUTEX_32: u32 = 2;
 pub const FUTEX_WAITV_MAX: u32 = 128;
 pub const FUTEX_WAITERS: u32 = 2147483648;
@@ -1691,25 +1789,6 @@ pub const LINUX_REBOOT_CMD_POWER_OFF: u32 = 1126301404;
 pub const LINUX_REBOOT_CMD_RESTART2: u32 = 2712847316;
 pub const LINUX_REBOOT_CMD_SW_SUSPEND: u32 = 3489725666;
 pub const LINUX_REBOOT_CMD_KEXEC: u32 = 1163412803;
-pub const ITIMER_REAL: u32 = 0;
-pub const ITIMER_VIRTUAL: u32 = 1;
-pub const ITIMER_PROF: u32 = 2;
-pub const CLOCK_REALTIME: u32 = 0;
-pub const CLOCK_MONOTONIC: u32 = 1;
-pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
-pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
-pub const CLOCK_MONOTONIC_RAW: u32 = 4;
-pub const CLOCK_REALTIME_COARSE: u32 = 5;
-pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
-pub const CLOCK_BOOTTIME: u32 = 7;
-pub const CLOCK_REALTIME_ALARM: u32 = 8;
-pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
-pub const CLOCK_SGI_CYCLE: u32 = 10;
-pub const CLOCK_TAI: u32 = 11;
-pub const MAX_CLOCKS: u32 = 16;
-pub const CLOCKS_MASK: u32 = 1;
-pub const CLOCKS_MONO: u32 = 1;
-pub const TIMER_ABSTIME: u32 = 1;
 pub const RUSAGE_SELF: u32 = 0;
 pub const RUSAGE_CHILDREN: i32 = -1;
 pub const RUSAGE_BOTH: i32 = -2;
@@ -1894,7 +1973,8 @@ pub const SEGV_ADIDERR: u32 = 6;
 pub const SEGV_ADIPERR: u32 = 7;
 pub const SEGV_MTEAERR: u32 = 8;
 pub const SEGV_MTESERR: u32 = 9;
-pub const NSIGSEGV: u32 = 9;
+pub const SEGV_CPERR: u32 = 10;
+pub const NSIGSEGV: u32 = 10;
 pub const BUS_ADRALN: u32 = 1;
 pub const BUS_ADRERR: u32 = 2;
 pub const BUS_OBJERR: u32 = 3;
@@ -1975,6 +2055,7 @@ pub const STATX_BASIC_STATS: u32 = 2047;
 pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
+pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2164,6 +2245,25 @@ pub const _VEOL: u32 = 6;
 pub const _VTIME: u32 = 7;
 pub const _VEOL2: u32 = 8;
 pub const _VSWTC: u32 = 9;
+pub const ITIMER_REAL: u32 = 0;
+pub const ITIMER_VIRTUAL: u32 = 1;
+pub const ITIMER_PROF: u32 = 2;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_SGI_CYCLE: u32 = 10;
+pub const CLOCK_TAI: u32 = 11;
+pub const MAX_CLOCKS: u32 = 16;
+pub const CLOCKS_MASK: u32 = 1;
+pub const CLOCKS_MONO: u32 = 1;
+pub const TIMER_ABSTIME: u32 = 1;
 pub const UIO_FASTIOV: u32 = 8;
 pub const UIO_MAXIOV: u32 = 1024;
 pub const __NR_restart_syscall: u32 = 0;
@@ -2598,6 +2698,16 @@ pub const __NR_process_mrelease: u32 = 448;
 pub const __NR_futex_waitv: u32 = 449;
 pub const __NR_set_mempolicy_home_node: u32 = 450;
 pub const __NR_cachestat: u32 = 451;
+pub const __NR_fchmodat2: u32 = 452;
+pub const __NR_map_shadow_stack: u32 = 453;
+pub const __NR_futex_wake: u32 = 454;
+pub const __NR_futex_wait: u32 = 455;
+pub const __NR_futex_requeue: u32 = 456;
+pub const __NR_statmount: u32 = 457;
+pub const __NR_listmount: u32 = 458;
+pub const __NR_lsm_get_self_attr: u32 = 459;
+pub const __NR_lsm_set_self_attr: u32 = 460;
+pub const __NR_lsm_list_modules: u32 = 461;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
 pub const WSTOPPED: u32 = 2;
@@ -2676,8 +2786,10 @@ pub const _UFFDIO_UNREGISTER: u32 = 1;
 pub const _UFFDIO_WAKE: u32 = 2;
 pub const _UFFDIO_COPY: u32 = 3;
 pub const _UFFDIO_ZEROPAGE: u32 = 4;
+pub const _UFFDIO_MOVE: u32 = 5;
 pub const _UFFDIO_WRITEPROTECT: u32 = 6;
 pub const _UFFDIO_CONTINUE: u32 = 7;
+pub const _UFFDIO_POISON: u32 = 8;
 pub const _UFFDIO_API: u32 = 63;
 pub const UFFDIO: u32 = 170;
 pub const UFFD_EVENT_PAGEFAULT: u32 = 18;
@@ -2702,6 +2814,9 @@ pub const UFFD_FEATURE_MINOR_SHMEM: u32 = 1024;
 pub const UFFD_FEATURE_EXACT_ADDRESS: u32 = 2048;
 pub const UFFD_FEATURE_WP_HUGETLBFS_SHMEM: u32 = 4096;
 pub const UFFD_FEATURE_WP_UNPOPULATED: u32 = 8192;
+pub const UFFD_FEATURE_POISON: u32 = 16384;
+pub const UFFD_FEATURE_WP_ASYNC: u32 = 32768;
+pub const UFFD_FEATURE_MOVE: u32 = 65536;
 pub const UFFD_USER_MODE_ONLY: u32 = 1;
 pub const DT_UNKNOWN: u32 = 0;
 pub const DT_FIFO: u32 = 1;
@@ -2776,6 +2891,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/powerpc/if_arp.rs
+++ b/src/powerpc/if_arp.rs
@@ -50,11 +50,6 @@ pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Copy, Clone)]
 pub struct __vector128 {
@@ -179,6 +174,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -186,23 +182,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -1130,6 +1111,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_4 = _bindgen_ty_4::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_4 = _bindgen_ty_4::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_MASK;
@@ -1198,6 +1180,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_HAIRPIN;
@@ -1245,6 +1229,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_10 = _bindgen_ty_10::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_KIND;
@@ -1306,301 +1291,310 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_19 = _bindgen_ty_19::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_40 = _bindgen_ty_40::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_46 = _bindgen_ty_46::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_DSA_MAX;
-pub const IF_PORT_UNKNOWN: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_UNKNOWN;
-pub const IF_PORT_10BASE2: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASE2;
-pub const IF_PORT_10BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASET;
-pub const IF_PORT_AUI: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_AUI;
-pub const IF_PORT_100BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASET;
-pub const IF_PORT_100BASETX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASETX;
-pub const IF_PORT_100BASEFX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASEFX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_20 = _bindgen_ty_20::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_23 = _bindgen_ty_23::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_47 = _bindgen_ty_47::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__IFLA_DSA_MAX;
+pub const IF_PORT_UNKNOWN: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_UNKNOWN;
+pub const IF_PORT_10BASE2: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASE2;
+pub const IF_PORT_10BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASET;
+pub const IF_PORT_AUI: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_AUI;
+pub const IF_PORT_100BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASET;
+pub const IF_PORT_100BASETX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASETX;
+pub const IF_PORT_100BASEFX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASEFX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1703,6 +1697,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1792,7 +1788,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1888,7 +1885,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1945,7 +1944,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2098,10 +2098,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_20 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_21 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -2117,7 +2145,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -2129,7 +2157,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum _bindgen_ty_23 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -2137,7 +2165,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2170,7 +2198,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2184,7 +2213,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_25 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2214,7 +2251,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2225,7 +2262,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2240,7 +2277,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2253,7 +2290,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2291,7 +2328,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2303,7 +2340,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2319,7 +2356,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2327,7 +2364,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2347,7 +2384,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2355,7 +2392,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2364,7 +2401,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2379,7 +2416,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2387,7 +2424,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2401,7 +2438,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2410,7 +2447,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2428,7 +2465,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2438,14 +2475,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2453,7 +2490,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2467,7 +2504,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2479,7 +2516,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2488,7 +2525,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2497,7 +2534,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2507,7 +2544,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2516,7 +2553,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2526,7 +2563,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2541,7 +2578,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2553,7 +2590,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2569,7 +2606,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2578,7 +2615,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2586,15 +2623,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 IF_PORT_UNKNOWN = 0,
 IF_PORT_10BASE2 = 1,
 IF_PORT_10BASET = 2,
@@ -2677,74 +2714,6 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 impl nlmsgerr_attrs {
 pub const NLMSGERR_ATTR_MAX: nlmsgerr_attrs = nlmsgerr_attrs::NLMSGERR_ATTR_MISS_NEST;
 }
@@ -2759,6 +2728,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/powerpc/if_packet.rs
+++ b/src/powerpc/if_packet.rs
@@ -49,11 +49,6 @@ pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Copy, Clone)]
 pub struct __vector128 {
@@ -67,6 +62,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -74,23 +70,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -331,71 +312,3 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}

--- a/src/powerpc/io_uring.rs
+++ b/src/powerpc/io_uring.rs
@@ -83,7 +83,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -138,6 +139,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -199,6 +233,29 @@ pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
 pub tv_nsec: crate::ctypes::c_longlong,
@@ -257,6 +314,12 @@ pub __pad1: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_sqe__bindgen_ty_2__bindgen_ty_1 {
+pub level: __u32,
+pub optname: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_sqe__bindgen_ty_5__bindgen_ty_1 {
 pub addr_len: __u16,
 pub __pad3: [__u16; 1usize],
@@ -264,6 +327,7 @@ pub __pad3: [__u16; 1usize],
 #[repr(C)]
 pub struct io_uring_sqe__bindgen_ty_6 {
 pub __bindgen_anon_1: __BindgenUnionField<io_uring_sqe__bindgen_ty_6__bindgen_ty_1>,
+pub optval: __BindgenUnionField<__u64>,
 pub cmd: __BindgenUnionField<[__u8; 0usize]>,
 pub bindgen_union_field: [u64; 2usize],
 }
@@ -425,6 +489,13 @@ pub resv: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_buf_status {
+pub buf_group: __u32,
+pub head: __u32,
+pub resv: [__u32; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -438,7 +509,9 @@ pub addr: __u64,
 pub fd: __s32,
 pub flags: __u32,
 pub timeout: __kernel_timespec,
-pub pad: [__u64; 4usize],
+pub opcode: __u8,
+pub pad: [__u8; 7usize],
+pub pad2: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -601,6 +674,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -672,6 +753,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const IORING_FILE_INDEX_ALLOC: i32 = -1;
 pub const IORING_SETUP_IOPOLL: u32 = 1;
 pub const IORING_SETUP_SQPOLL: u32 = 2;
@@ -689,8 +780,9 @@ pub const IORING_SETUP_SINGLE_ISSUER: u32 = 4096;
 pub const IORING_SETUP_DEFER_TASKRUN: u32 = 8192;
 pub const IORING_SETUP_NO_MMAP: u32 = 16384;
 pub const IORING_SETUP_REGISTERED_FD_ONLY: u32 = 32768;
+pub const IORING_SETUP_NO_SQARRAY: u32 = 65536;
 pub const IORING_URING_CMD_FIXED: u32 = 1;
-pub const IORING_URING_CMD_POLLED: u32 = 2147483648;
+pub const IORING_URING_CMD_MASK: u32 = 1;
 pub const IORING_FSYNC_DATASYNC: u32 = 1;
 pub const IORING_TIMEOUT_ABS: u32 = 1;
 pub const IORING_TIMEOUT_UPDATE: u32 = 2;
@@ -710,6 +802,8 @@ pub const IORING_ASYNC_CANCEL_ALL: u32 = 1;
 pub const IORING_ASYNC_CANCEL_FD: u32 = 2;
 pub const IORING_ASYNC_CANCEL_ANY: u32 = 4;
 pub const IORING_ASYNC_CANCEL_FD_FIXED: u32 = 8;
+pub const IORING_ASYNC_CANCEL_USERDATA: u32 = 16;
+pub const IORING_ASYNC_CANCEL_OP: u32 = 32;
 pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
@@ -718,6 +812,7 @@ pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
+pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
@@ -790,6 +885,7 @@ pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGIS
 pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
 pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
 pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
+pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
 pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
 pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
 pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
@@ -800,6 +896,10 @@ pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTR
 pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
 pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
 pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
+pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
+pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
+pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
+pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -812,6 +912,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -878,7 +979,13 @@ IORING_OP_SOCKET = 45,
 IORING_OP_URING_CMD = 46,
 IORING_OP_SEND_ZC = 47,
 IORING_OP_SENDMSG_ZC = 48,
-IORING_OP_LAST = 49,
+IORING_OP_READ_MULTISHOT = 49,
+IORING_OP_WAITID = 50,
+IORING_OP_FUTEX_WAIT = 51,
+IORING_OP_FUTEX_WAKE = 52,
+IORING_OP_FUTEX_WAITV = 53,
+IORING_OP_FIXED_FD_INSTALL = 54,
+IORING_OP_LAST = 55,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -923,7 +1030,8 @@ IORING_REGISTER_PBUF_RING = 22,
 IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
-IORING_REGISTER_LAST = 26,
+IORING_REGISTER_PBUF_STATUS = 26,
+IORING_REGISTER_LAST = 27,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
@@ -948,6 +1056,15 @@ IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
 IORING_RESTRICTION_SQE_FLAGS_REQUIRED = 3,
 IORING_RESTRICTION_LAST = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_8 {
+SOCKET_URING_OP_SIOCINQ = 0,
+SOCKET_URING_OP_SIOCOUTQ = 1,
+SOCKET_URING_OP_GETSOCKOPT = 2,
+SOCKET_URING_OP_SETSOCKOPT = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -975,6 +1092,7 @@ pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_1__bindgen_ty_1,
 pub union io_uring_sqe__bindgen_ty_2 {
 pub addr: __u64,
 pub splice_off_in: __u64,
+pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_2__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -998,6 +1116,9 @@ pub hardlink_flags: __u32,
 pub xattr_flags: __u32,
 pub msg_ring_flags: __u32,
 pub uring_cmd_flags: __u32,
+pub waitid_flags: __u32,
+pub futex_flags: __u32,
+pub install_fd_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]
@@ -1010,6 +1131,7 @@ pub buf_group: __u16,
 pub union io_uring_sqe__bindgen_ty_5 {
 pub splice_fd_in: __s32,
 pub file_index: __u32,
+pub optlen: __u32,
 pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]

--- a/src/powerpc/net.rs
+++ b/src/powerpc/net.rs
@@ -433,6 +433,9 @@ pub tcpi_rcv_ooopack: __u32,
 pub tcpi_snd_wnd: __u32,
 pub tcpi_rcv_wnd: __u32,
 pub tcpi_rehash: __u32,
+pub tcpi_total_rto: __u16,
+pub tcpi_total_rto_recoveries: __u16,
+pub tcpi_total_rto_time: __u32,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -452,6 +455,82 @@ pub tcpm_prefixlen: __u8,
 pub tcpm_keylen: __u16,
 pub tcpm_addr: [__be32; 4usize],
 pub tcpm_key: [__u8; 80usize],
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_add {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub key: [__u8; 80usize],
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_del {
+pub addr: __kernel_sockaddr_storage,
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub current_key: __u8,
+pub rnext: __u8,
+pub keyflags: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_info_opt {
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub current_key: __u8,
+pub rnext: __u8,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+pub pkt_key_not_found: __u64,
+pub pkt_ao_required: __u64,
+pub pkt_dropped_icmp: __u64,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_getsockopt {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub key: [__u8; 80usize],
+pub nkeys: __u32,
+pub _bitfield_align_1: [u16; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub prefix: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub ifindex: __s32,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_repair {
+pub snt_isn: __be32,
+pub rcv_isn: __be32,
+pub snd_sne: __u32,
+pub rcv_sne: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1181,6 +1260,11 @@ pub const TCP_ZEROCOPY_RECEIVE: u32 = 35;
 pub const TCP_INQ: u32 = 36;
 pub const TCP_CM_INQ: u32 = 36;
 pub const TCP_TX_DELAY: u32 = 37;
+pub const TCP_AO_ADD_KEY: u32 = 38;
+pub const TCP_AO_DEL_KEY: u32 = 39;
+pub const TCP_AO_INFO: u32 = 40;
+pub const TCP_AO_GET_KEYS: u32 = 41;
+pub const TCP_AO_REPAIR: u32 = 42;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1190,9 +1274,13 @@ pub const TCPI_OPT_WSCALE: u32 = 4;
 pub const TCPI_OPT_ECN: u32 = 8;
 pub const TCPI_OPT_ECN_SEEN: u32 = 16;
 pub const TCPI_OPT_SYN_DATA: u32 = 32;
+pub const TCPI_OPT_USEC_TS: u32 = 64;
 pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
+pub const TCP_AO_MAXKEYLEN: u32 = 80;
+pub const TCP_AO_KEYF_IFINDEX: u32 = 1;
+pub const TCP_AO_KEYF_EXCLUDE_OPT: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
@@ -1557,6 +1645,7 @@ pub const DEVCONF_IOAM6_ID: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID;
 pub const DEVCONF_IOAM6_ID_WIDE: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID_WIDE;
 pub const DEVCONF_NDISC_EVICT_NOCARRIER: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_NDISC_EVICT_NOCARRIER;
 pub const DEVCONF_ACCEPT_UNTRACKED_NA: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_UNTRACKED_NA;
+pub const DEVCONF_ACCEPT_RA_MIN_LFT: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_RA_MIN_LFT;
 pub const DEVCONF_MAX: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_MAX;
 pub const TCP_FLAG_CWR: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_CWR;
 pub const TCP_FLAG_ECE: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_ECE;
@@ -1754,7 +1843,8 @@ DEVCONF_IOAM6_ID = 54,
 DEVCONF_IOAM6_ID_WIDE = 55,
 DEVCONF_NDISC_EVICT_NOCARRIER = 56,
 DEVCONF_ACCEPT_UNTRACKED_NA = 57,
-DEVCONF_MAX = 58,
+DEVCONF_ACCEPT_RA_MIN_LFT = 58,
+DEVCONF_MAX = 59,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2472,6 +2562,289 @@ tcpi_delivery_rate_app_limited as u64
 __bindgen_bitfield_unit.set(9usize, 2u8, {
 let tcpi_fastopen_client_fail: u8 = unsafe { ::core::mem::transmute(tcpi_fastopen_client_fail) };
 tcpi_fastopen_client_fail as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_add {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 30u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 30u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_del {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn del_async(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_del_async(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 29u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 29u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, del_async: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let del_async: u32 = unsafe { ::core::mem::transmute(del_async) };
+del_async as u64
+});
+__bindgen_bitfield_unit.set(3usize, 29u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_info_opt {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn ao_required(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_ao_required(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_counters(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_counters(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn accept_icmps(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_accept_icmps(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(4usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(5usize, 27u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(5usize, 27u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, ao_required: __u32, set_counters: __u32, accept_icmps: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let ao_required: u32 = unsafe { ::core::mem::transmute(ao_required) };
+ao_required as u64
+});
+__bindgen_bitfield_unit.set(3usize, 1u8, {
+let set_counters: u32 = unsafe { ::core::mem::transmute(set_counters) };
+set_counters as u64
+});
+__bindgen_bitfield_unit.set(4usize, 1u8, {
+let accept_icmps: u32 = unsafe { ::core::mem::transmute(accept_icmps) };
+accept_icmps as u64
+});
+__bindgen_bitfield_unit.set(5usize, 27u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_getsockopt {
+#[inline]
+pub fn is_current(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_current(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn is_rnext(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_rnext(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn get_all(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_get_all(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 13u8) as u16) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 13u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(is_current: __u16, is_rnext: __u16, get_all: __u16, reserved: __u16) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let is_current: u16 = unsafe { ::core::mem::transmute(is_current) };
+is_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let is_rnext: u16 = unsafe { ::core::mem::transmute(is_rnext) };
+is_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let get_all: u16 = unsafe { ::core::mem::transmute(get_all) };
+get_all as u64
+});
+__bindgen_bitfield_unit.set(3usize, 13u8, {
+let reserved: u16 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
 });
 __bindgen_bitfield_unit
 }

--- a/src/powerpc/netlink.rs
+++ b/src/powerpc/netlink.rs
@@ -728,7 +728,8 @@ pub const RTAX_FEATURE_ECN: u32 = 1;
 pub const RTAX_FEATURE_SACK: u32 = 2;
 pub const RTAX_FEATURE_TIMESTAMP: u32 = 4;
 pub const RTAX_FEATURE_ALLFRAG: u32 = 8;
-pub const RTAX_FEATURE_MASK: u32 = 15;
+pub const RTAX_FEATURE_TCP_USEC_TS: u32 = 16;
+pub const RTAX_FEATURE_MASK: u32 = 31;
 pub const TCM_IFINDEX_MAGIC_BLOCK: u32 = 4294967295;
 pub const TCA_DUMP_FLAGS_TERSE: u32 = 1;
 pub const RTMGRP_LINK: u32 = 1;
@@ -825,6 +826,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_2 = _bindgen_ty_2::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_2 = _bindgen_ty_2::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_MASK;
@@ -893,6 +895,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_6 = _bindgen_ty_6::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_HAIRPIN;
@@ -940,6 +944,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_KIND;
@@ -1001,501 +1006,510 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_17 = _bindgen_ty_17::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_18 = _bindgen_ty_18::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_21 = _bindgen_ty_21::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_44 = _bindgen_ty_44::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_DSA_MAX;
-pub const IFA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFA_UNSPEC;
-pub const IFA_ADDRESS: _bindgen_ty_54 = _bindgen_ty_54::IFA_ADDRESS;
-pub const IFA_LOCAL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LOCAL;
-pub const IFA_LABEL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LABEL;
-pub const IFA_BROADCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_BROADCAST;
-pub const IFA_ANYCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_ANYCAST;
-pub const IFA_CACHEINFO: _bindgen_ty_54 = _bindgen_ty_54::IFA_CACHEINFO;
-pub const IFA_MULTICAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_MULTICAST;
-pub const IFA_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFA_FLAGS;
-pub const IFA_RT_PRIORITY: _bindgen_ty_54 = _bindgen_ty_54::IFA_RT_PRIORITY;
-pub const IFA_TARGET_NETNSID: _bindgen_ty_54 = _bindgen_ty_54::IFA_TARGET_NETNSID;
-pub const IFA_PROTO: _bindgen_ty_54 = _bindgen_ty_54::IFA_PROTO;
-pub const __IFA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFA_MAX;
-pub const NDA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::NDA_UNSPEC;
-pub const NDA_DST: _bindgen_ty_55 = _bindgen_ty_55::NDA_DST;
-pub const NDA_LLADDR: _bindgen_ty_55 = _bindgen_ty_55::NDA_LLADDR;
-pub const NDA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::NDA_CACHEINFO;
-pub const NDA_PROBES: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROBES;
-pub const NDA_VLAN: _bindgen_ty_55 = _bindgen_ty_55::NDA_VLAN;
-pub const NDA_PORT: _bindgen_ty_55 = _bindgen_ty_55::NDA_PORT;
-pub const NDA_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_VNI;
-pub const NDA_IFINDEX: _bindgen_ty_55 = _bindgen_ty_55::NDA_IFINDEX;
-pub const NDA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::NDA_MASTER;
-pub const NDA_LINK_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::NDA_LINK_NETNSID;
-pub const NDA_SRC_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_SRC_VNI;
-pub const NDA_PROTOCOL: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROTOCOL;
-pub const NDA_NH_ID: _bindgen_ty_55 = _bindgen_ty_55::NDA_NH_ID;
-pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_55 = _bindgen_ty_55::NDA_FDB_EXT_ATTRS;
-pub const NDA_FLAGS_EXT: _bindgen_ty_55 = _bindgen_ty_55::NDA_FLAGS_EXT;
-pub const NDA_NDM_STATE_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_STATE_MASK;
-pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_FLAGS_MASK;
-pub const __NDA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__NDA_MAX;
-pub const NDTPA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UNSPEC;
-pub const NDTPA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_IFINDEX;
-pub const NDTPA_REFCNT: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REFCNT;
-pub const NDTPA_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REACHABLE_TIME;
-pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_BASE_REACHABLE_TIME;
-pub const NDTPA_RETRANS_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_RETRANS_TIME;
-pub const NDTPA_GC_STALETIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_GC_STALETIME;
-pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_DELAY_PROBE_TIME;
-pub const NDTPA_QUEUE_LEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LEN;
-pub const NDTPA_APP_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_APP_PROBES;
-pub const NDTPA_UCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UCAST_PROBES;
-pub const NDTPA_MCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_PROBES;
-pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_ANYCAST_DELAY;
-pub const NDTPA_PROXY_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_DELAY;
-pub const NDTPA_PROXY_QLEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_QLEN;
-pub const NDTPA_LOCKTIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_LOCKTIME;
-pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LENBYTES;
-pub const NDTPA_MCAST_REPROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_REPROBES;
-pub const NDTPA_PAD: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PAD;
-pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_INTERVAL_PROBE_TIME_MS;
-pub const __NDTPA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDTPA_MAX;
-pub const NDTA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTA_UNSPEC;
-pub const NDTA_NAME: _bindgen_ty_57 = _bindgen_ty_57::NDTA_NAME;
-pub const NDTA_THRESH1: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH1;
-pub const NDTA_THRESH2: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH2;
-pub const NDTA_THRESH3: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH3;
-pub const NDTA_CONFIG: _bindgen_ty_57 = _bindgen_ty_57::NDTA_CONFIG;
-pub const NDTA_PARMS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PARMS;
-pub const NDTA_STATS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_STATS;
-pub const NDTA_GC_INTERVAL: _bindgen_ty_57 = _bindgen_ty_57::NDTA_GC_INTERVAL;
-pub const NDTA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PAD;
-pub const __NDTA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTA_MAX;
-pub const FDB_NOTIFY_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_BIT;
-pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_INACTIVE_BIT;
-pub const NFEA_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::NFEA_UNSPEC;
-pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_59 = _bindgen_ty_59::NFEA_ACTIVITY_NOTIFY;
-pub const NFEA_DONT_REFRESH: _bindgen_ty_59 = _bindgen_ty_59::NFEA_DONT_REFRESH;
-pub const __NFEA_MAX: _bindgen_ty_59 = _bindgen_ty_59::__NFEA_MAX;
-pub const RTM_BASE: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_NEWLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_DELLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINK;
-pub const RTM_GETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINK;
-pub const RTM_SETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETLINK;
-pub const RTM_NEWADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDR;
-pub const RTM_DELADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDR;
-pub const RTM_GETADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDR;
-pub const RTM_NEWROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWROUTE;
-pub const RTM_DELROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELROUTE;
-pub const RTM_GETROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETROUTE;
-pub const RTM_NEWNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGH;
-pub const RTM_DELNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEIGH;
-pub const RTM_GETNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGH;
-pub const RTM_NEWRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWRULE;
-pub const RTM_DELRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELRULE;
-pub const RTM_GETRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETRULE;
-pub const RTM_NEWQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWQDISC;
-pub const RTM_DELQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELQDISC;
-pub const RTM_GETQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETQDISC;
-pub const RTM_NEWTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTCLASS;
-pub const RTM_DELTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTCLASS;
-pub const RTM_GETTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTCLASS;
-pub const RTM_NEWTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTFILTER;
-pub const RTM_DELTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTFILTER;
-pub const RTM_GETTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTFILTER;
-pub const RTM_NEWACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWACTION;
-pub const RTM_DELACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELACTION;
-pub const RTM_GETACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETACTION;
-pub const RTM_NEWPREFIX: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWPREFIX;
-pub const RTM_GETMULTICAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMULTICAST;
-pub const RTM_GETANYCAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETANYCAST;
-pub const RTM_NEWNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGHTBL;
-pub const RTM_GETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGHTBL;
-pub const RTM_SETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETNEIGHTBL;
-pub const RTM_NEWNDUSEROPT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNDUSEROPT;
-pub const RTM_NEWADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDRLABEL;
-pub const RTM_DELADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDRLABEL;
-pub const RTM_GETADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDRLABEL;
-pub const RTM_GETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETDCB;
-pub const RTM_SETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETDCB;
-pub const RTM_NEWNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNETCONF;
-pub const RTM_DELNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNETCONF;
-pub const RTM_GETNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNETCONF;
-pub const RTM_NEWMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWMDB;
-pub const RTM_DELMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELMDB;
-pub const RTM_GETMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMDB;
-pub const RTM_NEWNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNSID;
-pub const RTM_DELNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNSID;
-pub const RTM_GETNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNSID;
-pub const RTM_NEWSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWSTATS;
-pub const RTM_GETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETSTATS;
-pub const RTM_SETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETSTATS;
-pub const RTM_NEWCACHEREPORT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCACHEREPORT;
-pub const RTM_NEWCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCHAIN;
-pub const RTM_DELCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELCHAIN;
-pub const RTM_GETCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETCHAIN;
-pub const RTM_NEWNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOP;
-pub const RTM_DELNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOP;
-pub const RTM_GETNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOP;
-pub const RTM_NEWLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWLINKPROP;
-pub const RTM_DELLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINKPROP;
-pub const RTM_GETLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINKPROP;
-pub const RTM_NEWVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWVLAN;
-pub const RTM_DELVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELVLAN;
-pub const RTM_GETVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETVLAN;
-pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOPBUCKET;
-pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOPBUCKET;
-pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOPBUCKET;
-pub const RTM_NEWTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTUNNEL;
-pub const RTM_DELTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTUNNEL;
-pub const RTM_GETTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTUNNEL;
-pub const __RTM_MAX: _bindgen_ty_60 = _bindgen_ty_60::__RTM_MAX;
-pub const RTN_UNSPEC: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNSPEC;
-pub const RTN_UNICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNICAST;
-pub const RTN_LOCAL: _bindgen_ty_61 = _bindgen_ty_61::RTN_LOCAL;
-pub const RTN_BROADCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_BROADCAST;
-pub const RTN_ANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_ANYCAST;
-pub const RTN_MULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_MULTICAST;
-pub const RTN_BLACKHOLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_BLACKHOLE;
-pub const RTN_UNREACHABLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNREACHABLE;
-pub const RTN_PROHIBIT: _bindgen_ty_61 = _bindgen_ty_61::RTN_PROHIBIT;
-pub const RTN_THROW: _bindgen_ty_61 = _bindgen_ty_61::RTN_THROW;
-pub const RTN_NAT: _bindgen_ty_61 = _bindgen_ty_61::RTN_NAT;
-pub const RTN_XRESOLVE: _bindgen_ty_61 = _bindgen_ty_61::RTN_XRESOLVE;
-pub const __RTN_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTN_MAX;
-pub const RTAX_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTAX_UNSPEC;
-pub const RTAX_LOCK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_LOCK;
-pub const RTAX_MTU: _bindgen_ty_62 = _bindgen_ty_62::RTAX_MTU;
-pub const RTAX_WINDOW: _bindgen_ty_62 = _bindgen_ty_62::RTAX_WINDOW;
-pub const RTAX_RTT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTT;
-pub const RTAX_RTTVAR: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTTVAR;
-pub const RTAX_SSTHRESH: _bindgen_ty_62 = _bindgen_ty_62::RTAX_SSTHRESH;
-pub const RTAX_CWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CWND;
-pub const RTAX_ADVMSS: _bindgen_ty_62 = _bindgen_ty_62::RTAX_ADVMSS;
-pub const RTAX_REORDERING: _bindgen_ty_62 = _bindgen_ty_62::RTAX_REORDERING;
-pub const RTAX_HOPLIMIT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_HOPLIMIT;
-pub const RTAX_INITCWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITCWND;
-pub const RTAX_FEATURES: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FEATURES;
-pub const RTAX_RTO_MIN: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTO_MIN;
-pub const RTAX_INITRWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITRWND;
-pub const RTAX_QUICKACK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_QUICKACK;
-pub const RTAX_CC_ALGO: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CC_ALGO;
-pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FASTOPEN_NO_COOKIE;
-pub const __RTAX_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTAX_MAX;
-pub const PREFIX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_UNSPEC;
-pub const PREFIX_ADDRESS: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_ADDRESS;
-pub const PREFIX_CACHEINFO: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_CACHEINFO;
-pub const __PREFIX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__PREFIX_MAX;
-pub const TCA_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::TCA_UNSPEC;
-pub const TCA_KIND: _bindgen_ty_64 = _bindgen_ty_64::TCA_KIND;
-pub const TCA_OPTIONS: _bindgen_ty_64 = _bindgen_ty_64::TCA_OPTIONS;
-pub const TCA_STATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS;
-pub const TCA_XSTATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_XSTATS;
-pub const TCA_RATE: _bindgen_ty_64 = _bindgen_ty_64::TCA_RATE;
-pub const TCA_FCNT: _bindgen_ty_64 = _bindgen_ty_64::TCA_FCNT;
-pub const TCA_STATS2: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS2;
-pub const TCA_STAB: _bindgen_ty_64 = _bindgen_ty_64::TCA_STAB;
-pub const TCA_PAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_PAD;
-pub const TCA_DUMP_INVISIBLE: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_INVISIBLE;
-pub const TCA_CHAIN: _bindgen_ty_64 = _bindgen_ty_64::TCA_CHAIN;
-pub const TCA_HW_OFFLOAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_HW_OFFLOAD;
-pub const TCA_INGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_INGRESS_BLOCK;
-pub const TCA_EGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_EGRESS_BLOCK;
-pub const TCA_DUMP_FLAGS: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_FLAGS;
-pub const TCA_EXT_WARN_MSG: _bindgen_ty_64 = _bindgen_ty_64::TCA_EXT_WARN_MSG;
-pub const __TCA_MAX: _bindgen_ty_64 = _bindgen_ty_64::__TCA_MAX;
-pub const NDUSEROPT_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_UNSPEC;
-pub const NDUSEROPT_SRCADDR: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_SRCADDR;
-pub const __NDUSEROPT_MAX: _bindgen_ty_65 = _bindgen_ty_65::__NDUSEROPT_MAX;
-pub const TCA_ROOT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_UNSPEC;
-pub const TCA_ROOT_TAB: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TAB;
-pub const TCA_ROOT_FLAGS: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_FLAGS;
-pub const TCA_ROOT_COUNT: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_COUNT;
-pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TIME_DELTA;
-pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_EXT_WARN_MSG;
-pub const __TCA_ROOT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__TCA_ROOT_MAX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_18 = _bindgen_ty_18::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_39 = _bindgen_ty_39::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_45 = _bindgen_ty_45::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_DSA_MAX;
+pub const IFA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFA_UNSPEC;
+pub const IFA_ADDRESS: _bindgen_ty_55 = _bindgen_ty_55::IFA_ADDRESS;
+pub const IFA_LOCAL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LOCAL;
+pub const IFA_LABEL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LABEL;
+pub const IFA_BROADCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_BROADCAST;
+pub const IFA_ANYCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_ANYCAST;
+pub const IFA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::IFA_CACHEINFO;
+pub const IFA_MULTICAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_MULTICAST;
+pub const IFA_FLAGS: _bindgen_ty_55 = _bindgen_ty_55::IFA_FLAGS;
+pub const IFA_RT_PRIORITY: _bindgen_ty_55 = _bindgen_ty_55::IFA_RT_PRIORITY;
+pub const IFA_TARGET_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::IFA_TARGET_NETNSID;
+pub const IFA_PROTO: _bindgen_ty_55 = _bindgen_ty_55::IFA_PROTO;
+pub const __IFA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFA_MAX;
+pub const NDA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDA_UNSPEC;
+pub const NDA_DST: _bindgen_ty_56 = _bindgen_ty_56::NDA_DST;
+pub const NDA_LLADDR: _bindgen_ty_56 = _bindgen_ty_56::NDA_LLADDR;
+pub const NDA_CACHEINFO: _bindgen_ty_56 = _bindgen_ty_56::NDA_CACHEINFO;
+pub const NDA_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROBES;
+pub const NDA_VLAN: _bindgen_ty_56 = _bindgen_ty_56::NDA_VLAN;
+pub const NDA_PORT: _bindgen_ty_56 = _bindgen_ty_56::NDA_PORT;
+pub const NDA_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_VNI;
+pub const NDA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDA_IFINDEX;
+pub const NDA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::NDA_MASTER;
+pub const NDA_LINK_NETNSID: _bindgen_ty_56 = _bindgen_ty_56::NDA_LINK_NETNSID;
+pub const NDA_SRC_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_SRC_VNI;
+pub const NDA_PROTOCOL: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROTOCOL;
+pub const NDA_NH_ID: _bindgen_ty_56 = _bindgen_ty_56::NDA_NH_ID;
+pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_56 = _bindgen_ty_56::NDA_FDB_EXT_ATTRS;
+pub const NDA_FLAGS_EXT: _bindgen_ty_56 = _bindgen_ty_56::NDA_FLAGS_EXT;
+pub const NDA_NDM_STATE_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_STATE_MASK;
+pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_FLAGS_MASK;
+pub const __NDA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDA_MAX;
+pub const NDTPA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UNSPEC;
+pub const NDTPA_IFINDEX: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_IFINDEX;
+pub const NDTPA_REFCNT: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REFCNT;
+pub const NDTPA_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REACHABLE_TIME;
+pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_BASE_REACHABLE_TIME;
+pub const NDTPA_RETRANS_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_RETRANS_TIME;
+pub const NDTPA_GC_STALETIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_GC_STALETIME;
+pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_DELAY_PROBE_TIME;
+pub const NDTPA_QUEUE_LEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LEN;
+pub const NDTPA_APP_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_APP_PROBES;
+pub const NDTPA_UCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UCAST_PROBES;
+pub const NDTPA_MCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_PROBES;
+pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_ANYCAST_DELAY;
+pub const NDTPA_PROXY_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_DELAY;
+pub const NDTPA_PROXY_QLEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_QLEN;
+pub const NDTPA_LOCKTIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_LOCKTIME;
+pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LENBYTES;
+pub const NDTPA_MCAST_REPROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_REPROBES;
+pub const NDTPA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PAD;
+pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_INTERVAL_PROBE_TIME_MS;
+pub const __NDTPA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTPA_MAX;
+pub const NDTA_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDTA_UNSPEC;
+pub const NDTA_NAME: _bindgen_ty_58 = _bindgen_ty_58::NDTA_NAME;
+pub const NDTA_THRESH1: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH1;
+pub const NDTA_THRESH2: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH2;
+pub const NDTA_THRESH3: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH3;
+pub const NDTA_CONFIG: _bindgen_ty_58 = _bindgen_ty_58::NDTA_CONFIG;
+pub const NDTA_PARMS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PARMS;
+pub const NDTA_STATS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_STATS;
+pub const NDTA_GC_INTERVAL: _bindgen_ty_58 = _bindgen_ty_58::NDTA_GC_INTERVAL;
+pub const NDTA_PAD: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PAD;
+pub const __NDTA_MAX: _bindgen_ty_58 = _bindgen_ty_58::__NDTA_MAX;
+pub const FDB_NOTIFY_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_BIT;
+pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_INACTIVE_BIT;
+pub const NFEA_UNSPEC: _bindgen_ty_60 = _bindgen_ty_60::NFEA_UNSPEC;
+pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_60 = _bindgen_ty_60::NFEA_ACTIVITY_NOTIFY;
+pub const NFEA_DONT_REFRESH: _bindgen_ty_60 = _bindgen_ty_60::NFEA_DONT_REFRESH;
+pub const __NFEA_MAX: _bindgen_ty_60 = _bindgen_ty_60::__NFEA_MAX;
+pub const RTM_BASE: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_NEWLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_DELLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINK;
+pub const RTM_GETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINK;
+pub const RTM_SETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETLINK;
+pub const RTM_NEWADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDR;
+pub const RTM_DELADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDR;
+pub const RTM_GETADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDR;
+pub const RTM_NEWROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWROUTE;
+pub const RTM_DELROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELROUTE;
+pub const RTM_GETROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETROUTE;
+pub const RTM_NEWNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGH;
+pub const RTM_DELNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEIGH;
+pub const RTM_GETNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGH;
+pub const RTM_NEWRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWRULE;
+pub const RTM_DELRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELRULE;
+pub const RTM_GETRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETRULE;
+pub const RTM_NEWQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWQDISC;
+pub const RTM_DELQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELQDISC;
+pub const RTM_GETQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETQDISC;
+pub const RTM_NEWTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTCLASS;
+pub const RTM_DELTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTCLASS;
+pub const RTM_GETTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTCLASS;
+pub const RTM_NEWTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTFILTER;
+pub const RTM_DELTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTFILTER;
+pub const RTM_GETTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTFILTER;
+pub const RTM_NEWACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWACTION;
+pub const RTM_DELACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELACTION;
+pub const RTM_GETACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETACTION;
+pub const RTM_NEWPREFIX: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWPREFIX;
+pub const RTM_GETMULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMULTICAST;
+pub const RTM_GETANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETANYCAST;
+pub const RTM_NEWNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGHTBL;
+pub const RTM_GETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGHTBL;
+pub const RTM_SETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETNEIGHTBL;
+pub const RTM_NEWNDUSEROPT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNDUSEROPT;
+pub const RTM_NEWADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDRLABEL;
+pub const RTM_DELADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDRLABEL;
+pub const RTM_GETADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDRLABEL;
+pub const RTM_GETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETDCB;
+pub const RTM_SETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETDCB;
+pub const RTM_NEWNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNETCONF;
+pub const RTM_DELNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNETCONF;
+pub const RTM_GETNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNETCONF;
+pub const RTM_NEWMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWMDB;
+pub const RTM_DELMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELMDB;
+pub const RTM_GETMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMDB;
+pub const RTM_NEWNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNSID;
+pub const RTM_DELNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNSID;
+pub const RTM_GETNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNSID;
+pub const RTM_NEWSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWSTATS;
+pub const RTM_GETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETSTATS;
+pub const RTM_SETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETSTATS;
+pub const RTM_NEWCACHEREPORT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCACHEREPORT;
+pub const RTM_NEWCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCHAIN;
+pub const RTM_DELCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELCHAIN;
+pub const RTM_GETCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETCHAIN;
+pub const RTM_NEWNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOP;
+pub const RTM_DELNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOP;
+pub const RTM_GETNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOP;
+pub const RTM_NEWLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWLINKPROP;
+pub const RTM_DELLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINKPROP;
+pub const RTM_GETLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINKPROP;
+pub const RTM_NEWVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWVLAN;
+pub const RTM_DELVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELVLAN;
+pub const RTM_GETVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETVLAN;
+pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOPBUCKET;
+pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOPBUCKET;
+pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOPBUCKET;
+pub const RTM_NEWTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTUNNEL;
+pub const RTM_DELTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTUNNEL;
+pub const RTM_GETTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTUNNEL;
+pub const __RTM_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTM_MAX;
+pub const RTN_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNSPEC;
+pub const RTN_UNICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNICAST;
+pub const RTN_LOCAL: _bindgen_ty_62 = _bindgen_ty_62::RTN_LOCAL;
+pub const RTN_BROADCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_BROADCAST;
+pub const RTN_ANYCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_ANYCAST;
+pub const RTN_MULTICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_MULTICAST;
+pub const RTN_BLACKHOLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_BLACKHOLE;
+pub const RTN_UNREACHABLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNREACHABLE;
+pub const RTN_PROHIBIT: _bindgen_ty_62 = _bindgen_ty_62::RTN_PROHIBIT;
+pub const RTN_THROW: _bindgen_ty_62 = _bindgen_ty_62::RTN_THROW;
+pub const RTN_NAT: _bindgen_ty_62 = _bindgen_ty_62::RTN_NAT;
+pub const RTN_XRESOLVE: _bindgen_ty_62 = _bindgen_ty_62::RTN_XRESOLVE;
+pub const __RTN_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTN_MAX;
+pub const RTAX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::RTAX_UNSPEC;
+pub const RTAX_LOCK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_LOCK;
+pub const RTAX_MTU: _bindgen_ty_63 = _bindgen_ty_63::RTAX_MTU;
+pub const RTAX_WINDOW: _bindgen_ty_63 = _bindgen_ty_63::RTAX_WINDOW;
+pub const RTAX_RTT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTT;
+pub const RTAX_RTTVAR: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTTVAR;
+pub const RTAX_SSTHRESH: _bindgen_ty_63 = _bindgen_ty_63::RTAX_SSTHRESH;
+pub const RTAX_CWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CWND;
+pub const RTAX_ADVMSS: _bindgen_ty_63 = _bindgen_ty_63::RTAX_ADVMSS;
+pub const RTAX_REORDERING: _bindgen_ty_63 = _bindgen_ty_63::RTAX_REORDERING;
+pub const RTAX_HOPLIMIT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_HOPLIMIT;
+pub const RTAX_INITCWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITCWND;
+pub const RTAX_FEATURES: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FEATURES;
+pub const RTAX_RTO_MIN: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTO_MIN;
+pub const RTAX_INITRWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITRWND;
+pub const RTAX_QUICKACK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_QUICKACK;
+pub const RTAX_CC_ALGO: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CC_ALGO;
+pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FASTOPEN_NO_COOKIE;
+pub const __RTAX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__RTAX_MAX;
+pub const PREFIX_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_UNSPEC;
+pub const PREFIX_ADDRESS: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_ADDRESS;
+pub const PREFIX_CACHEINFO: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_CACHEINFO;
+pub const __PREFIX_MAX: _bindgen_ty_64 = _bindgen_ty_64::__PREFIX_MAX;
+pub const TCA_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::TCA_UNSPEC;
+pub const TCA_KIND: _bindgen_ty_65 = _bindgen_ty_65::TCA_KIND;
+pub const TCA_OPTIONS: _bindgen_ty_65 = _bindgen_ty_65::TCA_OPTIONS;
+pub const TCA_STATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS;
+pub const TCA_XSTATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_XSTATS;
+pub const TCA_RATE: _bindgen_ty_65 = _bindgen_ty_65::TCA_RATE;
+pub const TCA_FCNT: _bindgen_ty_65 = _bindgen_ty_65::TCA_FCNT;
+pub const TCA_STATS2: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS2;
+pub const TCA_STAB: _bindgen_ty_65 = _bindgen_ty_65::TCA_STAB;
+pub const TCA_PAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_PAD;
+pub const TCA_DUMP_INVISIBLE: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_INVISIBLE;
+pub const TCA_CHAIN: _bindgen_ty_65 = _bindgen_ty_65::TCA_CHAIN;
+pub const TCA_HW_OFFLOAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_HW_OFFLOAD;
+pub const TCA_INGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_INGRESS_BLOCK;
+pub const TCA_EGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_EGRESS_BLOCK;
+pub const TCA_DUMP_FLAGS: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_FLAGS;
+pub const TCA_EXT_WARN_MSG: _bindgen_ty_65 = _bindgen_ty_65::TCA_EXT_WARN_MSG;
+pub const __TCA_MAX: _bindgen_ty_65 = _bindgen_ty_65::__TCA_MAX;
+pub const NDUSEROPT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_UNSPEC;
+pub const NDUSEROPT_SRCADDR: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_SRCADDR;
+pub const __NDUSEROPT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__NDUSEROPT_MAX;
+pub const TCA_ROOT_UNSPEC: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_UNSPEC;
+pub const TCA_ROOT_TAB: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TAB;
+pub const TCA_ROOT_FLAGS: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_FLAGS;
+pub const TCA_ROOT_COUNT: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_COUNT;
+pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TIME_DELTA;
+pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_EXT_WARN_MSG;
+pub const __TCA_ROOT_MAX: _bindgen_ty_67 = _bindgen_ty_67::__TCA_ROOT_MAX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1546,6 +1560,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1635,7 +1651,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1731,7 +1748,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1788,7 +1807,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1941,10 +1961,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_18 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_19 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -1960,7 +2008,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_19 {
+pub enum _bindgen_ty_20 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -1972,7 +2020,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_20 {
+pub enum _bindgen_ty_21 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -1980,7 +2028,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2013,7 +2061,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2027,7 +2076,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_23 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2057,7 +2114,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2068,7 +2125,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum _bindgen_ty_25 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2083,7 +2140,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2096,7 +2153,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2134,7 +2191,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2146,7 +2203,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2162,7 +2219,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2170,7 +2227,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2190,7 +2247,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2198,7 +2255,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2207,7 +2264,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2222,7 +2279,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2230,7 +2287,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2244,7 +2301,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2253,7 +2310,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2271,7 +2328,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2281,14 +2338,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2296,7 +2353,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2310,7 +2367,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2322,7 +2379,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2331,7 +2388,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2340,7 +2397,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2350,7 +2407,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2359,7 +2416,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2369,7 +2426,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2384,7 +2441,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2396,7 +2453,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2412,7 +2469,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2421,7 +2478,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2429,15 +2486,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFA_UNSPEC = 0,
 IFA_ADDRESS = 1,
 IFA_LOCAL = 2,
@@ -2455,7 +2512,7 @@ __IFA_MAX = 12,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 NDA_UNSPEC = 0,
 NDA_DST = 1,
 NDA_LLADDR = 2,
@@ -2479,7 +2536,7 @@ __NDA_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 NDTPA_UNSPEC = 0,
 NDTPA_IFINDEX = 1,
 NDTPA_REFCNT = 2,
@@ -2505,7 +2562,7 @@ __NDTPA_MAX = 20,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_57 {
+pub enum _bindgen_ty_58 {
 NDTA_UNSPEC = 0,
 NDTA_NAME = 1,
 NDTA_THRESH1 = 2,
@@ -2521,14 +2578,14 @@ __NDTA_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_58 {
+pub enum _bindgen_ty_59 {
 FDB_NOTIFY_BIT = 1,
 FDB_NOTIFY_INACTIVE_BIT = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_59 {
+pub enum _bindgen_ty_60 {
 NFEA_UNSPEC = 0,
 NFEA_ACTIVITY_NOTIFY = 1,
 NFEA_DONT_REFRESH = 2,
@@ -2537,7 +2594,7 @@ __NFEA_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_60 {
+pub enum _bindgen_ty_61 {
 RTM_BASE = 16,
 RTM_DELLINK = 17,
 RTM_GETLINK = 18,
@@ -2614,7 +2671,7 @@ __RTM_MAX = 123,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_61 {
+pub enum _bindgen_ty_62 {
 RTN_UNSPEC = 0,
 RTN_UNICAST = 1,
 RTN_LOCAL = 2,
@@ -2690,7 +2747,7 @@ __RTA_MAX = 31,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_62 {
+pub enum _bindgen_ty_63 {
 RTAX_UNSPEC = 0,
 RTAX_LOCK = 1,
 RTAX_MTU = 2,
@@ -2714,7 +2771,7 @@ __RTAX_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_63 {
+pub enum _bindgen_ty_64 {
 PREFIX_UNSPEC = 0,
 PREFIX_ADDRESS = 1,
 PREFIX_CACHEINFO = 2,
@@ -2723,7 +2780,7 @@ __PREFIX_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_64 {
+pub enum _bindgen_ty_65 {
 TCA_UNSPEC = 0,
 TCA_KIND = 1,
 TCA_OPTIONS = 2,
@@ -2746,7 +2803,7 @@ __TCA_MAX = 17,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_65 {
+pub enum _bindgen_ty_66 {
 NDUSEROPT_UNSPEC = 0,
 NDUSEROPT_SRCADDR = 1,
 __NDUSEROPT_MAX = 2,
@@ -2797,7 +2854,7 @@ __RTNLGRP_MAX = 37,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_66 {
+pub enum _bindgen_ty_67 {
 TCA_ROOT_UNSPEC = 0,
 TCA_ROOT_TAB = 1,
 TCA_ROOT_FLAGS = 2,
@@ -2860,6 +2917,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/powerpc/prctl.rs
+++ b/src/powerpc/prctl.rs
@@ -222,6 +222,7 @@ pub const PR_SME_VL_LEN_MASK: u32 = 65535;
 pub const PR_SME_VL_INHERIT: u32 = 131072;
 pub const PR_SET_MDWE: u32 = 65;
 pub const PR_MDWE_REFUSE_EXEC_GAIN: u32 = 1;
+pub const PR_MDWE_NO_INHERIT: u32 = 2;
 pub const PR_GET_MDWE: u32 = 66;
 pub const PR_SET_VMA: u32 = 1398164801;
 pub const PR_SET_VMA_ANON_NAME: u32 = 0;

--- a/src/powerpc/xdp.rs
+++ b/src/powerpc/xdp.rs
@@ -87,6 +87,7 @@ pub len: __u64,
 pub chunk_size: __u32,
 pub headroom: __u32,
 pub flags: __u32,
+pub tx_metadata_len: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -102,6 +103,23 @@ pub tx_ring_empty_descs: __u64,
 #[derive(Debug, Copy, Clone)]
 pub struct xdp_options {
 pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct xsk_tx_metadata {
+pub flags: __u64,
+pub __bindgen_anon_1: xsk_tx_metadata__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1 {
+pub csum_start: __u16,
+pub csum_offset: __u16,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2 {
+pub tx_timestamp: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -144,7 +162,9 @@ pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
 pub const XDP_USE_NEED_WAKEUP: u32 = 8;
+pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
+pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;
@@ -161,5 +181,13 @@ pub const XDP_UMEM_PGOFF_FILL_RING: u64 = 4294967296;
 pub const XDP_UMEM_PGOFF_COMPLETION_RING: u64 = 6442450944;
 pub const XSK_UNALIGNED_BUF_OFFSET_SHIFT: u32 = 48;
 pub const XSK_UNALIGNED_BUF_ADDR_MASK: u64 = 281474976710655;
-pub const XDP_USE_SG: u32 = 16;
+pub const XDP_TXMD_FLAGS_TIMESTAMP: u32 = 1;
+pub const XDP_TXMD_FLAGS_CHECKSUM: u32 = 2;
 pub const XDP_PKT_CONTD: u32 = 1;
+pub const XDP_TX_METADATA: u32 = 2;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union xsk_tx_metadata__bindgen_ty_1 {
+pub request: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1,
+pub completion: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2,
+}

--- a/src/powerpc64/general.rs
+++ b/src/powerpc64/general.rs
@@ -190,7 +190,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -245,6 +246,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -303,6 +337,29 @@ pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
 pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -397,36 +454,6 @@ pub it_value: __kernel_old_timeval,
 pub struct __kernel_sock_timeval {
 pub tv_sec: __s64,
 pub tv_usec: __s64,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timespec {
-pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: crate::ctypes::c_long,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timeval {
-pub tv_sec: __kernel_old_time_t,
-pub tv_usec: __kernel_suseconds_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerspec {
-pub it_interval: timespec,
-pub it_value: timespec,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerval {
-pub it_interval: timeval,
-pub it_value: timeval,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timezone {
-pub tz_minuteswest: crate::ctypes::c_int,
-pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -707,6 +734,36 @@ pub c_cc: [crate::ctypes::c_uchar; 10usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct timespec {
+pub tv_sec: __kernel_old_time_t,
+pub tv_nsec: crate::ctypes::c_long,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timeval {
+pub tv_sec: __kernel_old_time_t,
+pub tv_usec: __kernel_suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerspec {
+pub it_interval: timespec,
+pub it_value: timespec,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerval {
+pub it_interval: timeval,
+pub it_value: timeval,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timezone {
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct iovec {
 pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
@@ -800,6 +857,22 @@ pub struct uffdio_continue {
 pub range: uffdio_range,
 pub mode: __u64,
 pub mapped: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_poison {
+pub range: uffdio_range,
+pub mode: __u64,
+pub updated: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_move {
+pub dst: __u64,
+pub src: __u64,
+pub len: __u64,
+pub mode: __u64,
+pub move_: __s64,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -927,9 +1000,9 @@ pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 394496;
+pub const LINUX_VERSION_CODE: u32 = 395264;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 5;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_DCACHEBSIZE: u32 = 19;
 pub const AT_ICACHEBSIZE: u32 = 20;
@@ -1310,6 +1383,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1381,6 +1462,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const FUTEX_WAIT: u32 = 0;
 pub const FUTEX_WAKE: u32 = 1;
 pub const FUTEX_FD: u32 = 2;
@@ -1411,6 +1502,13 @@ pub const FUTEX_WAIT_BITSET_PRIVATE: u32 = 137;
 pub const FUTEX_WAKE_BITSET_PRIVATE: u32 = 138;
 pub const FUTEX_WAIT_REQUEUE_PI_PRIVATE: u32 = 139;
 pub const FUTEX_CMP_REQUEUE_PI_PRIVATE: u32 = 140;
+pub const FUTEX2_SIZE_U8: u32 = 0;
+pub const FUTEX2_SIZE_U16: u32 = 1;
+pub const FUTEX2_SIZE_U32: u32 = 2;
+pub const FUTEX2_SIZE_U64: u32 = 3;
+pub const FUTEX2_NUMA: u32 = 4;
+pub const FUTEX2_PRIVATE: u32 = 128;
+pub const FUTEX2_SIZE_MASK: u32 = 3;
 pub const FUTEX_32: u32 = 2;
 pub const FUTEX_WAITV_MAX: u32 = 128;
 pub const FUTEX_WAITERS: u32 = 2147483648;
@@ -1670,25 +1768,6 @@ pub const LINUX_REBOOT_CMD_POWER_OFF: u32 = 1126301404;
 pub const LINUX_REBOOT_CMD_RESTART2: u32 = 2712847316;
 pub const LINUX_REBOOT_CMD_SW_SUSPEND: u32 = 3489725666;
 pub const LINUX_REBOOT_CMD_KEXEC: u32 = 1163412803;
-pub const ITIMER_REAL: u32 = 0;
-pub const ITIMER_VIRTUAL: u32 = 1;
-pub const ITIMER_PROF: u32 = 2;
-pub const CLOCK_REALTIME: u32 = 0;
-pub const CLOCK_MONOTONIC: u32 = 1;
-pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
-pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
-pub const CLOCK_MONOTONIC_RAW: u32 = 4;
-pub const CLOCK_REALTIME_COARSE: u32 = 5;
-pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
-pub const CLOCK_BOOTTIME: u32 = 7;
-pub const CLOCK_REALTIME_ALARM: u32 = 8;
-pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
-pub const CLOCK_SGI_CYCLE: u32 = 10;
-pub const CLOCK_TAI: u32 = 11;
-pub const MAX_CLOCKS: u32 = 16;
-pub const CLOCKS_MASK: u32 = 1;
-pub const CLOCKS_MONO: u32 = 1;
-pub const TIMER_ABSTIME: u32 = 1;
 pub const RUSAGE_SELF: u32 = 0;
 pub const RUSAGE_CHILDREN: i32 = -1;
 pub const RUSAGE_BOTH: i32 = -2;
@@ -1871,7 +1950,8 @@ pub const SEGV_ADIDERR: u32 = 6;
 pub const SEGV_ADIPERR: u32 = 7;
 pub const SEGV_MTEAERR: u32 = 8;
 pub const SEGV_MTESERR: u32 = 9;
-pub const NSIGSEGV: u32 = 9;
+pub const SEGV_CPERR: u32 = 10;
+pub const NSIGSEGV: u32 = 10;
 pub const BUS_ADRALN: u32 = 1;
 pub const BUS_ADRERR: u32 = 2;
 pub const BUS_OBJERR: u32 = 3;
@@ -1952,6 +2032,7 @@ pub const STATX_BASIC_STATS: u32 = 2047;
 pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
+pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2141,6 +2222,25 @@ pub const _VEOL: u32 = 6;
 pub const _VTIME: u32 = 7;
 pub const _VEOL2: u32 = 8;
 pub const _VSWTC: u32 = 9;
+pub const ITIMER_REAL: u32 = 0;
+pub const ITIMER_VIRTUAL: u32 = 1;
+pub const ITIMER_PROF: u32 = 2;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_SGI_CYCLE: u32 = 10;
+pub const CLOCK_TAI: u32 = 11;
+pub const MAX_CLOCKS: u32 = 16;
+pub const CLOCKS_MASK: u32 = 1;
+pub const CLOCKS_MONO: u32 = 1;
+pub const TIMER_ABSTIME: u32 = 1;
 pub const UIO_FASTIOV: u32 = 8;
 pub const UIO_MAXIOV: u32 = 1024;
 pub const __NR_restart_syscall: u32 = 0;
@@ -2547,6 +2647,16 @@ pub const __NR_process_mrelease: u32 = 448;
 pub const __NR_futex_waitv: u32 = 449;
 pub const __NR_set_mempolicy_home_node: u32 = 450;
 pub const __NR_cachestat: u32 = 451;
+pub const __NR_fchmodat2: u32 = 452;
+pub const __NR_map_shadow_stack: u32 = 453;
+pub const __NR_futex_wake: u32 = 454;
+pub const __NR_futex_wait: u32 = 455;
+pub const __NR_futex_requeue: u32 = 456;
+pub const __NR_statmount: u32 = 457;
+pub const __NR_listmount: u32 = 458;
+pub const __NR_lsm_get_self_attr: u32 = 459;
+pub const __NR_lsm_set_self_attr: u32 = 460;
+pub const __NR_lsm_list_modules: u32 = 461;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
 pub const WSTOPPED: u32 = 2;
@@ -2625,8 +2735,10 @@ pub const _UFFDIO_UNREGISTER: u32 = 1;
 pub const _UFFDIO_WAKE: u32 = 2;
 pub const _UFFDIO_COPY: u32 = 3;
 pub const _UFFDIO_ZEROPAGE: u32 = 4;
+pub const _UFFDIO_MOVE: u32 = 5;
 pub const _UFFDIO_WRITEPROTECT: u32 = 6;
 pub const _UFFDIO_CONTINUE: u32 = 7;
+pub const _UFFDIO_POISON: u32 = 8;
 pub const _UFFDIO_API: u32 = 63;
 pub const UFFDIO: u32 = 170;
 pub const UFFD_EVENT_PAGEFAULT: u32 = 18;
@@ -2651,6 +2763,9 @@ pub const UFFD_FEATURE_MINOR_SHMEM: u32 = 1024;
 pub const UFFD_FEATURE_EXACT_ADDRESS: u32 = 2048;
 pub const UFFD_FEATURE_WP_HUGETLBFS_SHMEM: u32 = 4096;
 pub const UFFD_FEATURE_WP_UNPOPULATED: u32 = 8192;
+pub const UFFD_FEATURE_POISON: u32 = 16384;
+pub const UFFD_FEATURE_WP_ASYNC: u32 = 32768;
+pub const UFFD_FEATURE_MOVE: u32 = 65536;
 pub const UFFD_USER_MODE_ONLY: u32 = 1;
 pub const DT_UNKNOWN: u32 = 0;
 pub const DT_FIFO: u32 = 1;
@@ -2725,6 +2840,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/powerpc64/if_arp.rs
+++ b/src/powerpc64/if_arp.rs
@@ -52,11 +52,6 @@ pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Copy, Clone)]
 pub struct __vector128 {
@@ -181,6 +176,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -188,23 +184,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -1132,6 +1113,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_4 = _bindgen_ty_4::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_4 = _bindgen_ty_4::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_MASK;
@@ -1200,6 +1182,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_HAIRPIN;
@@ -1247,6 +1231,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_10 = _bindgen_ty_10::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_KIND;
@@ -1308,301 +1293,310 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_19 = _bindgen_ty_19::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_40 = _bindgen_ty_40::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_46 = _bindgen_ty_46::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_DSA_MAX;
-pub const IF_PORT_UNKNOWN: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_UNKNOWN;
-pub const IF_PORT_10BASE2: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASE2;
-pub const IF_PORT_10BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASET;
-pub const IF_PORT_AUI: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_AUI;
-pub const IF_PORT_100BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASET;
-pub const IF_PORT_100BASETX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASETX;
-pub const IF_PORT_100BASEFX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASEFX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_20 = _bindgen_ty_20::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_23 = _bindgen_ty_23::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_47 = _bindgen_ty_47::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__IFLA_DSA_MAX;
+pub const IF_PORT_UNKNOWN: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_UNKNOWN;
+pub const IF_PORT_10BASE2: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASE2;
+pub const IF_PORT_10BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASET;
+pub const IF_PORT_AUI: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_AUI;
+pub const IF_PORT_100BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASET;
+pub const IF_PORT_100BASETX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASETX;
+pub const IF_PORT_100BASEFX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASEFX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1705,6 +1699,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1794,7 +1790,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1890,7 +1887,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1947,7 +1946,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2100,10 +2100,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_20 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_21 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -2119,7 +2147,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -2131,7 +2159,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum _bindgen_ty_23 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -2139,7 +2167,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2172,7 +2200,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2186,7 +2215,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_25 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2216,7 +2253,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2227,7 +2264,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2242,7 +2279,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2255,7 +2292,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2293,7 +2330,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2305,7 +2342,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2321,7 +2358,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2329,7 +2366,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2349,7 +2386,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2357,7 +2394,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2366,7 +2403,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2381,7 +2418,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2389,7 +2426,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2403,7 +2440,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2412,7 +2449,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2430,7 +2467,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2440,14 +2477,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2455,7 +2492,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2469,7 +2506,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2481,7 +2518,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2490,7 +2527,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2499,7 +2536,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2509,7 +2546,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2518,7 +2555,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2528,7 +2565,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2543,7 +2580,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2555,7 +2592,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2571,7 +2608,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2580,7 +2617,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2588,15 +2625,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 IF_PORT_UNKNOWN = 0,
 IF_PORT_10BASE2 = 1,
 IF_PORT_10BASET = 2,
@@ -2679,74 +2716,6 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 impl nlmsgerr_attrs {
 pub const NLMSGERR_ATTR_MAX: nlmsgerr_attrs = nlmsgerr_attrs::NLMSGERR_ATTR_MISS_NEST;
 }
@@ -2761,6 +2730,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/powerpc64/if_packet.rs
+++ b/src/powerpc64/if_packet.rs
@@ -51,11 +51,6 @@ pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Copy, Clone)]
 pub struct __vector128 {
@@ -69,6 +64,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -76,23 +72,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -333,71 +314,3 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}

--- a/src/powerpc64/io_uring.rs
+++ b/src/powerpc64/io_uring.rs
@@ -85,7 +85,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -140,6 +141,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -201,6 +235,29 @@ pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
 pub tv_nsec: crate::ctypes::c_longlong,
@@ -259,6 +316,12 @@ pub __pad1: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_sqe__bindgen_ty_2__bindgen_ty_1 {
+pub level: __u32,
+pub optname: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_sqe__bindgen_ty_5__bindgen_ty_1 {
 pub addr_len: __u16,
 pub __pad3: [__u16; 1usize],
@@ -266,6 +329,7 @@ pub __pad3: [__u16; 1usize],
 #[repr(C)]
 pub struct io_uring_sqe__bindgen_ty_6 {
 pub __bindgen_anon_1: __BindgenUnionField<io_uring_sqe__bindgen_ty_6__bindgen_ty_1>,
+pub optval: __BindgenUnionField<__u64>,
 pub cmd: __BindgenUnionField<[__u8; 0usize]>,
 pub bindgen_union_field: [u64; 2usize],
 }
@@ -427,6 +491,13 @@ pub resv: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_buf_status {
+pub buf_group: __u32,
+pub head: __u32,
+pub resv: [__u32; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -440,7 +511,9 @@ pub addr: __u64,
 pub fd: __s32,
 pub flags: __u32,
 pub timeout: __kernel_timespec,
-pub pad: [__u64; 4usize],
+pub opcode: __u8,
+pub pad: [__u8; 7usize],
+pub pad2: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -603,6 +676,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -674,6 +755,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const IORING_FILE_INDEX_ALLOC: i32 = -1;
 pub const IORING_SETUP_IOPOLL: u32 = 1;
 pub const IORING_SETUP_SQPOLL: u32 = 2;
@@ -691,8 +782,9 @@ pub const IORING_SETUP_SINGLE_ISSUER: u32 = 4096;
 pub const IORING_SETUP_DEFER_TASKRUN: u32 = 8192;
 pub const IORING_SETUP_NO_MMAP: u32 = 16384;
 pub const IORING_SETUP_REGISTERED_FD_ONLY: u32 = 32768;
+pub const IORING_SETUP_NO_SQARRAY: u32 = 65536;
 pub const IORING_URING_CMD_FIXED: u32 = 1;
-pub const IORING_URING_CMD_POLLED: u32 = 2147483648;
+pub const IORING_URING_CMD_MASK: u32 = 1;
 pub const IORING_FSYNC_DATASYNC: u32 = 1;
 pub const IORING_TIMEOUT_ABS: u32 = 1;
 pub const IORING_TIMEOUT_UPDATE: u32 = 2;
@@ -712,6 +804,8 @@ pub const IORING_ASYNC_CANCEL_ALL: u32 = 1;
 pub const IORING_ASYNC_CANCEL_FD: u32 = 2;
 pub const IORING_ASYNC_CANCEL_ANY: u32 = 4;
 pub const IORING_ASYNC_CANCEL_FD_FIXED: u32 = 8;
+pub const IORING_ASYNC_CANCEL_USERDATA: u32 = 16;
+pub const IORING_ASYNC_CANCEL_OP: u32 = 32;
 pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
@@ -720,6 +814,7 @@ pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
+pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
@@ -792,6 +887,7 @@ pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGIS
 pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
 pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
 pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
+pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
 pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
 pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
 pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
@@ -802,6 +898,10 @@ pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTR
 pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
 pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
 pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
+pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
+pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
+pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
+pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -814,6 +914,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -880,7 +981,13 @@ IORING_OP_SOCKET = 45,
 IORING_OP_URING_CMD = 46,
 IORING_OP_SEND_ZC = 47,
 IORING_OP_SENDMSG_ZC = 48,
-IORING_OP_LAST = 49,
+IORING_OP_READ_MULTISHOT = 49,
+IORING_OP_WAITID = 50,
+IORING_OP_FUTEX_WAIT = 51,
+IORING_OP_FUTEX_WAKE = 52,
+IORING_OP_FUTEX_WAITV = 53,
+IORING_OP_FIXED_FD_INSTALL = 54,
+IORING_OP_LAST = 55,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -925,7 +1032,8 @@ IORING_REGISTER_PBUF_RING = 22,
 IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
-IORING_REGISTER_LAST = 26,
+IORING_REGISTER_PBUF_STATUS = 26,
+IORING_REGISTER_LAST = 27,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
@@ -950,6 +1058,15 @@ IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
 IORING_RESTRICTION_SQE_FLAGS_REQUIRED = 3,
 IORING_RESTRICTION_LAST = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_8 {
+SOCKET_URING_OP_SIOCINQ = 0,
+SOCKET_URING_OP_SIOCOUTQ = 1,
+SOCKET_URING_OP_GETSOCKOPT = 2,
+SOCKET_URING_OP_SETSOCKOPT = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -977,6 +1094,7 @@ pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_1__bindgen_ty_1,
 pub union io_uring_sqe__bindgen_ty_2 {
 pub addr: __u64,
 pub splice_off_in: __u64,
+pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_2__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -1000,6 +1118,9 @@ pub hardlink_flags: __u32,
 pub xattr_flags: __u32,
 pub msg_ring_flags: __u32,
 pub uring_cmd_flags: __u32,
+pub waitid_flags: __u32,
+pub futex_flags: __u32,
+pub install_fd_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]
@@ -1012,6 +1133,7 @@ pub buf_group: __u16,
 pub union io_uring_sqe__bindgen_ty_5 {
 pub splice_fd_in: __s32,
 pub file_index: __u32,
+pub optlen: __u32,
 pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]

--- a/src/powerpc64/net.rs
+++ b/src/powerpc64/net.rs
@@ -435,6 +435,9 @@ pub tcpi_rcv_ooopack: __u32,
 pub tcpi_snd_wnd: __u32,
 pub tcpi_rcv_wnd: __u32,
 pub tcpi_rehash: __u32,
+pub tcpi_total_rto: __u16,
+pub tcpi_total_rto_recoveries: __u16,
+pub tcpi_total_rto_time: __u32,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -454,6 +457,80 @@ pub tcpm_prefixlen: __u8,
 pub tcpm_keylen: __u16,
 pub tcpm_addr: [__be32; 4usize],
 pub tcpm_key: [__u8; 80usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_add {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub key: [__u8; 80usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_del {
+pub addr: __kernel_sockaddr_storage,
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub current_key: __u8,
+pub rnext: __u8,
+pub keyflags: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_info_opt {
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub current_key: __u8,
+pub rnext: __u8,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+pub pkt_key_not_found: __u64,
+pub pkt_ao_required: __u64,
+pub pkt_dropped_icmp: __u64,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_getsockopt {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub key: [__u8; 80usize],
+pub nkeys: __u32,
+pub _bitfield_align_1: [u16; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub prefix: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub ifindex: __s32,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_repair {
+pub snt_isn: __be32,
+pub rcv_isn: __be32,
+pub snd_sne: __u32,
+pub rcv_sne: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1191,6 +1268,11 @@ pub const TCP_ZEROCOPY_RECEIVE: u32 = 35;
 pub const TCP_INQ: u32 = 36;
 pub const TCP_CM_INQ: u32 = 36;
 pub const TCP_TX_DELAY: u32 = 37;
+pub const TCP_AO_ADD_KEY: u32 = 38;
+pub const TCP_AO_DEL_KEY: u32 = 39;
+pub const TCP_AO_INFO: u32 = 40;
+pub const TCP_AO_GET_KEYS: u32 = 41;
+pub const TCP_AO_REPAIR: u32 = 42;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1200,9 +1282,13 @@ pub const TCPI_OPT_WSCALE: u32 = 4;
 pub const TCPI_OPT_ECN: u32 = 8;
 pub const TCPI_OPT_ECN_SEEN: u32 = 16;
 pub const TCPI_OPT_SYN_DATA: u32 = 32;
+pub const TCPI_OPT_USEC_TS: u32 = 64;
 pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
+pub const TCP_AO_MAXKEYLEN: u32 = 80;
+pub const TCP_AO_KEYF_IFINDEX: u32 = 1;
+pub const TCP_AO_KEYF_EXCLUDE_OPT: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
@@ -1567,6 +1653,7 @@ pub const DEVCONF_IOAM6_ID: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID;
 pub const DEVCONF_IOAM6_ID_WIDE: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID_WIDE;
 pub const DEVCONF_NDISC_EVICT_NOCARRIER: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_NDISC_EVICT_NOCARRIER;
 pub const DEVCONF_ACCEPT_UNTRACKED_NA: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_UNTRACKED_NA;
+pub const DEVCONF_ACCEPT_RA_MIN_LFT: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_RA_MIN_LFT;
 pub const DEVCONF_MAX: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_MAX;
 pub const TCP_FLAG_CWR: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_CWR;
 pub const TCP_FLAG_ECE: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_ECE;
@@ -1764,7 +1851,8 @@ DEVCONF_IOAM6_ID = 54,
 DEVCONF_IOAM6_ID_WIDE = 55,
 DEVCONF_NDISC_EVICT_NOCARRIER = 56,
 DEVCONF_ACCEPT_UNTRACKED_NA = 57,
-DEVCONF_MAX = 58,
+DEVCONF_ACCEPT_RA_MIN_LFT = 58,
+DEVCONF_MAX = 59,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2482,6 +2570,289 @@ tcpi_delivery_rate_app_limited as u64
 __bindgen_bitfield_unit.set(9usize, 2u8, {
 let tcpi_fastopen_client_fail: u8 = unsafe { ::core::mem::transmute(tcpi_fastopen_client_fail) };
 tcpi_fastopen_client_fail as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_add {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 30u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 30u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_del {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn del_async(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_del_async(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 29u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 29u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, del_async: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let del_async: u32 = unsafe { ::core::mem::transmute(del_async) };
+del_async as u64
+});
+__bindgen_bitfield_unit.set(3usize, 29u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_info_opt {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn ao_required(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_ao_required(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_counters(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_counters(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn accept_icmps(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_accept_icmps(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(4usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(5usize, 27u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(5usize, 27u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, ao_required: __u32, set_counters: __u32, accept_icmps: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let ao_required: u32 = unsafe { ::core::mem::transmute(ao_required) };
+ao_required as u64
+});
+__bindgen_bitfield_unit.set(3usize, 1u8, {
+let set_counters: u32 = unsafe { ::core::mem::transmute(set_counters) };
+set_counters as u64
+});
+__bindgen_bitfield_unit.set(4usize, 1u8, {
+let accept_icmps: u32 = unsafe { ::core::mem::transmute(accept_icmps) };
+accept_icmps as u64
+});
+__bindgen_bitfield_unit.set(5usize, 27u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_getsockopt {
+#[inline]
+pub fn is_current(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_current(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn is_rnext(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_rnext(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn get_all(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_get_all(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 13u8) as u16) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 13u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(is_current: __u16, is_rnext: __u16, get_all: __u16, reserved: __u16) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let is_current: u16 = unsafe { ::core::mem::transmute(is_current) };
+is_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let is_rnext: u16 = unsafe { ::core::mem::transmute(is_rnext) };
+is_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let get_all: u16 = unsafe { ::core::mem::transmute(get_all) };
+get_all as u64
+});
+__bindgen_bitfield_unit.set(3usize, 13u8, {
+let reserved: u16 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
 });
 __bindgen_bitfield_unit
 }

--- a/src/powerpc64/netlink.rs
+++ b/src/powerpc64/netlink.rs
@@ -730,7 +730,8 @@ pub const RTAX_FEATURE_ECN: u32 = 1;
 pub const RTAX_FEATURE_SACK: u32 = 2;
 pub const RTAX_FEATURE_TIMESTAMP: u32 = 4;
 pub const RTAX_FEATURE_ALLFRAG: u32 = 8;
-pub const RTAX_FEATURE_MASK: u32 = 15;
+pub const RTAX_FEATURE_TCP_USEC_TS: u32 = 16;
+pub const RTAX_FEATURE_MASK: u32 = 31;
 pub const TCM_IFINDEX_MAGIC_BLOCK: u32 = 4294967295;
 pub const TCA_DUMP_FLAGS_TERSE: u32 = 1;
 pub const RTMGRP_LINK: u32 = 1;
@@ -827,6 +828,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_2 = _bindgen_ty_2::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_2 = _bindgen_ty_2::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_MASK;
@@ -895,6 +897,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_6 = _bindgen_ty_6::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_HAIRPIN;
@@ -942,6 +946,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_KIND;
@@ -1003,501 +1008,510 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_17 = _bindgen_ty_17::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_18 = _bindgen_ty_18::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_21 = _bindgen_ty_21::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_44 = _bindgen_ty_44::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_DSA_MAX;
-pub const IFA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFA_UNSPEC;
-pub const IFA_ADDRESS: _bindgen_ty_54 = _bindgen_ty_54::IFA_ADDRESS;
-pub const IFA_LOCAL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LOCAL;
-pub const IFA_LABEL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LABEL;
-pub const IFA_BROADCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_BROADCAST;
-pub const IFA_ANYCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_ANYCAST;
-pub const IFA_CACHEINFO: _bindgen_ty_54 = _bindgen_ty_54::IFA_CACHEINFO;
-pub const IFA_MULTICAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_MULTICAST;
-pub const IFA_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFA_FLAGS;
-pub const IFA_RT_PRIORITY: _bindgen_ty_54 = _bindgen_ty_54::IFA_RT_PRIORITY;
-pub const IFA_TARGET_NETNSID: _bindgen_ty_54 = _bindgen_ty_54::IFA_TARGET_NETNSID;
-pub const IFA_PROTO: _bindgen_ty_54 = _bindgen_ty_54::IFA_PROTO;
-pub const __IFA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFA_MAX;
-pub const NDA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::NDA_UNSPEC;
-pub const NDA_DST: _bindgen_ty_55 = _bindgen_ty_55::NDA_DST;
-pub const NDA_LLADDR: _bindgen_ty_55 = _bindgen_ty_55::NDA_LLADDR;
-pub const NDA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::NDA_CACHEINFO;
-pub const NDA_PROBES: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROBES;
-pub const NDA_VLAN: _bindgen_ty_55 = _bindgen_ty_55::NDA_VLAN;
-pub const NDA_PORT: _bindgen_ty_55 = _bindgen_ty_55::NDA_PORT;
-pub const NDA_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_VNI;
-pub const NDA_IFINDEX: _bindgen_ty_55 = _bindgen_ty_55::NDA_IFINDEX;
-pub const NDA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::NDA_MASTER;
-pub const NDA_LINK_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::NDA_LINK_NETNSID;
-pub const NDA_SRC_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_SRC_VNI;
-pub const NDA_PROTOCOL: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROTOCOL;
-pub const NDA_NH_ID: _bindgen_ty_55 = _bindgen_ty_55::NDA_NH_ID;
-pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_55 = _bindgen_ty_55::NDA_FDB_EXT_ATTRS;
-pub const NDA_FLAGS_EXT: _bindgen_ty_55 = _bindgen_ty_55::NDA_FLAGS_EXT;
-pub const NDA_NDM_STATE_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_STATE_MASK;
-pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_FLAGS_MASK;
-pub const __NDA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__NDA_MAX;
-pub const NDTPA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UNSPEC;
-pub const NDTPA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_IFINDEX;
-pub const NDTPA_REFCNT: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REFCNT;
-pub const NDTPA_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REACHABLE_TIME;
-pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_BASE_REACHABLE_TIME;
-pub const NDTPA_RETRANS_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_RETRANS_TIME;
-pub const NDTPA_GC_STALETIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_GC_STALETIME;
-pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_DELAY_PROBE_TIME;
-pub const NDTPA_QUEUE_LEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LEN;
-pub const NDTPA_APP_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_APP_PROBES;
-pub const NDTPA_UCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UCAST_PROBES;
-pub const NDTPA_MCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_PROBES;
-pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_ANYCAST_DELAY;
-pub const NDTPA_PROXY_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_DELAY;
-pub const NDTPA_PROXY_QLEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_QLEN;
-pub const NDTPA_LOCKTIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_LOCKTIME;
-pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LENBYTES;
-pub const NDTPA_MCAST_REPROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_REPROBES;
-pub const NDTPA_PAD: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PAD;
-pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_INTERVAL_PROBE_TIME_MS;
-pub const __NDTPA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDTPA_MAX;
-pub const NDTA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTA_UNSPEC;
-pub const NDTA_NAME: _bindgen_ty_57 = _bindgen_ty_57::NDTA_NAME;
-pub const NDTA_THRESH1: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH1;
-pub const NDTA_THRESH2: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH2;
-pub const NDTA_THRESH3: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH3;
-pub const NDTA_CONFIG: _bindgen_ty_57 = _bindgen_ty_57::NDTA_CONFIG;
-pub const NDTA_PARMS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PARMS;
-pub const NDTA_STATS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_STATS;
-pub const NDTA_GC_INTERVAL: _bindgen_ty_57 = _bindgen_ty_57::NDTA_GC_INTERVAL;
-pub const NDTA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PAD;
-pub const __NDTA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTA_MAX;
-pub const FDB_NOTIFY_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_BIT;
-pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_INACTIVE_BIT;
-pub const NFEA_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::NFEA_UNSPEC;
-pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_59 = _bindgen_ty_59::NFEA_ACTIVITY_NOTIFY;
-pub const NFEA_DONT_REFRESH: _bindgen_ty_59 = _bindgen_ty_59::NFEA_DONT_REFRESH;
-pub const __NFEA_MAX: _bindgen_ty_59 = _bindgen_ty_59::__NFEA_MAX;
-pub const RTM_BASE: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_NEWLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_DELLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINK;
-pub const RTM_GETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINK;
-pub const RTM_SETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETLINK;
-pub const RTM_NEWADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDR;
-pub const RTM_DELADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDR;
-pub const RTM_GETADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDR;
-pub const RTM_NEWROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWROUTE;
-pub const RTM_DELROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELROUTE;
-pub const RTM_GETROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETROUTE;
-pub const RTM_NEWNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGH;
-pub const RTM_DELNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEIGH;
-pub const RTM_GETNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGH;
-pub const RTM_NEWRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWRULE;
-pub const RTM_DELRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELRULE;
-pub const RTM_GETRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETRULE;
-pub const RTM_NEWQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWQDISC;
-pub const RTM_DELQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELQDISC;
-pub const RTM_GETQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETQDISC;
-pub const RTM_NEWTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTCLASS;
-pub const RTM_DELTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTCLASS;
-pub const RTM_GETTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTCLASS;
-pub const RTM_NEWTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTFILTER;
-pub const RTM_DELTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTFILTER;
-pub const RTM_GETTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTFILTER;
-pub const RTM_NEWACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWACTION;
-pub const RTM_DELACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELACTION;
-pub const RTM_GETACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETACTION;
-pub const RTM_NEWPREFIX: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWPREFIX;
-pub const RTM_GETMULTICAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMULTICAST;
-pub const RTM_GETANYCAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETANYCAST;
-pub const RTM_NEWNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGHTBL;
-pub const RTM_GETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGHTBL;
-pub const RTM_SETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETNEIGHTBL;
-pub const RTM_NEWNDUSEROPT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNDUSEROPT;
-pub const RTM_NEWADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDRLABEL;
-pub const RTM_DELADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDRLABEL;
-pub const RTM_GETADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDRLABEL;
-pub const RTM_GETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETDCB;
-pub const RTM_SETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETDCB;
-pub const RTM_NEWNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNETCONF;
-pub const RTM_DELNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNETCONF;
-pub const RTM_GETNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNETCONF;
-pub const RTM_NEWMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWMDB;
-pub const RTM_DELMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELMDB;
-pub const RTM_GETMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMDB;
-pub const RTM_NEWNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNSID;
-pub const RTM_DELNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNSID;
-pub const RTM_GETNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNSID;
-pub const RTM_NEWSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWSTATS;
-pub const RTM_GETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETSTATS;
-pub const RTM_SETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETSTATS;
-pub const RTM_NEWCACHEREPORT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCACHEREPORT;
-pub const RTM_NEWCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCHAIN;
-pub const RTM_DELCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELCHAIN;
-pub const RTM_GETCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETCHAIN;
-pub const RTM_NEWNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOP;
-pub const RTM_DELNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOP;
-pub const RTM_GETNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOP;
-pub const RTM_NEWLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWLINKPROP;
-pub const RTM_DELLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINKPROP;
-pub const RTM_GETLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINKPROP;
-pub const RTM_NEWVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWVLAN;
-pub const RTM_DELVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELVLAN;
-pub const RTM_GETVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETVLAN;
-pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOPBUCKET;
-pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOPBUCKET;
-pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOPBUCKET;
-pub const RTM_NEWTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTUNNEL;
-pub const RTM_DELTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTUNNEL;
-pub const RTM_GETTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTUNNEL;
-pub const __RTM_MAX: _bindgen_ty_60 = _bindgen_ty_60::__RTM_MAX;
-pub const RTN_UNSPEC: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNSPEC;
-pub const RTN_UNICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNICAST;
-pub const RTN_LOCAL: _bindgen_ty_61 = _bindgen_ty_61::RTN_LOCAL;
-pub const RTN_BROADCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_BROADCAST;
-pub const RTN_ANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_ANYCAST;
-pub const RTN_MULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_MULTICAST;
-pub const RTN_BLACKHOLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_BLACKHOLE;
-pub const RTN_UNREACHABLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNREACHABLE;
-pub const RTN_PROHIBIT: _bindgen_ty_61 = _bindgen_ty_61::RTN_PROHIBIT;
-pub const RTN_THROW: _bindgen_ty_61 = _bindgen_ty_61::RTN_THROW;
-pub const RTN_NAT: _bindgen_ty_61 = _bindgen_ty_61::RTN_NAT;
-pub const RTN_XRESOLVE: _bindgen_ty_61 = _bindgen_ty_61::RTN_XRESOLVE;
-pub const __RTN_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTN_MAX;
-pub const RTAX_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTAX_UNSPEC;
-pub const RTAX_LOCK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_LOCK;
-pub const RTAX_MTU: _bindgen_ty_62 = _bindgen_ty_62::RTAX_MTU;
-pub const RTAX_WINDOW: _bindgen_ty_62 = _bindgen_ty_62::RTAX_WINDOW;
-pub const RTAX_RTT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTT;
-pub const RTAX_RTTVAR: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTTVAR;
-pub const RTAX_SSTHRESH: _bindgen_ty_62 = _bindgen_ty_62::RTAX_SSTHRESH;
-pub const RTAX_CWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CWND;
-pub const RTAX_ADVMSS: _bindgen_ty_62 = _bindgen_ty_62::RTAX_ADVMSS;
-pub const RTAX_REORDERING: _bindgen_ty_62 = _bindgen_ty_62::RTAX_REORDERING;
-pub const RTAX_HOPLIMIT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_HOPLIMIT;
-pub const RTAX_INITCWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITCWND;
-pub const RTAX_FEATURES: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FEATURES;
-pub const RTAX_RTO_MIN: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTO_MIN;
-pub const RTAX_INITRWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITRWND;
-pub const RTAX_QUICKACK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_QUICKACK;
-pub const RTAX_CC_ALGO: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CC_ALGO;
-pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FASTOPEN_NO_COOKIE;
-pub const __RTAX_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTAX_MAX;
-pub const PREFIX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_UNSPEC;
-pub const PREFIX_ADDRESS: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_ADDRESS;
-pub const PREFIX_CACHEINFO: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_CACHEINFO;
-pub const __PREFIX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__PREFIX_MAX;
-pub const TCA_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::TCA_UNSPEC;
-pub const TCA_KIND: _bindgen_ty_64 = _bindgen_ty_64::TCA_KIND;
-pub const TCA_OPTIONS: _bindgen_ty_64 = _bindgen_ty_64::TCA_OPTIONS;
-pub const TCA_STATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS;
-pub const TCA_XSTATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_XSTATS;
-pub const TCA_RATE: _bindgen_ty_64 = _bindgen_ty_64::TCA_RATE;
-pub const TCA_FCNT: _bindgen_ty_64 = _bindgen_ty_64::TCA_FCNT;
-pub const TCA_STATS2: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS2;
-pub const TCA_STAB: _bindgen_ty_64 = _bindgen_ty_64::TCA_STAB;
-pub const TCA_PAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_PAD;
-pub const TCA_DUMP_INVISIBLE: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_INVISIBLE;
-pub const TCA_CHAIN: _bindgen_ty_64 = _bindgen_ty_64::TCA_CHAIN;
-pub const TCA_HW_OFFLOAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_HW_OFFLOAD;
-pub const TCA_INGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_INGRESS_BLOCK;
-pub const TCA_EGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_EGRESS_BLOCK;
-pub const TCA_DUMP_FLAGS: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_FLAGS;
-pub const TCA_EXT_WARN_MSG: _bindgen_ty_64 = _bindgen_ty_64::TCA_EXT_WARN_MSG;
-pub const __TCA_MAX: _bindgen_ty_64 = _bindgen_ty_64::__TCA_MAX;
-pub const NDUSEROPT_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_UNSPEC;
-pub const NDUSEROPT_SRCADDR: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_SRCADDR;
-pub const __NDUSEROPT_MAX: _bindgen_ty_65 = _bindgen_ty_65::__NDUSEROPT_MAX;
-pub const TCA_ROOT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_UNSPEC;
-pub const TCA_ROOT_TAB: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TAB;
-pub const TCA_ROOT_FLAGS: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_FLAGS;
-pub const TCA_ROOT_COUNT: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_COUNT;
-pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TIME_DELTA;
-pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_EXT_WARN_MSG;
-pub const __TCA_ROOT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__TCA_ROOT_MAX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_18 = _bindgen_ty_18::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_39 = _bindgen_ty_39::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_45 = _bindgen_ty_45::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_DSA_MAX;
+pub const IFA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFA_UNSPEC;
+pub const IFA_ADDRESS: _bindgen_ty_55 = _bindgen_ty_55::IFA_ADDRESS;
+pub const IFA_LOCAL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LOCAL;
+pub const IFA_LABEL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LABEL;
+pub const IFA_BROADCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_BROADCAST;
+pub const IFA_ANYCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_ANYCAST;
+pub const IFA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::IFA_CACHEINFO;
+pub const IFA_MULTICAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_MULTICAST;
+pub const IFA_FLAGS: _bindgen_ty_55 = _bindgen_ty_55::IFA_FLAGS;
+pub const IFA_RT_PRIORITY: _bindgen_ty_55 = _bindgen_ty_55::IFA_RT_PRIORITY;
+pub const IFA_TARGET_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::IFA_TARGET_NETNSID;
+pub const IFA_PROTO: _bindgen_ty_55 = _bindgen_ty_55::IFA_PROTO;
+pub const __IFA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFA_MAX;
+pub const NDA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDA_UNSPEC;
+pub const NDA_DST: _bindgen_ty_56 = _bindgen_ty_56::NDA_DST;
+pub const NDA_LLADDR: _bindgen_ty_56 = _bindgen_ty_56::NDA_LLADDR;
+pub const NDA_CACHEINFO: _bindgen_ty_56 = _bindgen_ty_56::NDA_CACHEINFO;
+pub const NDA_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROBES;
+pub const NDA_VLAN: _bindgen_ty_56 = _bindgen_ty_56::NDA_VLAN;
+pub const NDA_PORT: _bindgen_ty_56 = _bindgen_ty_56::NDA_PORT;
+pub const NDA_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_VNI;
+pub const NDA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDA_IFINDEX;
+pub const NDA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::NDA_MASTER;
+pub const NDA_LINK_NETNSID: _bindgen_ty_56 = _bindgen_ty_56::NDA_LINK_NETNSID;
+pub const NDA_SRC_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_SRC_VNI;
+pub const NDA_PROTOCOL: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROTOCOL;
+pub const NDA_NH_ID: _bindgen_ty_56 = _bindgen_ty_56::NDA_NH_ID;
+pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_56 = _bindgen_ty_56::NDA_FDB_EXT_ATTRS;
+pub const NDA_FLAGS_EXT: _bindgen_ty_56 = _bindgen_ty_56::NDA_FLAGS_EXT;
+pub const NDA_NDM_STATE_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_STATE_MASK;
+pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_FLAGS_MASK;
+pub const __NDA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDA_MAX;
+pub const NDTPA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UNSPEC;
+pub const NDTPA_IFINDEX: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_IFINDEX;
+pub const NDTPA_REFCNT: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REFCNT;
+pub const NDTPA_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REACHABLE_TIME;
+pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_BASE_REACHABLE_TIME;
+pub const NDTPA_RETRANS_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_RETRANS_TIME;
+pub const NDTPA_GC_STALETIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_GC_STALETIME;
+pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_DELAY_PROBE_TIME;
+pub const NDTPA_QUEUE_LEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LEN;
+pub const NDTPA_APP_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_APP_PROBES;
+pub const NDTPA_UCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UCAST_PROBES;
+pub const NDTPA_MCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_PROBES;
+pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_ANYCAST_DELAY;
+pub const NDTPA_PROXY_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_DELAY;
+pub const NDTPA_PROXY_QLEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_QLEN;
+pub const NDTPA_LOCKTIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_LOCKTIME;
+pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LENBYTES;
+pub const NDTPA_MCAST_REPROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_REPROBES;
+pub const NDTPA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PAD;
+pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_INTERVAL_PROBE_TIME_MS;
+pub const __NDTPA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTPA_MAX;
+pub const NDTA_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDTA_UNSPEC;
+pub const NDTA_NAME: _bindgen_ty_58 = _bindgen_ty_58::NDTA_NAME;
+pub const NDTA_THRESH1: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH1;
+pub const NDTA_THRESH2: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH2;
+pub const NDTA_THRESH3: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH3;
+pub const NDTA_CONFIG: _bindgen_ty_58 = _bindgen_ty_58::NDTA_CONFIG;
+pub const NDTA_PARMS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PARMS;
+pub const NDTA_STATS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_STATS;
+pub const NDTA_GC_INTERVAL: _bindgen_ty_58 = _bindgen_ty_58::NDTA_GC_INTERVAL;
+pub const NDTA_PAD: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PAD;
+pub const __NDTA_MAX: _bindgen_ty_58 = _bindgen_ty_58::__NDTA_MAX;
+pub const FDB_NOTIFY_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_BIT;
+pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_INACTIVE_BIT;
+pub const NFEA_UNSPEC: _bindgen_ty_60 = _bindgen_ty_60::NFEA_UNSPEC;
+pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_60 = _bindgen_ty_60::NFEA_ACTIVITY_NOTIFY;
+pub const NFEA_DONT_REFRESH: _bindgen_ty_60 = _bindgen_ty_60::NFEA_DONT_REFRESH;
+pub const __NFEA_MAX: _bindgen_ty_60 = _bindgen_ty_60::__NFEA_MAX;
+pub const RTM_BASE: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_NEWLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_DELLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINK;
+pub const RTM_GETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINK;
+pub const RTM_SETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETLINK;
+pub const RTM_NEWADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDR;
+pub const RTM_DELADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDR;
+pub const RTM_GETADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDR;
+pub const RTM_NEWROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWROUTE;
+pub const RTM_DELROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELROUTE;
+pub const RTM_GETROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETROUTE;
+pub const RTM_NEWNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGH;
+pub const RTM_DELNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEIGH;
+pub const RTM_GETNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGH;
+pub const RTM_NEWRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWRULE;
+pub const RTM_DELRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELRULE;
+pub const RTM_GETRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETRULE;
+pub const RTM_NEWQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWQDISC;
+pub const RTM_DELQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELQDISC;
+pub const RTM_GETQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETQDISC;
+pub const RTM_NEWTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTCLASS;
+pub const RTM_DELTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTCLASS;
+pub const RTM_GETTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTCLASS;
+pub const RTM_NEWTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTFILTER;
+pub const RTM_DELTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTFILTER;
+pub const RTM_GETTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTFILTER;
+pub const RTM_NEWACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWACTION;
+pub const RTM_DELACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELACTION;
+pub const RTM_GETACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETACTION;
+pub const RTM_NEWPREFIX: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWPREFIX;
+pub const RTM_GETMULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMULTICAST;
+pub const RTM_GETANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETANYCAST;
+pub const RTM_NEWNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGHTBL;
+pub const RTM_GETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGHTBL;
+pub const RTM_SETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETNEIGHTBL;
+pub const RTM_NEWNDUSEROPT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNDUSEROPT;
+pub const RTM_NEWADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDRLABEL;
+pub const RTM_DELADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDRLABEL;
+pub const RTM_GETADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDRLABEL;
+pub const RTM_GETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETDCB;
+pub const RTM_SETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETDCB;
+pub const RTM_NEWNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNETCONF;
+pub const RTM_DELNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNETCONF;
+pub const RTM_GETNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNETCONF;
+pub const RTM_NEWMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWMDB;
+pub const RTM_DELMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELMDB;
+pub const RTM_GETMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMDB;
+pub const RTM_NEWNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNSID;
+pub const RTM_DELNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNSID;
+pub const RTM_GETNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNSID;
+pub const RTM_NEWSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWSTATS;
+pub const RTM_GETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETSTATS;
+pub const RTM_SETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETSTATS;
+pub const RTM_NEWCACHEREPORT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCACHEREPORT;
+pub const RTM_NEWCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCHAIN;
+pub const RTM_DELCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELCHAIN;
+pub const RTM_GETCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETCHAIN;
+pub const RTM_NEWNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOP;
+pub const RTM_DELNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOP;
+pub const RTM_GETNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOP;
+pub const RTM_NEWLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWLINKPROP;
+pub const RTM_DELLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINKPROP;
+pub const RTM_GETLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINKPROP;
+pub const RTM_NEWVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWVLAN;
+pub const RTM_DELVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELVLAN;
+pub const RTM_GETVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETVLAN;
+pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOPBUCKET;
+pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOPBUCKET;
+pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOPBUCKET;
+pub const RTM_NEWTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTUNNEL;
+pub const RTM_DELTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTUNNEL;
+pub const RTM_GETTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTUNNEL;
+pub const __RTM_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTM_MAX;
+pub const RTN_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNSPEC;
+pub const RTN_UNICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNICAST;
+pub const RTN_LOCAL: _bindgen_ty_62 = _bindgen_ty_62::RTN_LOCAL;
+pub const RTN_BROADCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_BROADCAST;
+pub const RTN_ANYCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_ANYCAST;
+pub const RTN_MULTICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_MULTICAST;
+pub const RTN_BLACKHOLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_BLACKHOLE;
+pub const RTN_UNREACHABLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNREACHABLE;
+pub const RTN_PROHIBIT: _bindgen_ty_62 = _bindgen_ty_62::RTN_PROHIBIT;
+pub const RTN_THROW: _bindgen_ty_62 = _bindgen_ty_62::RTN_THROW;
+pub const RTN_NAT: _bindgen_ty_62 = _bindgen_ty_62::RTN_NAT;
+pub const RTN_XRESOLVE: _bindgen_ty_62 = _bindgen_ty_62::RTN_XRESOLVE;
+pub const __RTN_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTN_MAX;
+pub const RTAX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::RTAX_UNSPEC;
+pub const RTAX_LOCK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_LOCK;
+pub const RTAX_MTU: _bindgen_ty_63 = _bindgen_ty_63::RTAX_MTU;
+pub const RTAX_WINDOW: _bindgen_ty_63 = _bindgen_ty_63::RTAX_WINDOW;
+pub const RTAX_RTT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTT;
+pub const RTAX_RTTVAR: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTTVAR;
+pub const RTAX_SSTHRESH: _bindgen_ty_63 = _bindgen_ty_63::RTAX_SSTHRESH;
+pub const RTAX_CWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CWND;
+pub const RTAX_ADVMSS: _bindgen_ty_63 = _bindgen_ty_63::RTAX_ADVMSS;
+pub const RTAX_REORDERING: _bindgen_ty_63 = _bindgen_ty_63::RTAX_REORDERING;
+pub const RTAX_HOPLIMIT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_HOPLIMIT;
+pub const RTAX_INITCWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITCWND;
+pub const RTAX_FEATURES: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FEATURES;
+pub const RTAX_RTO_MIN: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTO_MIN;
+pub const RTAX_INITRWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITRWND;
+pub const RTAX_QUICKACK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_QUICKACK;
+pub const RTAX_CC_ALGO: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CC_ALGO;
+pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FASTOPEN_NO_COOKIE;
+pub const __RTAX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__RTAX_MAX;
+pub const PREFIX_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_UNSPEC;
+pub const PREFIX_ADDRESS: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_ADDRESS;
+pub const PREFIX_CACHEINFO: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_CACHEINFO;
+pub const __PREFIX_MAX: _bindgen_ty_64 = _bindgen_ty_64::__PREFIX_MAX;
+pub const TCA_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::TCA_UNSPEC;
+pub const TCA_KIND: _bindgen_ty_65 = _bindgen_ty_65::TCA_KIND;
+pub const TCA_OPTIONS: _bindgen_ty_65 = _bindgen_ty_65::TCA_OPTIONS;
+pub const TCA_STATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS;
+pub const TCA_XSTATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_XSTATS;
+pub const TCA_RATE: _bindgen_ty_65 = _bindgen_ty_65::TCA_RATE;
+pub const TCA_FCNT: _bindgen_ty_65 = _bindgen_ty_65::TCA_FCNT;
+pub const TCA_STATS2: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS2;
+pub const TCA_STAB: _bindgen_ty_65 = _bindgen_ty_65::TCA_STAB;
+pub const TCA_PAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_PAD;
+pub const TCA_DUMP_INVISIBLE: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_INVISIBLE;
+pub const TCA_CHAIN: _bindgen_ty_65 = _bindgen_ty_65::TCA_CHAIN;
+pub const TCA_HW_OFFLOAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_HW_OFFLOAD;
+pub const TCA_INGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_INGRESS_BLOCK;
+pub const TCA_EGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_EGRESS_BLOCK;
+pub const TCA_DUMP_FLAGS: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_FLAGS;
+pub const TCA_EXT_WARN_MSG: _bindgen_ty_65 = _bindgen_ty_65::TCA_EXT_WARN_MSG;
+pub const __TCA_MAX: _bindgen_ty_65 = _bindgen_ty_65::__TCA_MAX;
+pub const NDUSEROPT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_UNSPEC;
+pub const NDUSEROPT_SRCADDR: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_SRCADDR;
+pub const __NDUSEROPT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__NDUSEROPT_MAX;
+pub const TCA_ROOT_UNSPEC: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_UNSPEC;
+pub const TCA_ROOT_TAB: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TAB;
+pub const TCA_ROOT_FLAGS: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_FLAGS;
+pub const TCA_ROOT_COUNT: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_COUNT;
+pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TIME_DELTA;
+pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_EXT_WARN_MSG;
+pub const __TCA_ROOT_MAX: _bindgen_ty_67 = _bindgen_ty_67::__TCA_ROOT_MAX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1548,6 +1562,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1637,7 +1653,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1733,7 +1750,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1790,7 +1809,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1943,10 +1963,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_18 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_19 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -1962,7 +2010,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_19 {
+pub enum _bindgen_ty_20 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -1974,7 +2022,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_20 {
+pub enum _bindgen_ty_21 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -1982,7 +2030,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2015,7 +2063,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2029,7 +2078,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_23 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2059,7 +2116,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2070,7 +2127,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum _bindgen_ty_25 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2085,7 +2142,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2098,7 +2155,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2136,7 +2193,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2148,7 +2205,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2164,7 +2221,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2172,7 +2229,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2192,7 +2249,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2200,7 +2257,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2209,7 +2266,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2224,7 +2281,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2232,7 +2289,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2246,7 +2303,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2255,7 +2312,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2273,7 +2330,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2283,14 +2340,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2298,7 +2355,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2312,7 +2369,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2324,7 +2381,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2333,7 +2390,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2342,7 +2399,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2352,7 +2409,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2361,7 +2418,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2371,7 +2428,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2386,7 +2443,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2398,7 +2455,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2414,7 +2471,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2423,7 +2480,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2431,15 +2488,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFA_UNSPEC = 0,
 IFA_ADDRESS = 1,
 IFA_LOCAL = 2,
@@ -2457,7 +2514,7 @@ __IFA_MAX = 12,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 NDA_UNSPEC = 0,
 NDA_DST = 1,
 NDA_LLADDR = 2,
@@ -2481,7 +2538,7 @@ __NDA_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 NDTPA_UNSPEC = 0,
 NDTPA_IFINDEX = 1,
 NDTPA_REFCNT = 2,
@@ -2507,7 +2564,7 @@ __NDTPA_MAX = 20,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_57 {
+pub enum _bindgen_ty_58 {
 NDTA_UNSPEC = 0,
 NDTA_NAME = 1,
 NDTA_THRESH1 = 2,
@@ -2523,14 +2580,14 @@ __NDTA_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_58 {
+pub enum _bindgen_ty_59 {
 FDB_NOTIFY_BIT = 1,
 FDB_NOTIFY_INACTIVE_BIT = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_59 {
+pub enum _bindgen_ty_60 {
 NFEA_UNSPEC = 0,
 NFEA_ACTIVITY_NOTIFY = 1,
 NFEA_DONT_REFRESH = 2,
@@ -2539,7 +2596,7 @@ __NFEA_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_60 {
+pub enum _bindgen_ty_61 {
 RTM_BASE = 16,
 RTM_DELLINK = 17,
 RTM_GETLINK = 18,
@@ -2616,7 +2673,7 @@ __RTM_MAX = 123,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_61 {
+pub enum _bindgen_ty_62 {
 RTN_UNSPEC = 0,
 RTN_UNICAST = 1,
 RTN_LOCAL = 2,
@@ -2692,7 +2749,7 @@ __RTA_MAX = 31,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_62 {
+pub enum _bindgen_ty_63 {
 RTAX_UNSPEC = 0,
 RTAX_LOCK = 1,
 RTAX_MTU = 2,
@@ -2716,7 +2773,7 @@ __RTAX_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_63 {
+pub enum _bindgen_ty_64 {
 PREFIX_UNSPEC = 0,
 PREFIX_ADDRESS = 1,
 PREFIX_CACHEINFO = 2,
@@ -2725,7 +2782,7 @@ __PREFIX_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_64 {
+pub enum _bindgen_ty_65 {
 TCA_UNSPEC = 0,
 TCA_KIND = 1,
 TCA_OPTIONS = 2,
@@ -2748,7 +2805,7 @@ __TCA_MAX = 17,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_65 {
+pub enum _bindgen_ty_66 {
 NDUSEROPT_UNSPEC = 0,
 NDUSEROPT_SRCADDR = 1,
 __NDUSEROPT_MAX = 2,
@@ -2799,7 +2856,7 @@ __RTNLGRP_MAX = 37,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_66 {
+pub enum _bindgen_ty_67 {
 TCA_ROOT_UNSPEC = 0,
 TCA_ROOT_TAB = 1,
 TCA_ROOT_FLAGS = 2,
@@ -2862,6 +2919,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/powerpc64/prctl.rs
+++ b/src/powerpc64/prctl.rs
@@ -224,6 +224,7 @@ pub const PR_SME_VL_LEN_MASK: u32 = 65535;
 pub const PR_SME_VL_INHERIT: u32 = 131072;
 pub const PR_SET_MDWE: u32 = 65;
 pub const PR_MDWE_REFUSE_EXEC_GAIN: u32 = 1;
+pub const PR_MDWE_NO_INHERIT: u32 = 2;
 pub const PR_GET_MDWE: u32 = 66;
 pub const PR_SET_VMA: u32 = 1398164801;
 pub const PR_SET_VMA_ANON_NAME: u32 = 0;

--- a/src/powerpc64/xdp.rs
+++ b/src/powerpc64/xdp.rs
@@ -89,6 +89,7 @@ pub len: __u64,
 pub chunk_size: __u32,
 pub headroom: __u32,
 pub flags: __u32,
+pub tx_metadata_len: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -104,6 +105,23 @@ pub tx_ring_empty_descs: __u64,
 #[derive(Debug, Copy, Clone)]
 pub struct xdp_options {
 pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct xsk_tx_metadata {
+pub flags: __u64,
+pub __bindgen_anon_1: xsk_tx_metadata__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1 {
+pub csum_start: __u16,
+pub csum_offset: __u16,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2 {
+pub tx_timestamp: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -146,7 +164,9 @@ pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
 pub const XDP_USE_NEED_WAKEUP: u32 = 8;
+pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
+pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;
@@ -163,5 +183,13 @@ pub const XDP_UMEM_PGOFF_FILL_RING: u64 = 4294967296;
 pub const XDP_UMEM_PGOFF_COMPLETION_RING: u64 = 6442450944;
 pub const XSK_UNALIGNED_BUF_OFFSET_SHIFT: u32 = 48;
 pub const XSK_UNALIGNED_BUF_ADDR_MASK: u64 = 281474976710655;
-pub const XDP_USE_SG: u32 = 16;
+pub const XDP_TXMD_FLAGS_TIMESTAMP: u32 = 1;
+pub const XDP_TXMD_FLAGS_CHECKSUM: u32 = 2;
 pub const XDP_PKT_CONTD: u32 = 1;
+pub const XDP_TX_METADATA: u32 = 2;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union xsk_tx_metadata__bindgen_ty_1 {
+pub request: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1,
+pub completion: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2,
+}

--- a/src/riscv32/general.rs
+++ b/src/riscv32/general.rs
@@ -181,7 +181,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -236,6 +237,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -294,6 +328,29 @@ pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
 pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -388,36 +445,6 @@ pub it_value: __kernel_old_timeval,
 pub struct __kernel_sock_timeval {
 pub tv_sec: __s64,
 pub tv_usec: __s64,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timespec {
-pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: crate::ctypes::c_long,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timeval {
-pub tv_sec: __kernel_old_time_t,
-pub tv_usec: __kernel_suseconds_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerspec {
-pub it_interval: timespec,
-pub it_value: timespec,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerval {
-pub it_interval: timeval,
-pub it_value: timeval,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timezone {
-pub tz_minuteswest: crate::ctypes::c_int,
-pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -670,6 +697,36 @@ pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct timespec {
+pub tv_sec: __kernel_old_time_t,
+pub tv_nsec: crate::ctypes::c_long,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timeval {
+pub tv_sec: __kernel_old_time_t,
+pub tv_usec: __kernel_suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerspec {
+pub it_interval: timespec,
+pub it_value: timespec,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerval {
+pub it_interval: timeval,
+pub it_value: timeval,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timezone {
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct iovec {
 pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
@@ -763,6 +820,22 @@ pub struct uffdio_continue {
 pub range: uffdio_range,
 pub mode: __u64,
 pub mapped: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_poison {
+pub range: uffdio_range,
+pub mode: __u64,
+pub updated: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_move {
+pub dst: __u64,
+pub src: __u64,
+pub len: __u64,
+pub mode: __u64,
+pub move_: __s64,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -891,9 +964,9 @@ pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 394496;
+pub const LINUX_VERSION_CODE: u32 = 395264;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 5;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_L1I_CACHESIZE: u32 = 40;
@@ -1273,6 +1346,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1344,6 +1425,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const FUTEX_WAIT: u32 = 0;
 pub const FUTEX_WAKE: u32 = 1;
 pub const FUTEX_FD: u32 = 2;
@@ -1374,6 +1465,13 @@ pub const FUTEX_WAIT_BITSET_PRIVATE: u32 = 137;
 pub const FUTEX_WAKE_BITSET_PRIVATE: u32 = 138;
 pub const FUTEX_WAIT_REQUEUE_PI_PRIVATE: u32 = 139;
 pub const FUTEX_CMP_REQUEUE_PI_PRIVATE: u32 = 140;
+pub const FUTEX2_SIZE_U8: u32 = 0;
+pub const FUTEX2_SIZE_U16: u32 = 1;
+pub const FUTEX2_SIZE_U32: u32 = 2;
+pub const FUTEX2_SIZE_U64: u32 = 3;
+pub const FUTEX2_NUMA: u32 = 4;
+pub const FUTEX2_PRIVATE: u32 = 128;
+pub const FUTEX2_SIZE_MASK: u32 = 3;
 pub const FUTEX_32: u32 = 2;
 pub const FUTEX_WAITV_MAX: u32 = 128;
 pub const FUTEX_WAITERS: u32 = 2147483648;
@@ -1630,25 +1728,6 @@ pub const LINUX_REBOOT_CMD_POWER_OFF: u32 = 1126301404;
 pub const LINUX_REBOOT_CMD_RESTART2: u32 = 2712847316;
 pub const LINUX_REBOOT_CMD_SW_SUSPEND: u32 = 3489725666;
 pub const LINUX_REBOOT_CMD_KEXEC: u32 = 1163412803;
-pub const ITIMER_REAL: u32 = 0;
-pub const ITIMER_VIRTUAL: u32 = 1;
-pub const ITIMER_PROF: u32 = 2;
-pub const CLOCK_REALTIME: u32 = 0;
-pub const CLOCK_MONOTONIC: u32 = 1;
-pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
-pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
-pub const CLOCK_MONOTONIC_RAW: u32 = 4;
-pub const CLOCK_REALTIME_COARSE: u32 = 5;
-pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
-pub const CLOCK_BOOTTIME: u32 = 7;
-pub const CLOCK_REALTIME_ALARM: u32 = 8;
-pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
-pub const CLOCK_SGI_CYCLE: u32 = 10;
-pub const CLOCK_TAI: u32 = 11;
-pub const MAX_CLOCKS: u32 = 16;
-pub const CLOCKS_MASK: u32 = 1;
-pub const CLOCKS_MONO: u32 = 1;
-pub const TIMER_ABSTIME: u32 = 1;
 pub const RUSAGE_SELF: u32 = 0;
 pub const RUSAGE_CHILDREN: i32 = -1;
 pub const RUSAGE_BOTH: i32 = -2;
@@ -1828,7 +1907,8 @@ pub const SEGV_ADIDERR: u32 = 6;
 pub const SEGV_ADIPERR: u32 = 7;
 pub const SEGV_MTEAERR: u32 = 8;
 pub const SEGV_MTESERR: u32 = 9;
-pub const NSIGSEGV: u32 = 9;
+pub const SEGV_CPERR: u32 = 10;
+pub const NSIGSEGV: u32 = 10;
 pub const BUS_ADRALN: u32 = 1;
 pub const BUS_ADRERR: u32 = 2;
 pub const BUS_OBJERR: u32 = 3;
@@ -1909,6 +1989,7 @@ pub const STATX_BASIC_STATS: u32 = 2047;
 pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
+pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2086,6 +2167,25 @@ pub const TIOCM_RI: u32 = 128;
 pub const TIOCM_OUT1: u32 = 8192;
 pub const TIOCM_OUT2: u32 = 16384;
 pub const TIOCM_LOOP: u32 = 32768;
+pub const ITIMER_REAL: u32 = 0;
+pub const ITIMER_VIRTUAL: u32 = 1;
+pub const ITIMER_PROF: u32 = 2;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_SGI_CYCLE: u32 = 10;
+pub const CLOCK_TAI: u32 = 11;
+pub const MAX_CLOCKS: u32 = 16;
+pub const CLOCKS_MASK: u32 = 1;
+pub const CLOCKS_MONO: u32 = 1;
+pub const TIMER_ABSTIME: u32 = 1;
 pub const UIO_FASTIOV: u32 = 8;
 pub const UIO_MAXIOV: u32 = 1024;
 pub const __NR_io_setup: u32 = 0;
@@ -2385,7 +2485,17 @@ pub const __NR_process_mrelease: u32 = 448;
 pub const __NR_futex_waitv: u32 = 449;
 pub const __NR_set_mempolicy_home_node: u32 = 450;
 pub const __NR_cachestat: u32 = 451;
-pub const __NR_syscalls: u32 = 452;
+pub const __NR_fchmodat2: u32 = 452;
+pub const __NR_map_shadow_stack: u32 = 453;
+pub const __NR_futex_wake: u32 = 454;
+pub const __NR_futex_wait: u32 = 455;
+pub const __NR_futex_requeue: u32 = 456;
+pub const __NR_statmount: u32 = 457;
+pub const __NR_listmount: u32 = 458;
+pub const __NR_lsm_get_self_attr: u32 = 459;
+pub const __NR_lsm_set_self_attr: u32 = 460;
+pub const __NR_lsm_list_modules: u32 = 461;
+pub const __NR_syscalls: u32 = 462;
 pub const __NR_fcntl64: u32 = 25;
 pub const __NR_statfs64: u32 = 43;
 pub const __NR_fstatfs64: u32 = 44;
@@ -2475,8 +2585,10 @@ pub const _UFFDIO_UNREGISTER: u32 = 1;
 pub const _UFFDIO_WAKE: u32 = 2;
 pub const _UFFDIO_COPY: u32 = 3;
 pub const _UFFDIO_ZEROPAGE: u32 = 4;
+pub const _UFFDIO_MOVE: u32 = 5;
 pub const _UFFDIO_WRITEPROTECT: u32 = 6;
 pub const _UFFDIO_CONTINUE: u32 = 7;
+pub const _UFFDIO_POISON: u32 = 8;
 pub const _UFFDIO_API: u32 = 63;
 pub const UFFDIO: u32 = 170;
 pub const UFFD_EVENT_PAGEFAULT: u32 = 18;
@@ -2501,6 +2613,9 @@ pub const UFFD_FEATURE_MINOR_SHMEM: u32 = 1024;
 pub const UFFD_FEATURE_EXACT_ADDRESS: u32 = 2048;
 pub const UFFD_FEATURE_WP_HUGETLBFS_SHMEM: u32 = 4096;
 pub const UFFD_FEATURE_WP_UNPOPULATED: u32 = 8192;
+pub const UFFD_FEATURE_POISON: u32 = 16384;
+pub const UFFD_FEATURE_WP_ASYNC: u32 = 32768;
+pub const UFFD_FEATURE_MOVE: u32 = 65536;
 pub const UFFD_USER_MODE_ONLY: u32 = 1;
 pub const DT_UNKNOWN: u32 = 0;
 pub const DT_FIFO: u32 = 1;
@@ -2575,6 +2690,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/riscv32/if_arp.rs
+++ b/src/riscv32/if_arp.rs
@@ -50,11 +50,6 @@ pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
@@ -173,6 +168,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -180,23 +176,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -1124,6 +1105,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_4 = _bindgen_ty_4::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_4 = _bindgen_ty_4::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_MASK;
@@ -1192,6 +1174,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_HAIRPIN;
@@ -1239,6 +1223,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_10 = _bindgen_ty_10::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_KIND;
@@ -1300,301 +1285,310 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_19 = _bindgen_ty_19::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_40 = _bindgen_ty_40::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_46 = _bindgen_ty_46::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_DSA_MAX;
-pub const IF_PORT_UNKNOWN: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_UNKNOWN;
-pub const IF_PORT_10BASE2: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASE2;
-pub const IF_PORT_10BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASET;
-pub const IF_PORT_AUI: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_AUI;
-pub const IF_PORT_100BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASET;
-pub const IF_PORT_100BASETX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASETX;
-pub const IF_PORT_100BASEFX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASEFX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_20 = _bindgen_ty_20::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_23 = _bindgen_ty_23::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_47 = _bindgen_ty_47::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__IFLA_DSA_MAX;
+pub const IF_PORT_UNKNOWN: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_UNKNOWN;
+pub const IF_PORT_10BASE2: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASE2;
+pub const IF_PORT_10BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASET;
+pub const IF_PORT_AUI: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_AUI;
+pub const IF_PORT_100BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASET;
+pub const IF_PORT_100BASETX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASETX;
+pub const IF_PORT_100BASEFX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASEFX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1697,6 +1691,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1786,7 +1782,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1882,7 +1879,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1939,7 +1938,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2092,10 +2092,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_20 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_21 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -2111,7 +2139,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -2123,7 +2151,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum _bindgen_ty_23 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -2131,7 +2159,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2164,7 +2192,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2178,7 +2207,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_25 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2208,7 +2245,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2219,7 +2256,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2234,7 +2271,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2247,7 +2284,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2285,7 +2322,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2297,7 +2334,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2313,7 +2350,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2321,7 +2358,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2341,7 +2378,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2349,7 +2386,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2358,7 +2395,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2373,7 +2410,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2381,7 +2418,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2395,7 +2432,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2404,7 +2441,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2422,7 +2459,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2432,14 +2469,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2447,7 +2484,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2461,7 +2498,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2473,7 +2510,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2482,7 +2519,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2491,7 +2528,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2501,7 +2538,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2510,7 +2547,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2520,7 +2557,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2535,7 +2572,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2547,7 +2584,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2563,7 +2600,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2572,7 +2609,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2580,15 +2617,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 IF_PORT_UNKNOWN = 0,
 IF_PORT_10BASE2 = 1,
 IF_PORT_10BASET = 2,
@@ -2671,74 +2708,6 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 impl nlmsgerr_attrs {
 pub const NLMSGERR_ATTR_MAX: nlmsgerr_attrs = nlmsgerr_attrs::NLMSGERR_ATTR_MISS_NEST;
 }
@@ -2753,6 +2722,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/riscv32/if_packet.rs
+++ b/src/riscv32/if_packet.rs
@@ -49,11 +49,6 @@ pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_pkt {
 pub spkt_family: crate::ctypes::c_ushort,
@@ -61,6 +56,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -68,23 +64,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -325,71 +306,3 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}

--- a/src/riscv32/io_uring.rs
+++ b/src/riscv32/io_uring.rs
@@ -77,7 +77,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -132,6 +133,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -193,6 +227,29 @@ pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
 pub tv_nsec: crate::ctypes::c_longlong,
@@ -251,6 +308,12 @@ pub __pad1: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_sqe__bindgen_ty_2__bindgen_ty_1 {
+pub level: __u32,
+pub optname: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_sqe__bindgen_ty_5__bindgen_ty_1 {
 pub addr_len: __u16,
 pub __pad3: [__u16; 1usize],
@@ -258,6 +321,7 @@ pub __pad3: [__u16; 1usize],
 #[repr(C)]
 pub struct io_uring_sqe__bindgen_ty_6 {
 pub __bindgen_anon_1: __BindgenUnionField<io_uring_sqe__bindgen_ty_6__bindgen_ty_1>,
+pub optval: __BindgenUnionField<__u64>,
 pub cmd: __BindgenUnionField<[__u8; 0usize]>,
 pub bindgen_union_field: [u64; 2usize],
 }
@@ -419,6 +483,13 @@ pub resv: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_buf_status {
+pub buf_group: __u32,
+pub head: __u32,
+pub resv: [__u32; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -432,7 +503,9 @@ pub addr: __u64,
 pub fd: __s32,
 pub flags: __u32,
 pub timeout: __kernel_timespec,
-pub pad: [__u64; 4usize],
+pub opcode: __u8,
+pub pad: [__u8; 7usize],
+pub pad2: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -595,6 +668,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -666,6 +747,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const IORING_FILE_INDEX_ALLOC: i32 = -1;
 pub const IORING_SETUP_IOPOLL: u32 = 1;
 pub const IORING_SETUP_SQPOLL: u32 = 2;
@@ -683,8 +774,9 @@ pub const IORING_SETUP_SINGLE_ISSUER: u32 = 4096;
 pub const IORING_SETUP_DEFER_TASKRUN: u32 = 8192;
 pub const IORING_SETUP_NO_MMAP: u32 = 16384;
 pub const IORING_SETUP_REGISTERED_FD_ONLY: u32 = 32768;
+pub const IORING_SETUP_NO_SQARRAY: u32 = 65536;
 pub const IORING_URING_CMD_FIXED: u32 = 1;
-pub const IORING_URING_CMD_POLLED: u32 = 2147483648;
+pub const IORING_URING_CMD_MASK: u32 = 1;
 pub const IORING_FSYNC_DATASYNC: u32 = 1;
 pub const IORING_TIMEOUT_ABS: u32 = 1;
 pub const IORING_TIMEOUT_UPDATE: u32 = 2;
@@ -704,6 +796,8 @@ pub const IORING_ASYNC_CANCEL_ALL: u32 = 1;
 pub const IORING_ASYNC_CANCEL_FD: u32 = 2;
 pub const IORING_ASYNC_CANCEL_ANY: u32 = 4;
 pub const IORING_ASYNC_CANCEL_FD_FIXED: u32 = 8;
+pub const IORING_ASYNC_CANCEL_USERDATA: u32 = 16;
+pub const IORING_ASYNC_CANCEL_OP: u32 = 32;
 pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
@@ -712,6 +806,7 @@ pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
+pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
@@ -784,6 +879,7 @@ pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGIS
 pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
 pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
 pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
+pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
 pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
 pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
 pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
@@ -794,6 +890,10 @@ pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTR
 pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
 pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
 pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
+pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
+pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
+pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
+pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -806,6 +906,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -872,7 +973,13 @@ IORING_OP_SOCKET = 45,
 IORING_OP_URING_CMD = 46,
 IORING_OP_SEND_ZC = 47,
 IORING_OP_SENDMSG_ZC = 48,
-IORING_OP_LAST = 49,
+IORING_OP_READ_MULTISHOT = 49,
+IORING_OP_WAITID = 50,
+IORING_OP_FUTEX_WAIT = 51,
+IORING_OP_FUTEX_WAKE = 52,
+IORING_OP_FUTEX_WAITV = 53,
+IORING_OP_FIXED_FD_INSTALL = 54,
+IORING_OP_LAST = 55,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -917,7 +1024,8 @@ IORING_REGISTER_PBUF_RING = 22,
 IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
-IORING_REGISTER_LAST = 26,
+IORING_REGISTER_PBUF_STATUS = 26,
+IORING_REGISTER_LAST = 27,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
@@ -942,6 +1050,15 @@ IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
 IORING_RESTRICTION_SQE_FLAGS_REQUIRED = 3,
 IORING_RESTRICTION_LAST = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_8 {
+SOCKET_URING_OP_SIOCINQ = 0,
+SOCKET_URING_OP_SIOCOUTQ = 1,
+SOCKET_URING_OP_GETSOCKOPT = 2,
+SOCKET_URING_OP_SETSOCKOPT = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -969,6 +1086,7 @@ pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_1__bindgen_ty_1,
 pub union io_uring_sqe__bindgen_ty_2 {
 pub addr: __u64,
 pub splice_off_in: __u64,
+pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_2__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -992,6 +1110,9 @@ pub hardlink_flags: __u32,
 pub xattr_flags: __u32,
 pub msg_ring_flags: __u32,
 pub uring_cmd_flags: __u32,
+pub waitid_flags: __u32,
+pub futex_flags: __u32,
+pub install_fd_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]
@@ -1004,6 +1125,7 @@ pub buf_group: __u16,
 pub union io_uring_sqe__bindgen_ty_5 {
 pub splice_fd_in: __s32,
 pub file_index: __u32,
+pub optlen: __u32,
 pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]

--- a/src/riscv32/net.rs
+++ b/src/riscv32/net.rs
@@ -427,6 +427,9 @@ pub tcpi_rcv_ooopack: __u32,
 pub tcpi_snd_wnd: __u32,
 pub tcpi_rcv_wnd: __u32,
 pub tcpi_rehash: __u32,
+pub tcpi_total_rto: __u16,
+pub tcpi_total_rto_recoveries: __u16,
+pub tcpi_total_rto_time: __u32,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -446,6 +449,82 @@ pub tcpm_prefixlen: __u8,
 pub tcpm_keylen: __u16,
 pub tcpm_addr: [__be32; 4usize],
 pub tcpm_key: [__u8; 80usize],
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_add {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub key: [__u8; 80usize],
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_del {
+pub addr: __kernel_sockaddr_storage,
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub current_key: __u8,
+pub rnext: __u8,
+pub keyflags: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_info_opt {
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub current_key: __u8,
+pub rnext: __u8,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+pub pkt_key_not_found: __u64,
+pub pkt_ao_required: __u64,
+pub pkt_dropped_icmp: __u64,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_getsockopt {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub key: [__u8; 80usize],
+pub nkeys: __u32,
+pub _bitfield_align_1: [u16; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub prefix: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub ifindex: __s32,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_repair {
+pub snt_isn: __be32,
+pub rcv_isn: __be32,
+pub snd_sne: __u32,
+pub rcv_sne: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1175,6 +1254,11 @@ pub const TCP_ZEROCOPY_RECEIVE: u32 = 35;
 pub const TCP_INQ: u32 = 36;
 pub const TCP_CM_INQ: u32 = 36;
 pub const TCP_TX_DELAY: u32 = 37;
+pub const TCP_AO_ADD_KEY: u32 = 38;
+pub const TCP_AO_DEL_KEY: u32 = 39;
+pub const TCP_AO_INFO: u32 = 40;
+pub const TCP_AO_GET_KEYS: u32 = 41;
+pub const TCP_AO_REPAIR: u32 = 42;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1184,9 +1268,13 @@ pub const TCPI_OPT_WSCALE: u32 = 4;
 pub const TCPI_OPT_ECN: u32 = 8;
 pub const TCPI_OPT_ECN_SEEN: u32 = 16;
 pub const TCPI_OPT_SYN_DATA: u32 = 32;
+pub const TCPI_OPT_USEC_TS: u32 = 64;
 pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
+pub const TCP_AO_MAXKEYLEN: u32 = 80;
+pub const TCP_AO_KEYF_IFINDEX: u32 = 1;
+pub const TCP_AO_KEYF_EXCLUDE_OPT: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
@@ -1551,6 +1639,7 @@ pub const DEVCONF_IOAM6_ID: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID;
 pub const DEVCONF_IOAM6_ID_WIDE: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID_WIDE;
 pub const DEVCONF_NDISC_EVICT_NOCARRIER: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_NDISC_EVICT_NOCARRIER;
 pub const DEVCONF_ACCEPT_UNTRACKED_NA: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_UNTRACKED_NA;
+pub const DEVCONF_ACCEPT_RA_MIN_LFT: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_RA_MIN_LFT;
 pub const DEVCONF_MAX: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_MAX;
 pub const TCP_FLAG_CWR: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_CWR;
 pub const TCP_FLAG_ECE: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_ECE;
@@ -1748,7 +1837,8 @@ DEVCONF_IOAM6_ID = 54,
 DEVCONF_IOAM6_ID_WIDE = 55,
 DEVCONF_NDISC_EVICT_NOCARRIER = 56,
 DEVCONF_ACCEPT_UNTRACKED_NA = 57,
-DEVCONF_MAX = 58,
+DEVCONF_ACCEPT_RA_MIN_LFT = 58,
+DEVCONF_MAX = 59,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2466,6 +2556,289 @@ tcpi_delivery_rate_app_limited as u64
 __bindgen_bitfield_unit.set(9usize, 2u8, {
 let tcpi_fastopen_client_fail: u8 = unsafe { ::core::mem::transmute(tcpi_fastopen_client_fail) };
 tcpi_fastopen_client_fail as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_add {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 30u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 30u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_del {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn del_async(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_del_async(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 29u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 29u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, del_async: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let del_async: u32 = unsafe { ::core::mem::transmute(del_async) };
+del_async as u64
+});
+__bindgen_bitfield_unit.set(3usize, 29u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_info_opt {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn ao_required(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_ao_required(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_counters(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_counters(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn accept_icmps(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_accept_icmps(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(4usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(5usize, 27u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(5usize, 27u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, ao_required: __u32, set_counters: __u32, accept_icmps: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let ao_required: u32 = unsafe { ::core::mem::transmute(ao_required) };
+ao_required as u64
+});
+__bindgen_bitfield_unit.set(3usize, 1u8, {
+let set_counters: u32 = unsafe { ::core::mem::transmute(set_counters) };
+set_counters as u64
+});
+__bindgen_bitfield_unit.set(4usize, 1u8, {
+let accept_icmps: u32 = unsafe { ::core::mem::transmute(accept_icmps) };
+accept_icmps as u64
+});
+__bindgen_bitfield_unit.set(5usize, 27u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_getsockopt {
+#[inline]
+pub fn is_current(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_current(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn is_rnext(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_rnext(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn get_all(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_get_all(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 13u8) as u16) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 13u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(is_current: __u16, is_rnext: __u16, get_all: __u16, reserved: __u16) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let is_current: u16 = unsafe { ::core::mem::transmute(is_current) };
+is_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let is_rnext: u16 = unsafe { ::core::mem::transmute(is_rnext) };
+is_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let get_all: u16 = unsafe { ::core::mem::transmute(get_all) };
+get_all as u64
+});
+__bindgen_bitfield_unit.set(3usize, 13u8, {
+let reserved: u16 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
 });
 __bindgen_bitfield_unit
 }

--- a/src/riscv32/netlink.rs
+++ b/src/riscv32/netlink.rs
@@ -722,7 +722,8 @@ pub const RTAX_FEATURE_ECN: u32 = 1;
 pub const RTAX_FEATURE_SACK: u32 = 2;
 pub const RTAX_FEATURE_TIMESTAMP: u32 = 4;
 pub const RTAX_FEATURE_ALLFRAG: u32 = 8;
-pub const RTAX_FEATURE_MASK: u32 = 15;
+pub const RTAX_FEATURE_TCP_USEC_TS: u32 = 16;
+pub const RTAX_FEATURE_MASK: u32 = 31;
 pub const TCM_IFINDEX_MAGIC_BLOCK: u32 = 4294967295;
 pub const TCA_DUMP_FLAGS_TERSE: u32 = 1;
 pub const RTMGRP_LINK: u32 = 1;
@@ -819,6 +820,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_2 = _bindgen_ty_2::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_2 = _bindgen_ty_2::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_MASK;
@@ -887,6 +889,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_6 = _bindgen_ty_6::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_HAIRPIN;
@@ -934,6 +938,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_KIND;
@@ -995,501 +1000,510 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_17 = _bindgen_ty_17::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_18 = _bindgen_ty_18::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_21 = _bindgen_ty_21::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_44 = _bindgen_ty_44::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_DSA_MAX;
-pub const IFA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFA_UNSPEC;
-pub const IFA_ADDRESS: _bindgen_ty_54 = _bindgen_ty_54::IFA_ADDRESS;
-pub const IFA_LOCAL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LOCAL;
-pub const IFA_LABEL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LABEL;
-pub const IFA_BROADCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_BROADCAST;
-pub const IFA_ANYCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_ANYCAST;
-pub const IFA_CACHEINFO: _bindgen_ty_54 = _bindgen_ty_54::IFA_CACHEINFO;
-pub const IFA_MULTICAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_MULTICAST;
-pub const IFA_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFA_FLAGS;
-pub const IFA_RT_PRIORITY: _bindgen_ty_54 = _bindgen_ty_54::IFA_RT_PRIORITY;
-pub const IFA_TARGET_NETNSID: _bindgen_ty_54 = _bindgen_ty_54::IFA_TARGET_NETNSID;
-pub const IFA_PROTO: _bindgen_ty_54 = _bindgen_ty_54::IFA_PROTO;
-pub const __IFA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFA_MAX;
-pub const NDA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::NDA_UNSPEC;
-pub const NDA_DST: _bindgen_ty_55 = _bindgen_ty_55::NDA_DST;
-pub const NDA_LLADDR: _bindgen_ty_55 = _bindgen_ty_55::NDA_LLADDR;
-pub const NDA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::NDA_CACHEINFO;
-pub const NDA_PROBES: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROBES;
-pub const NDA_VLAN: _bindgen_ty_55 = _bindgen_ty_55::NDA_VLAN;
-pub const NDA_PORT: _bindgen_ty_55 = _bindgen_ty_55::NDA_PORT;
-pub const NDA_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_VNI;
-pub const NDA_IFINDEX: _bindgen_ty_55 = _bindgen_ty_55::NDA_IFINDEX;
-pub const NDA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::NDA_MASTER;
-pub const NDA_LINK_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::NDA_LINK_NETNSID;
-pub const NDA_SRC_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_SRC_VNI;
-pub const NDA_PROTOCOL: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROTOCOL;
-pub const NDA_NH_ID: _bindgen_ty_55 = _bindgen_ty_55::NDA_NH_ID;
-pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_55 = _bindgen_ty_55::NDA_FDB_EXT_ATTRS;
-pub const NDA_FLAGS_EXT: _bindgen_ty_55 = _bindgen_ty_55::NDA_FLAGS_EXT;
-pub const NDA_NDM_STATE_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_STATE_MASK;
-pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_FLAGS_MASK;
-pub const __NDA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__NDA_MAX;
-pub const NDTPA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UNSPEC;
-pub const NDTPA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_IFINDEX;
-pub const NDTPA_REFCNT: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REFCNT;
-pub const NDTPA_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REACHABLE_TIME;
-pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_BASE_REACHABLE_TIME;
-pub const NDTPA_RETRANS_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_RETRANS_TIME;
-pub const NDTPA_GC_STALETIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_GC_STALETIME;
-pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_DELAY_PROBE_TIME;
-pub const NDTPA_QUEUE_LEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LEN;
-pub const NDTPA_APP_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_APP_PROBES;
-pub const NDTPA_UCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UCAST_PROBES;
-pub const NDTPA_MCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_PROBES;
-pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_ANYCAST_DELAY;
-pub const NDTPA_PROXY_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_DELAY;
-pub const NDTPA_PROXY_QLEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_QLEN;
-pub const NDTPA_LOCKTIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_LOCKTIME;
-pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LENBYTES;
-pub const NDTPA_MCAST_REPROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_REPROBES;
-pub const NDTPA_PAD: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PAD;
-pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_INTERVAL_PROBE_TIME_MS;
-pub const __NDTPA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDTPA_MAX;
-pub const NDTA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTA_UNSPEC;
-pub const NDTA_NAME: _bindgen_ty_57 = _bindgen_ty_57::NDTA_NAME;
-pub const NDTA_THRESH1: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH1;
-pub const NDTA_THRESH2: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH2;
-pub const NDTA_THRESH3: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH3;
-pub const NDTA_CONFIG: _bindgen_ty_57 = _bindgen_ty_57::NDTA_CONFIG;
-pub const NDTA_PARMS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PARMS;
-pub const NDTA_STATS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_STATS;
-pub const NDTA_GC_INTERVAL: _bindgen_ty_57 = _bindgen_ty_57::NDTA_GC_INTERVAL;
-pub const NDTA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PAD;
-pub const __NDTA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTA_MAX;
-pub const FDB_NOTIFY_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_BIT;
-pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_INACTIVE_BIT;
-pub const NFEA_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::NFEA_UNSPEC;
-pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_59 = _bindgen_ty_59::NFEA_ACTIVITY_NOTIFY;
-pub const NFEA_DONT_REFRESH: _bindgen_ty_59 = _bindgen_ty_59::NFEA_DONT_REFRESH;
-pub const __NFEA_MAX: _bindgen_ty_59 = _bindgen_ty_59::__NFEA_MAX;
-pub const RTM_BASE: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_NEWLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_DELLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINK;
-pub const RTM_GETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINK;
-pub const RTM_SETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETLINK;
-pub const RTM_NEWADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDR;
-pub const RTM_DELADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDR;
-pub const RTM_GETADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDR;
-pub const RTM_NEWROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWROUTE;
-pub const RTM_DELROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELROUTE;
-pub const RTM_GETROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETROUTE;
-pub const RTM_NEWNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGH;
-pub const RTM_DELNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEIGH;
-pub const RTM_GETNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGH;
-pub const RTM_NEWRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWRULE;
-pub const RTM_DELRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELRULE;
-pub const RTM_GETRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETRULE;
-pub const RTM_NEWQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWQDISC;
-pub const RTM_DELQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELQDISC;
-pub const RTM_GETQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETQDISC;
-pub const RTM_NEWTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTCLASS;
-pub const RTM_DELTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTCLASS;
-pub const RTM_GETTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTCLASS;
-pub const RTM_NEWTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTFILTER;
-pub const RTM_DELTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTFILTER;
-pub const RTM_GETTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTFILTER;
-pub const RTM_NEWACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWACTION;
-pub const RTM_DELACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELACTION;
-pub const RTM_GETACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETACTION;
-pub const RTM_NEWPREFIX: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWPREFIX;
-pub const RTM_GETMULTICAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMULTICAST;
-pub const RTM_GETANYCAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETANYCAST;
-pub const RTM_NEWNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGHTBL;
-pub const RTM_GETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGHTBL;
-pub const RTM_SETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETNEIGHTBL;
-pub const RTM_NEWNDUSEROPT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNDUSEROPT;
-pub const RTM_NEWADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDRLABEL;
-pub const RTM_DELADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDRLABEL;
-pub const RTM_GETADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDRLABEL;
-pub const RTM_GETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETDCB;
-pub const RTM_SETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETDCB;
-pub const RTM_NEWNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNETCONF;
-pub const RTM_DELNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNETCONF;
-pub const RTM_GETNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNETCONF;
-pub const RTM_NEWMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWMDB;
-pub const RTM_DELMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELMDB;
-pub const RTM_GETMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMDB;
-pub const RTM_NEWNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNSID;
-pub const RTM_DELNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNSID;
-pub const RTM_GETNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNSID;
-pub const RTM_NEWSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWSTATS;
-pub const RTM_GETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETSTATS;
-pub const RTM_SETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETSTATS;
-pub const RTM_NEWCACHEREPORT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCACHEREPORT;
-pub const RTM_NEWCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCHAIN;
-pub const RTM_DELCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELCHAIN;
-pub const RTM_GETCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETCHAIN;
-pub const RTM_NEWNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOP;
-pub const RTM_DELNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOP;
-pub const RTM_GETNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOP;
-pub const RTM_NEWLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWLINKPROP;
-pub const RTM_DELLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINKPROP;
-pub const RTM_GETLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINKPROP;
-pub const RTM_NEWVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWVLAN;
-pub const RTM_DELVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELVLAN;
-pub const RTM_GETVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETVLAN;
-pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOPBUCKET;
-pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOPBUCKET;
-pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOPBUCKET;
-pub const RTM_NEWTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTUNNEL;
-pub const RTM_DELTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTUNNEL;
-pub const RTM_GETTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTUNNEL;
-pub const __RTM_MAX: _bindgen_ty_60 = _bindgen_ty_60::__RTM_MAX;
-pub const RTN_UNSPEC: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNSPEC;
-pub const RTN_UNICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNICAST;
-pub const RTN_LOCAL: _bindgen_ty_61 = _bindgen_ty_61::RTN_LOCAL;
-pub const RTN_BROADCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_BROADCAST;
-pub const RTN_ANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_ANYCAST;
-pub const RTN_MULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_MULTICAST;
-pub const RTN_BLACKHOLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_BLACKHOLE;
-pub const RTN_UNREACHABLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNREACHABLE;
-pub const RTN_PROHIBIT: _bindgen_ty_61 = _bindgen_ty_61::RTN_PROHIBIT;
-pub const RTN_THROW: _bindgen_ty_61 = _bindgen_ty_61::RTN_THROW;
-pub const RTN_NAT: _bindgen_ty_61 = _bindgen_ty_61::RTN_NAT;
-pub const RTN_XRESOLVE: _bindgen_ty_61 = _bindgen_ty_61::RTN_XRESOLVE;
-pub const __RTN_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTN_MAX;
-pub const RTAX_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTAX_UNSPEC;
-pub const RTAX_LOCK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_LOCK;
-pub const RTAX_MTU: _bindgen_ty_62 = _bindgen_ty_62::RTAX_MTU;
-pub const RTAX_WINDOW: _bindgen_ty_62 = _bindgen_ty_62::RTAX_WINDOW;
-pub const RTAX_RTT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTT;
-pub const RTAX_RTTVAR: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTTVAR;
-pub const RTAX_SSTHRESH: _bindgen_ty_62 = _bindgen_ty_62::RTAX_SSTHRESH;
-pub const RTAX_CWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CWND;
-pub const RTAX_ADVMSS: _bindgen_ty_62 = _bindgen_ty_62::RTAX_ADVMSS;
-pub const RTAX_REORDERING: _bindgen_ty_62 = _bindgen_ty_62::RTAX_REORDERING;
-pub const RTAX_HOPLIMIT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_HOPLIMIT;
-pub const RTAX_INITCWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITCWND;
-pub const RTAX_FEATURES: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FEATURES;
-pub const RTAX_RTO_MIN: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTO_MIN;
-pub const RTAX_INITRWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITRWND;
-pub const RTAX_QUICKACK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_QUICKACK;
-pub const RTAX_CC_ALGO: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CC_ALGO;
-pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FASTOPEN_NO_COOKIE;
-pub const __RTAX_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTAX_MAX;
-pub const PREFIX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_UNSPEC;
-pub const PREFIX_ADDRESS: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_ADDRESS;
-pub const PREFIX_CACHEINFO: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_CACHEINFO;
-pub const __PREFIX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__PREFIX_MAX;
-pub const TCA_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::TCA_UNSPEC;
-pub const TCA_KIND: _bindgen_ty_64 = _bindgen_ty_64::TCA_KIND;
-pub const TCA_OPTIONS: _bindgen_ty_64 = _bindgen_ty_64::TCA_OPTIONS;
-pub const TCA_STATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS;
-pub const TCA_XSTATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_XSTATS;
-pub const TCA_RATE: _bindgen_ty_64 = _bindgen_ty_64::TCA_RATE;
-pub const TCA_FCNT: _bindgen_ty_64 = _bindgen_ty_64::TCA_FCNT;
-pub const TCA_STATS2: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS2;
-pub const TCA_STAB: _bindgen_ty_64 = _bindgen_ty_64::TCA_STAB;
-pub const TCA_PAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_PAD;
-pub const TCA_DUMP_INVISIBLE: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_INVISIBLE;
-pub const TCA_CHAIN: _bindgen_ty_64 = _bindgen_ty_64::TCA_CHAIN;
-pub const TCA_HW_OFFLOAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_HW_OFFLOAD;
-pub const TCA_INGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_INGRESS_BLOCK;
-pub const TCA_EGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_EGRESS_BLOCK;
-pub const TCA_DUMP_FLAGS: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_FLAGS;
-pub const TCA_EXT_WARN_MSG: _bindgen_ty_64 = _bindgen_ty_64::TCA_EXT_WARN_MSG;
-pub const __TCA_MAX: _bindgen_ty_64 = _bindgen_ty_64::__TCA_MAX;
-pub const NDUSEROPT_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_UNSPEC;
-pub const NDUSEROPT_SRCADDR: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_SRCADDR;
-pub const __NDUSEROPT_MAX: _bindgen_ty_65 = _bindgen_ty_65::__NDUSEROPT_MAX;
-pub const TCA_ROOT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_UNSPEC;
-pub const TCA_ROOT_TAB: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TAB;
-pub const TCA_ROOT_FLAGS: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_FLAGS;
-pub const TCA_ROOT_COUNT: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_COUNT;
-pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TIME_DELTA;
-pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_EXT_WARN_MSG;
-pub const __TCA_ROOT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__TCA_ROOT_MAX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_18 = _bindgen_ty_18::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_39 = _bindgen_ty_39::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_45 = _bindgen_ty_45::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_DSA_MAX;
+pub const IFA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFA_UNSPEC;
+pub const IFA_ADDRESS: _bindgen_ty_55 = _bindgen_ty_55::IFA_ADDRESS;
+pub const IFA_LOCAL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LOCAL;
+pub const IFA_LABEL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LABEL;
+pub const IFA_BROADCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_BROADCAST;
+pub const IFA_ANYCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_ANYCAST;
+pub const IFA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::IFA_CACHEINFO;
+pub const IFA_MULTICAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_MULTICAST;
+pub const IFA_FLAGS: _bindgen_ty_55 = _bindgen_ty_55::IFA_FLAGS;
+pub const IFA_RT_PRIORITY: _bindgen_ty_55 = _bindgen_ty_55::IFA_RT_PRIORITY;
+pub const IFA_TARGET_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::IFA_TARGET_NETNSID;
+pub const IFA_PROTO: _bindgen_ty_55 = _bindgen_ty_55::IFA_PROTO;
+pub const __IFA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFA_MAX;
+pub const NDA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDA_UNSPEC;
+pub const NDA_DST: _bindgen_ty_56 = _bindgen_ty_56::NDA_DST;
+pub const NDA_LLADDR: _bindgen_ty_56 = _bindgen_ty_56::NDA_LLADDR;
+pub const NDA_CACHEINFO: _bindgen_ty_56 = _bindgen_ty_56::NDA_CACHEINFO;
+pub const NDA_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROBES;
+pub const NDA_VLAN: _bindgen_ty_56 = _bindgen_ty_56::NDA_VLAN;
+pub const NDA_PORT: _bindgen_ty_56 = _bindgen_ty_56::NDA_PORT;
+pub const NDA_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_VNI;
+pub const NDA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDA_IFINDEX;
+pub const NDA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::NDA_MASTER;
+pub const NDA_LINK_NETNSID: _bindgen_ty_56 = _bindgen_ty_56::NDA_LINK_NETNSID;
+pub const NDA_SRC_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_SRC_VNI;
+pub const NDA_PROTOCOL: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROTOCOL;
+pub const NDA_NH_ID: _bindgen_ty_56 = _bindgen_ty_56::NDA_NH_ID;
+pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_56 = _bindgen_ty_56::NDA_FDB_EXT_ATTRS;
+pub const NDA_FLAGS_EXT: _bindgen_ty_56 = _bindgen_ty_56::NDA_FLAGS_EXT;
+pub const NDA_NDM_STATE_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_STATE_MASK;
+pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_FLAGS_MASK;
+pub const __NDA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDA_MAX;
+pub const NDTPA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UNSPEC;
+pub const NDTPA_IFINDEX: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_IFINDEX;
+pub const NDTPA_REFCNT: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REFCNT;
+pub const NDTPA_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REACHABLE_TIME;
+pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_BASE_REACHABLE_TIME;
+pub const NDTPA_RETRANS_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_RETRANS_TIME;
+pub const NDTPA_GC_STALETIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_GC_STALETIME;
+pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_DELAY_PROBE_TIME;
+pub const NDTPA_QUEUE_LEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LEN;
+pub const NDTPA_APP_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_APP_PROBES;
+pub const NDTPA_UCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UCAST_PROBES;
+pub const NDTPA_MCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_PROBES;
+pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_ANYCAST_DELAY;
+pub const NDTPA_PROXY_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_DELAY;
+pub const NDTPA_PROXY_QLEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_QLEN;
+pub const NDTPA_LOCKTIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_LOCKTIME;
+pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LENBYTES;
+pub const NDTPA_MCAST_REPROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_REPROBES;
+pub const NDTPA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PAD;
+pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_INTERVAL_PROBE_TIME_MS;
+pub const __NDTPA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTPA_MAX;
+pub const NDTA_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDTA_UNSPEC;
+pub const NDTA_NAME: _bindgen_ty_58 = _bindgen_ty_58::NDTA_NAME;
+pub const NDTA_THRESH1: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH1;
+pub const NDTA_THRESH2: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH2;
+pub const NDTA_THRESH3: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH3;
+pub const NDTA_CONFIG: _bindgen_ty_58 = _bindgen_ty_58::NDTA_CONFIG;
+pub const NDTA_PARMS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PARMS;
+pub const NDTA_STATS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_STATS;
+pub const NDTA_GC_INTERVAL: _bindgen_ty_58 = _bindgen_ty_58::NDTA_GC_INTERVAL;
+pub const NDTA_PAD: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PAD;
+pub const __NDTA_MAX: _bindgen_ty_58 = _bindgen_ty_58::__NDTA_MAX;
+pub const FDB_NOTIFY_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_BIT;
+pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_INACTIVE_BIT;
+pub const NFEA_UNSPEC: _bindgen_ty_60 = _bindgen_ty_60::NFEA_UNSPEC;
+pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_60 = _bindgen_ty_60::NFEA_ACTIVITY_NOTIFY;
+pub const NFEA_DONT_REFRESH: _bindgen_ty_60 = _bindgen_ty_60::NFEA_DONT_REFRESH;
+pub const __NFEA_MAX: _bindgen_ty_60 = _bindgen_ty_60::__NFEA_MAX;
+pub const RTM_BASE: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_NEWLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_DELLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINK;
+pub const RTM_GETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINK;
+pub const RTM_SETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETLINK;
+pub const RTM_NEWADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDR;
+pub const RTM_DELADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDR;
+pub const RTM_GETADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDR;
+pub const RTM_NEWROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWROUTE;
+pub const RTM_DELROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELROUTE;
+pub const RTM_GETROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETROUTE;
+pub const RTM_NEWNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGH;
+pub const RTM_DELNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEIGH;
+pub const RTM_GETNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGH;
+pub const RTM_NEWRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWRULE;
+pub const RTM_DELRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELRULE;
+pub const RTM_GETRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETRULE;
+pub const RTM_NEWQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWQDISC;
+pub const RTM_DELQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELQDISC;
+pub const RTM_GETQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETQDISC;
+pub const RTM_NEWTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTCLASS;
+pub const RTM_DELTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTCLASS;
+pub const RTM_GETTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTCLASS;
+pub const RTM_NEWTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTFILTER;
+pub const RTM_DELTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTFILTER;
+pub const RTM_GETTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTFILTER;
+pub const RTM_NEWACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWACTION;
+pub const RTM_DELACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELACTION;
+pub const RTM_GETACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETACTION;
+pub const RTM_NEWPREFIX: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWPREFIX;
+pub const RTM_GETMULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMULTICAST;
+pub const RTM_GETANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETANYCAST;
+pub const RTM_NEWNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGHTBL;
+pub const RTM_GETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGHTBL;
+pub const RTM_SETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETNEIGHTBL;
+pub const RTM_NEWNDUSEROPT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNDUSEROPT;
+pub const RTM_NEWADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDRLABEL;
+pub const RTM_DELADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDRLABEL;
+pub const RTM_GETADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDRLABEL;
+pub const RTM_GETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETDCB;
+pub const RTM_SETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETDCB;
+pub const RTM_NEWNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNETCONF;
+pub const RTM_DELNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNETCONF;
+pub const RTM_GETNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNETCONF;
+pub const RTM_NEWMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWMDB;
+pub const RTM_DELMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELMDB;
+pub const RTM_GETMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMDB;
+pub const RTM_NEWNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNSID;
+pub const RTM_DELNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNSID;
+pub const RTM_GETNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNSID;
+pub const RTM_NEWSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWSTATS;
+pub const RTM_GETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETSTATS;
+pub const RTM_SETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETSTATS;
+pub const RTM_NEWCACHEREPORT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCACHEREPORT;
+pub const RTM_NEWCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCHAIN;
+pub const RTM_DELCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELCHAIN;
+pub const RTM_GETCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETCHAIN;
+pub const RTM_NEWNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOP;
+pub const RTM_DELNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOP;
+pub const RTM_GETNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOP;
+pub const RTM_NEWLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWLINKPROP;
+pub const RTM_DELLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINKPROP;
+pub const RTM_GETLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINKPROP;
+pub const RTM_NEWVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWVLAN;
+pub const RTM_DELVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELVLAN;
+pub const RTM_GETVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETVLAN;
+pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOPBUCKET;
+pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOPBUCKET;
+pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOPBUCKET;
+pub const RTM_NEWTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTUNNEL;
+pub const RTM_DELTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTUNNEL;
+pub const RTM_GETTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTUNNEL;
+pub const __RTM_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTM_MAX;
+pub const RTN_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNSPEC;
+pub const RTN_UNICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNICAST;
+pub const RTN_LOCAL: _bindgen_ty_62 = _bindgen_ty_62::RTN_LOCAL;
+pub const RTN_BROADCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_BROADCAST;
+pub const RTN_ANYCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_ANYCAST;
+pub const RTN_MULTICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_MULTICAST;
+pub const RTN_BLACKHOLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_BLACKHOLE;
+pub const RTN_UNREACHABLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNREACHABLE;
+pub const RTN_PROHIBIT: _bindgen_ty_62 = _bindgen_ty_62::RTN_PROHIBIT;
+pub const RTN_THROW: _bindgen_ty_62 = _bindgen_ty_62::RTN_THROW;
+pub const RTN_NAT: _bindgen_ty_62 = _bindgen_ty_62::RTN_NAT;
+pub const RTN_XRESOLVE: _bindgen_ty_62 = _bindgen_ty_62::RTN_XRESOLVE;
+pub const __RTN_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTN_MAX;
+pub const RTAX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::RTAX_UNSPEC;
+pub const RTAX_LOCK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_LOCK;
+pub const RTAX_MTU: _bindgen_ty_63 = _bindgen_ty_63::RTAX_MTU;
+pub const RTAX_WINDOW: _bindgen_ty_63 = _bindgen_ty_63::RTAX_WINDOW;
+pub const RTAX_RTT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTT;
+pub const RTAX_RTTVAR: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTTVAR;
+pub const RTAX_SSTHRESH: _bindgen_ty_63 = _bindgen_ty_63::RTAX_SSTHRESH;
+pub const RTAX_CWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CWND;
+pub const RTAX_ADVMSS: _bindgen_ty_63 = _bindgen_ty_63::RTAX_ADVMSS;
+pub const RTAX_REORDERING: _bindgen_ty_63 = _bindgen_ty_63::RTAX_REORDERING;
+pub const RTAX_HOPLIMIT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_HOPLIMIT;
+pub const RTAX_INITCWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITCWND;
+pub const RTAX_FEATURES: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FEATURES;
+pub const RTAX_RTO_MIN: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTO_MIN;
+pub const RTAX_INITRWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITRWND;
+pub const RTAX_QUICKACK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_QUICKACK;
+pub const RTAX_CC_ALGO: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CC_ALGO;
+pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FASTOPEN_NO_COOKIE;
+pub const __RTAX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__RTAX_MAX;
+pub const PREFIX_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_UNSPEC;
+pub const PREFIX_ADDRESS: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_ADDRESS;
+pub const PREFIX_CACHEINFO: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_CACHEINFO;
+pub const __PREFIX_MAX: _bindgen_ty_64 = _bindgen_ty_64::__PREFIX_MAX;
+pub const TCA_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::TCA_UNSPEC;
+pub const TCA_KIND: _bindgen_ty_65 = _bindgen_ty_65::TCA_KIND;
+pub const TCA_OPTIONS: _bindgen_ty_65 = _bindgen_ty_65::TCA_OPTIONS;
+pub const TCA_STATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS;
+pub const TCA_XSTATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_XSTATS;
+pub const TCA_RATE: _bindgen_ty_65 = _bindgen_ty_65::TCA_RATE;
+pub const TCA_FCNT: _bindgen_ty_65 = _bindgen_ty_65::TCA_FCNT;
+pub const TCA_STATS2: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS2;
+pub const TCA_STAB: _bindgen_ty_65 = _bindgen_ty_65::TCA_STAB;
+pub const TCA_PAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_PAD;
+pub const TCA_DUMP_INVISIBLE: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_INVISIBLE;
+pub const TCA_CHAIN: _bindgen_ty_65 = _bindgen_ty_65::TCA_CHAIN;
+pub const TCA_HW_OFFLOAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_HW_OFFLOAD;
+pub const TCA_INGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_INGRESS_BLOCK;
+pub const TCA_EGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_EGRESS_BLOCK;
+pub const TCA_DUMP_FLAGS: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_FLAGS;
+pub const TCA_EXT_WARN_MSG: _bindgen_ty_65 = _bindgen_ty_65::TCA_EXT_WARN_MSG;
+pub const __TCA_MAX: _bindgen_ty_65 = _bindgen_ty_65::__TCA_MAX;
+pub const NDUSEROPT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_UNSPEC;
+pub const NDUSEROPT_SRCADDR: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_SRCADDR;
+pub const __NDUSEROPT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__NDUSEROPT_MAX;
+pub const TCA_ROOT_UNSPEC: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_UNSPEC;
+pub const TCA_ROOT_TAB: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TAB;
+pub const TCA_ROOT_FLAGS: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_FLAGS;
+pub const TCA_ROOT_COUNT: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_COUNT;
+pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TIME_DELTA;
+pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_EXT_WARN_MSG;
+pub const __TCA_ROOT_MAX: _bindgen_ty_67 = _bindgen_ty_67::__TCA_ROOT_MAX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1540,6 +1554,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1629,7 +1645,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1725,7 +1742,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1782,7 +1801,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1935,10 +1955,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_18 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_19 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -1954,7 +2002,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_19 {
+pub enum _bindgen_ty_20 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -1966,7 +2014,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_20 {
+pub enum _bindgen_ty_21 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -1974,7 +2022,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2007,7 +2055,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2021,7 +2070,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_23 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2051,7 +2108,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2062,7 +2119,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum _bindgen_ty_25 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2077,7 +2134,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2090,7 +2147,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2128,7 +2185,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2140,7 +2197,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2156,7 +2213,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2164,7 +2221,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2184,7 +2241,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2192,7 +2249,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2201,7 +2258,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2216,7 +2273,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2224,7 +2281,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2238,7 +2295,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2247,7 +2304,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2265,7 +2322,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2275,14 +2332,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2290,7 +2347,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2304,7 +2361,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2316,7 +2373,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2325,7 +2382,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2334,7 +2391,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2344,7 +2401,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2353,7 +2410,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2363,7 +2420,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2378,7 +2435,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2390,7 +2447,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2406,7 +2463,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2415,7 +2472,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2423,15 +2480,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFA_UNSPEC = 0,
 IFA_ADDRESS = 1,
 IFA_LOCAL = 2,
@@ -2449,7 +2506,7 @@ __IFA_MAX = 12,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 NDA_UNSPEC = 0,
 NDA_DST = 1,
 NDA_LLADDR = 2,
@@ -2473,7 +2530,7 @@ __NDA_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 NDTPA_UNSPEC = 0,
 NDTPA_IFINDEX = 1,
 NDTPA_REFCNT = 2,
@@ -2499,7 +2556,7 @@ __NDTPA_MAX = 20,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_57 {
+pub enum _bindgen_ty_58 {
 NDTA_UNSPEC = 0,
 NDTA_NAME = 1,
 NDTA_THRESH1 = 2,
@@ -2515,14 +2572,14 @@ __NDTA_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_58 {
+pub enum _bindgen_ty_59 {
 FDB_NOTIFY_BIT = 1,
 FDB_NOTIFY_INACTIVE_BIT = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_59 {
+pub enum _bindgen_ty_60 {
 NFEA_UNSPEC = 0,
 NFEA_ACTIVITY_NOTIFY = 1,
 NFEA_DONT_REFRESH = 2,
@@ -2531,7 +2588,7 @@ __NFEA_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_60 {
+pub enum _bindgen_ty_61 {
 RTM_BASE = 16,
 RTM_DELLINK = 17,
 RTM_GETLINK = 18,
@@ -2608,7 +2665,7 @@ __RTM_MAX = 123,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_61 {
+pub enum _bindgen_ty_62 {
 RTN_UNSPEC = 0,
 RTN_UNICAST = 1,
 RTN_LOCAL = 2,
@@ -2684,7 +2741,7 @@ __RTA_MAX = 31,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_62 {
+pub enum _bindgen_ty_63 {
 RTAX_UNSPEC = 0,
 RTAX_LOCK = 1,
 RTAX_MTU = 2,
@@ -2708,7 +2765,7 @@ __RTAX_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_63 {
+pub enum _bindgen_ty_64 {
 PREFIX_UNSPEC = 0,
 PREFIX_ADDRESS = 1,
 PREFIX_CACHEINFO = 2,
@@ -2717,7 +2774,7 @@ __PREFIX_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_64 {
+pub enum _bindgen_ty_65 {
 TCA_UNSPEC = 0,
 TCA_KIND = 1,
 TCA_OPTIONS = 2,
@@ -2740,7 +2797,7 @@ __TCA_MAX = 17,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_65 {
+pub enum _bindgen_ty_66 {
 NDUSEROPT_UNSPEC = 0,
 NDUSEROPT_SRCADDR = 1,
 __NDUSEROPT_MAX = 2,
@@ -2791,7 +2848,7 @@ __RTNLGRP_MAX = 37,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_66 {
+pub enum _bindgen_ty_67 {
 TCA_ROOT_UNSPEC = 0,
 TCA_ROOT_TAB = 1,
 TCA_ROOT_FLAGS = 2,
@@ -2854,6 +2911,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/riscv32/prctl.rs
+++ b/src/riscv32/prctl.rs
@@ -216,6 +216,7 @@ pub const PR_SME_VL_LEN_MASK: u32 = 65535;
 pub const PR_SME_VL_INHERIT: u32 = 131072;
 pub const PR_SET_MDWE: u32 = 65;
 pub const PR_MDWE_REFUSE_EXEC_GAIN: u32 = 1;
+pub const PR_MDWE_NO_INHERIT: u32 = 2;
 pub const PR_GET_MDWE: u32 = 66;
 pub const PR_SET_VMA: u32 = 1398164801;
 pub const PR_SET_VMA_ANON_NAME: u32 = 0;

--- a/src/riscv32/xdp.rs
+++ b/src/riscv32/xdp.rs
@@ -81,6 +81,7 @@ pub len: __u64,
 pub chunk_size: __u32,
 pub headroom: __u32,
 pub flags: __u32,
+pub tx_metadata_len: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -96,6 +97,23 @@ pub tx_ring_empty_descs: __u64,
 #[derive(Debug, Copy, Clone)]
 pub struct xdp_options {
 pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct xsk_tx_metadata {
+pub flags: __u64,
+pub __bindgen_anon_1: xsk_tx_metadata__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1 {
+pub csum_start: __u16,
+pub csum_offset: __u16,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2 {
+pub tx_timestamp: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -138,7 +156,9 @@ pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
 pub const XDP_USE_NEED_WAKEUP: u32 = 8;
+pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
+pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;
@@ -155,5 +175,13 @@ pub const XDP_UMEM_PGOFF_FILL_RING: u64 = 4294967296;
 pub const XDP_UMEM_PGOFF_COMPLETION_RING: u64 = 6442450944;
 pub const XSK_UNALIGNED_BUF_OFFSET_SHIFT: u32 = 48;
 pub const XSK_UNALIGNED_BUF_ADDR_MASK: u64 = 281474976710655;
-pub const XDP_USE_SG: u32 = 16;
+pub const XDP_TXMD_FLAGS_TIMESTAMP: u32 = 1;
+pub const XDP_TXMD_FLAGS_CHECKSUM: u32 = 2;
 pub const XDP_PKT_CONTD: u32 = 1;
+pub const XDP_TX_METADATA: u32 = 2;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union xsk_tx_metadata__bindgen_ty_1 {
+pub request: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1,
+pub completion: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2,
+}

--- a/src/riscv64/general.rs
+++ b/src/riscv64/general.rs
@@ -183,7 +183,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -238,6 +239,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -296,6 +330,29 @@ pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
 pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -390,36 +447,6 @@ pub it_value: __kernel_old_timeval,
 pub struct __kernel_sock_timeval {
 pub tv_sec: __s64,
 pub tv_usec: __s64,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timespec {
-pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: crate::ctypes::c_long,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timeval {
-pub tv_sec: __kernel_old_time_t,
-pub tv_usec: __kernel_suseconds_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerspec {
-pub it_interval: timespec,
-pub it_value: timespec,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerval {
-pub it_interval: timeval,
-pub it_value: timeval,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timezone {
-pub tz_minuteswest: crate::ctypes::c_int,
-pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -672,6 +699,36 @@ pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct timespec {
+pub tv_sec: __kernel_old_time_t,
+pub tv_nsec: crate::ctypes::c_long,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timeval {
+pub tv_sec: __kernel_old_time_t,
+pub tv_usec: __kernel_suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerspec {
+pub it_interval: timespec,
+pub it_value: timespec,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerval {
+pub it_interval: timeval,
+pub it_value: timeval,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timezone {
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct iovec {
 pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
@@ -765,6 +822,22 @@ pub struct uffdio_continue {
 pub range: uffdio_range,
 pub mode: __u64,
 pub mapped: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_poison {
+pub range: uffdio_range,
+pub mode: __u64,
+pub updated: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_move {
+pub dst: __u64,
+pub src: __u64,
+pub len: __u64,
+pub mode: __u64,
+pub move_: __s64,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -869,9 +942,9 @@ pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 394496;
+pub const LINUX_VERSION_CODE: u32 = 395264;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 5;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_L1I_CACHESIZE: u32 = 40;
@@ -1248,6 +1321,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1319,6 +1400,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const FUTEX_WAIT: u32 = 0;
 pub const FUTEX_WAKE: u32 = 1;
 pub const FUTEX_FD: u32 = 2;
@@ -1349,6 +1440,13 @@ pub const FUTEX_WAIT_BITSET_PRIVATE: u32 = 137;
 pub const FUTEX_WAKE_BITSET_PRIVATE: u32 = 138;
 pub const FUTEX_WAIT_REQUEUE_PI_PRIVATE: u32 = 139;
 pub const FUTEX_CMP_REQUEUE_PI_PRIVATE: u32 = 140;
+pub const FUTEX2_SIZE_U8: u32 = 0;
+pub const FUTEX2_SIZE_U16: u32 = 1;
+pub const FUTEX2_SIZE_U32: u32 = 2;
+pub const FUTEX2_SIZE_U64: u32 = 3;
+pub const FUTEX2_NUMA: u32 = 4;
+pub const FUTEX2_PRIVATE: u32 = 128;
+pub const FUTEX2_SIZE_MASK: u32 = 3;
 pub const FUTEX_32: u32 = 2;
 pub const FUTEX_WAITV_MAX: u32 = 128;
 pub const FUTEX_WAITERS: u32 = 2147483648;
@@ -1605,25 +1703,6 @@ pub const LINUX_REBOOT_CMD_POWER_OFF: u32 = 1126301404;
 pub const LINUX_REBOOT_CMD_RESTART2: u32 = 2712847316;
 pub const LINUX_REBOOT_CMD_SW_SUSPEND: u32 = 3489725666;
 pub const LINUX_REBOOT_CMD_KEXEC: u32 = 1163412803;
-pub const ITIMER_REAL: u32 = 0;
-pub const ITIMER_VIRTUAL: u32 = 1;
-pub const ITIMER_PROF: u32 = 2;
-pub const CLOCK_REALTIME: u32 = 0;
-pub const CLOCK_MONOTONIC: u32 = 1;
-pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
-pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
-pub const CLOCK_MONOTONIC_RAW: u32 = 4;
-pub const CLOCK_REALTIME_COARSE: u32 = 5;
-pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
-pub const CLOCK_BOOTTIME: u32 = 7;
-pub const CLOCK_REALTIME_ALARM: u32 = 8;
-pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
-pub const CLOCK_SGI_CYCLE: u32 = 10;
-pub const CLOCK_TAI: u32 = 11;
-pub const MAX_CLOCKS: u32 = 16;
-pub const CLOCKS_MASK: u32 = 1;
-pub const CLOCKS_MONO: u32 = 1;
-pub const TIMER_ABSTIME: u32 = 1;
 pub const RUSAGE_SELF: u32 = 0;
 pub const RUSAGE_CHILDREN: i32 = -1;
 pub const RUSAGE_BOTH: i32 = -2;
@@ -1803,7 +1882,8 @@ pub const SEGV_ADIDERR: u32 = 6;
 pub const SEGV_ADIPERR: u32 = 7;
 pub const SEGV_MTEAERR: u32 = 8;
 pub const SEGV_MTESERR: u32 = 9;
-pub const NSIGSEGV: u32 = 9;
+pub const SEGV_CPERR: u32 = 10;
+pub const NSIGSEGV: u32 = 10;
 pub const BUS_ADRALN: u32 = 1;
 pub const BUS_ADRERR: u32 = 2;
 pub const BUS_OBJERR: u32 = 3;
@@ -1884,6 +1964,7 @@ pub const STATX_BASIC_STATS: u32 = 2047;
 pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
+pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2061,6 +2142,25 @@ pub const TIOCM_RI: u32 = 128;
 pub const TIOCM_OUT1: u32 = 8192;
 pub const TIOCM_OUT2: u32 = 16384;
 pub const TIOCM_LOOP: u32 = 32768;
+pub const ITIMER_REAL: u32 = 0;
+pub const ITIMER_VIRTUAL: u32 = 1;
+pub const ITIMER_PROF: u32 = 2;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_SGI_CYCLE: u32 = 10;
+pub const CLOCK_TAI: u32 = 11;
+pub const MAX_CLOCKS: u32 = 16;
+pub const CLOCKS_MASK: u32 = 1;
+pub const CLOCKS_MONO: u32 = 1;
+pub const TIMER_ABSTIME: u32 = 1;
 pub const UIO_FASTIOV: u32 = 8;
 pub const UIO_MAXIOV: u32 = 1024;
 pub const __NR_io_setup: u32 = 0;
@@ -2370,7 +2470,17 @@ pub const __NR_process_mrelease: u32 = 448;
 pub const __NR_futex_waitv: u32 = 449;
 pub const __NR_set_mempolicy_home_node: u32 = 450;
 pub const __NR_cachestat: u32 = 451;
-pub const __NR_syscalls: u32 = 452;
+pub const __NR_fchmodat2: u32 = 452;
+pub const __NR_map_shadow_stack: u32 = 453;
+pub const __NR_futex_wake: u32 = 454;
+pub const __NR_futex_wait: u32 = 455;
+pub const __NR_futex_requeue: u32 = 456;
+pub const __NR_statmount: u32 = 457;
+pub const __NR_listmount: u32 = 458;
+pub const __NR_lsm_get_self_attr: u32 = 459;
+pub const __NR_lsm_set_self_attr: u32 = 460;
+pub const __NR_lsm_list_modules: u32 = 461;
+pub const __NR_syscalls: u32 = 462;
 pub const __NR_fcntl: u32 = 25;
 pub const __NR_statfs: u32 = 43;
 pub const __NR_fstatfs: u32 = 44;
@@ -2462,8 +2572,10 @@ pub const _UFFDIO_UNREGISTER: u32 = 1;
 pub const _UFFDIO_WAKE: u32 = 2;
 pub const _UFFDIO_COPY: u32 = 3;
 pub const _UFFDIO_ZEROPAGE: u32 = 4;
+pub const _UFFDIO_MOVE: u32 = 5;
 pub const _UFFDIO_WRITEPROTECT: u32 = 6;
 pub const _UFFDIO_CONTINUE: u32 = 7;
+pub const _UFFDIO_POISON: u32 = 8;
 pub const _UFFDIO_API: u32 = 63;
 pub const UFFDIO: u32 = 170;
 pub const UFFD_EVENT_PAGEFAULT: u32 = 18;
@@ -2488,6 +2600,9 @@ pub const UFFD_FEATURE_MINOR_SHMEM: u32 = 1024;
 pub const UFFD_FEATURE_EXACT_ADDRESS: u32 = 2048;
 pub const UFFD_FEATURE_WP_HUGETLBFS_SHMEM: u32 = 4096;
 pub const UFFD_FEATURE_WP_UNPOPULATED: u32 = 8192;
+pub const UFFD_FEATURE_POISON: u32 = 16384;
+pub const UFFD_FEATURE_WP_ASYNC: u32 = 32768;
+pub const UFFD_FEATURE_MOVE: u32 = 65536;
 pub const UFFD_USER_MODE_ONLY: u32 = 1;
 pub const DT_UNKNOWN: u32 = 0;
 pub const DT_FIFO: u32 = 1;
@@ -2562,6 +2677,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/riscv64/if_arp.rs
+++ b/src/riscv64/if_arp.rs
@@ -52,11 +52,6 @@ pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
@@ -175,6 +170,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -182,23 +178,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -1126,6 +1107,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_4 = _bindgen_ty_4::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_4 = _bindgen_ty_4::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_MASK;
@@ -1194,6 +1176,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_HAIRPIN;
@@ -1241,6 +1225,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_10 = _bindgen_ty_10::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_KIND;
@@ -1302,301 +1287,310 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_19 = _bindgen_ty_19::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_40 = _bindgen_ty_40::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_46 = _bindgen_ty_46::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_DSA_MAX;
-pub const IF_PORT_UNKNOWN: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_UNKNOWN;
-pub const IF_PORT_10BASE2: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASE2;
-pub const IF_PORT_10BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASET;
-pub const IF_PORT_AUI: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_AUI;
-pub const IF_PORT_100BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASET;
-pub const IF_PORT_100BASETX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASETX;
-pub const IF_PORT_100BASEFX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASEFX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_20 = _bindgen_ty_20::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_23 = _bindgen_ty_23::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_47 = _bindgen_ty_47::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__IFLA_DSA_MAX;
+pub const IF_PORT_UNKNOWN: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_UNKNOWN;
+pub const IF_PORT_10BASE2: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASE2;
+pub const IF_PORT_10BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASET;
+pub const IF_PORT_AUI: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_AUI;
+pub const IF_PORT_100BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASET;
+pub const IF_PORT_100BASETX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASETX;
+pub const IF_PORT_100BASEFX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASEFX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1699,6 +1693,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1788,7 +1784,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1884,7 +1881,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1941,7 +1940,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2094,10 +2094,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_20 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_21 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -2113,7 +2141,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -2125,7 +2153,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum _bindgen_ty_23 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -2133,7 +2161,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2166,7 +2194,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2180,7 +2209,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_25 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2210,7 +2247,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2221,7 +2258,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2236,7 +2273,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2249,7 +2286,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2287,7 +2324,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2299,7 +2336,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2315,7 +2352,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2323,7 +2360,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2343,7 +2380,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2351,7 +2388,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2360,7 +2397,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2375,7 +2412,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2383,7 +2420,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2397,7 +2434,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2406,7 +2443,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2424,7 +2461,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2434,14 +2471,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2449,7 +2486,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2463,7 +2500,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2475,7 +2512,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2484,7 +2521,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2493,7 +2530,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2503,7 +2540,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2512,7 +2549,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2522,7 +2559,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2537,7 +2574,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2549,7 +2586,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2565,7 +2602,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2574,7 +2611,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2582,15 +2619,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 IF_PORT_UNKNOWN = 0,
 IF_PORT_10BASE2 = 1,
 IF_PORT_10BASET = 2,
@@ -2673,74 +2710,6 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 impl nlmsgerr_attrs {
 pub const NLMSGERR_ATTR_MAX: nlmsgerr_attrs = nlmsgerr_attrs::NLMSGERR_ATTR_MISS_NEST;
 }
@@ -2755,6 +2724,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/riscv64/if_packet.rs
+++ b/src/riscv64/if_packet.rs
@@ -51,11 +51,6 @@ pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_pkt {
 pub spkt_family: crate::ctypes::c_ushort,
@@ -63,6 +58,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -70,23 +66,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -327,71 +308,3 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}

--- a/src/riscv64/io_uring.rs
+++ b/src/riscv64/io_uring.rs
@@ -79,7 +79,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -134,6 +135,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -195,6 +229,29 @@ pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
 pub tv_nsec: crate::ctypes::c_longlong,
@@ -253,6 +310,12 @@ pub __pad1: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_sqe__bindgen_ty_2__bindgen_ty_1 {
+pub level: __u32,
+pub optname: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_sqe__bindgen_ty_5__bindgen_ty_1 {
 pub addr_len: __u16,
 pub __pad3: [__u16; 1usize],
@@ -260,6 +323,7 @@ pub __pad3: [__u16; 1usize],
 #[repr(C)]
 pub struct io_uring_sqe__bindgen_ty_6 {
 pub __bindgen_anon_1: __BindgenUnionField<io_uring_sqe__bindgen_ty_6__bindgen_ty_1>,
+pub optval: __BindgenUnionField<__u64>,
 pub cmd: __BindgenUnionField<[__u8; 0usize]>,
 pub bindgen_union_field: [u64; 2usize],
 }
@@ -421,6 +485,13 @@ pub resv: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_buf_status {
+pub buf_group: __u32,
+pub head: __u32,
+pub resv: [__u32; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -434,7 +505,9 @@ pub addr: __u64,
 pub fd: __s32,
 pub flags: __u32,
 pub timeout: __kernel_timespec,
-pub pad: [__u64; 4usize],
+pub opcode: __u8,
+pub pad: [__u8; 7usize],
+pub pad2: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -597,6 +670,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -668,6 +749,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const IORING_FILE_INDEX_ALLOC: i32 = -1;
 pub const IORING_SETUP_IOPOLL: u32 = 1;
 pub const IORING_SETUP_SQPOLL: u32 = 2;
@@ -685,8 +776,9 @@ pub const IORING_SETUP_SINGLE_ISSUER: u32 = 4096;
 pub const IORING_SETUP_DEFER_TASKRUN: u32 = 8192;
 pub const IORING_SETUP_NO_MMAP: u32 = 16384;
 pub const IORING_SETUP_REGISTERED_FD_ONLY: u32 = 32768;
+pub const IORING_SETUP_NO_SQARRAY: u32 = 65536;
 pub const IORING_URING_CMD_FIXED: u32 = 1;
-pub const IORING_URING_CMD_POLLED: u32 = 2147483648;
+pub const IORING_URING_CMD_MASK: u32 = 1;
 pub const IORING_FSYNC_DATASYNC: u32 = 1;
 pub const IORING_TIMEOUT_ABS: u32 = 1;
 pub const IORING_TIMEOUT_UPDATE: u32 = 2;
@@ -706,6 +798,8 @@ pub const IORING_ASYNC_CANCEL_ALL: u32 = 1;
 pub const IORING_ASYNC_CANCEL_FD: u32 = 2;
 pub const IORING_ASYNC_CANCEL_ANY: u32 = 4;
 pub const IORING_ASYNC_CANCEL_FD_FIXED: u32 = 8;
+pub const IORING_ASYNC_CANCEL_USERDATA: u32 = 16;
+pub const IORING_ASYNC_CANCEL_OP: u32 = 32;
 pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
@@ -714,6 +808,7 @@ pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
+pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
@@ -786,6 +881,7 @@ pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGIS
 pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
 pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
 pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
+pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
 pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
 pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
 pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
@@ -796,6 +892,10 @@ pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTR
 pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
 pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
 pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
+pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
+pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
+pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
+pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -808,6 +908,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -874,7 +975,13 @@ IORING_OP_SOCKET = 45,
 IORING_OP_URING_CMD = 46,
 IORING_OP_SEND_ZC = 47,
 IORING_OP_SENDMSG_ZC = 48,
-IORING_OP_LAST = 49,
+IORING_OP_READ_MULTISHOT = 49,
+IORING_OP_WAITID = 50,
+IORING_OP_FUTEX_WAIT = 51,
+IORING_OP_FUTEX_WAKE = 52,
+IORING_OP_FUTEX_WAITV = 53,
+IORING_OP_FIXED_FD_INSTALL = 54,
+IORING_OP_LAST = 55,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -919,7 +1026,8 @@ IORING_REGISTER_PBUF_RING = 22,
 IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
-IORING_REGISTER_LAST = 26,
+IORING_REGISTER_PBUF_STATUS = 26,
+IORING_REGISTER_LAST = 27,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
@@ -944,6 +1052,15 @@ IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
 IORING_RESTRICTION_SQE_FLAGS_REQUIRED = 3,
 IORING_RESTRICTION_LAST = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_8 {
+SOCKET_URING_OP_SIOCINQ = 0,
+SOCKET_URING_OP_SIOCOUTQ = 1,
+SOCKET_URING_OP_GETSOCKOPT = 2,
+SOCKET_URING_OP_SETSOCKOPT = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -971,6 +1088,7 @@ pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_1__bindgen_ty_1,
 pub union io_uring_sqe__bindgen_ty_2 {
 pub addr: __u64,
 pub splice_off_in: __u64,
+pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_2__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -994,6 +1112,9 @@ pub hardlink_flags: __u32,
 pub xattr_flags: __u32,
 pub msg_ring_flags: __u32,
 pub uring_cmd_flags: __u32,
+pub waitid_flags: __u32,
+pub futex_flags: __u32,
+pub install_fd_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]
@@ -1006,6 +1127,7 @@ pub buf_group: __u16,
 pub union io_uring_sqe__bindgen_ty_5 {
 pub splice_fd_in: __s32,
 pub file_index: __u32,
+pub optlen: __u32,
 pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]

--- a/src/riscv64/net.rs
+++ b/src/riscv64/net.rs
@@ -429,6 +429,9 @@ pub tcpi_rcv_ooopack: __u32,
 pub tcpi_snd_wnd: __u32,
 pub tcpi_rcv_wnd: __u32,
 pub tcpi_rehash: __u32,
+pub tcpi_total_rto: __u16,
+pub tcpi_total_rto_recoveries: __u16,
+pub tcpi_total_rto_time: __u32,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -448,6 +451,80 @@ pub tcpm_prefixlen: __u8,
 pub tcpm_keylen: __u16,
 pub tcpm_addr: [__be32; 4usize],
 pub tcpm_key: [__u8; 80usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_add {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub key: [__u8; 80usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_del {
+pub addr: __kernel_sockaddr_storage,
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub current_key: __u8,
+pub rnext: __u8,
+pub keyflags: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_info_opt {
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub current_key: __u8,
+pub rnext: __u8,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+pub pkt_key_not_found: __u64,
+pub pkt_ao_required: __u64,
+pub pkt_dropped_icmp: __u64,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_getsockopt {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub key: [__u8; 80usize],
+pub nkeys: __u32,
+pub _bitfield_align_1: [u16; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub prefix: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub ifindex: __s32,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_repair {
+pub snt_isn: __be32,
+pub rcv_isn: __be32,
+pub snd_sne: __u32,
+pub rcv_sne: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1185,6 +1262,11 @@ pub const TCP_ZEROCOPY_RECEIVE: u32 = 35;
 pub const TCP_INQ: u32 = 36;
 pub const TCP_CM_INQ: u32 = 36;
 pub const TCP_TX_DELAY: u32 = 37;
+pub const TCP_AO_ADD_KEY: u32 = 38;
+pub const TCP_AO_DEL_KEY: u32 = 39;
+pub const TCP_AO_INFO: u32 = 40;
+pub const TCP_AO_GET_KEYS: u32 = 41;
+pub const TCP_AO_REPAIR: u32 = 42;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1194,9 +1276,13 @@ pub const TCPI_OPT_WSCALE: u32 = 4;
 pub const TCPI_OPT_ECN: u32 = 8;
 pub const TCPI_OPT_ECN_SEEN: u32 = 16;
 pub const TCPI_OPT_SYN_DATA: u32 = 32;
+pub const TCPI_OPT_USEC_TS: u32 = 64;
 pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
+pub const TCP_AO_MAXKEYLEN: u32 = 80;
+pub const TCP_AO_KEYF_IFINDEX: u32 = 1;
+pub const TCP_AO_KEYF_EXCLUDE_OPT: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
@@ -1561,6 +1647,7 @@ pub const DEVCONF_IOAM6_ID: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID;
 pub const DEVCONF_IOAM6_ID_WIDE: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID_WIDE;
 pub const DEVCONF_NDISC_EVICT_NOCARRIER: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_NDISC_EVICT_NOCARRIER;
 pub const DEVCONF_ACCEPT_UNTRACKED_NA: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_UNTRACKED_NA;
+pub const DEVCONF_ACCEPT_RA_MIN_LFT: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_RA_MIN_LFT;
 pub const DEVCONF_MAX: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_MAX;
 pub const TCP_FLAG_CWR: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_CWR;
 pub const TCP_FLAG_ECE: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_ECE;
@@ -1758,7 +1845,8 @@ DEVCONF_IOAM6_ID = 54,
 DEVCONF_IOAM6_ID_WIDE = 55,
 DEVCONF_NDISC_EVICT_NOCARRIER = 56,
 DEVCONF_ACCEPT_UNTRACKED_NA = 57,
-DEVCONF_MAX = 58,
+DEVCONF_ACCEPT_RA_MIN_LFT = 58,
+DEVCONF_MAX = 59,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2476,6 +2564,289 @@ tcpi_delivery_rate_app_limited as u64
 __bindgen_bitfield_unit.set(9usize, 2u8, {
 let tcpi_fastopen_client_fail: u8 = unsafe { ::core::mem::transmute(tcpi_fastopen_client_fail) };
 tcpi_fastopen_client_fail as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_add {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 30u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 30u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_del {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn del_async(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_del_async(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 29u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 29u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, del_async: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let del_async: u32 = unsafe { ::core::mem::transmute(del_async) };
+del_async as u64
+});
+__bindgen_bitfield_unit.set(3usize, 29u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_info_opt {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn ao_required(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_ao_required(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_counters(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_counters(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn accept_icmps(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_accept_icmps(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(4usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(5usize, 27u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(5usize, 27u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, ao_required: __u32, set_counters: __u32, accept_icmps: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let ao_required: u32 = unsafe { ::core::mem::transmute(ao_required) };
+ao_required as u64
+});
+__bindgen_bitfield_unit.set(3usize, 1u8, {
+let set_counters: u32 = unsafe { ::core::mem::transmute(set_counters) };
+set_counters as u64
+});
+__bindgen_bitfield_unit.set(4usize, 1u8, {
+let accept_icmps: u32 = unsafe { ::core::mem::transmute(accept_icmps) };
+accept_icmps as u64
+});
+__bindgen_bitfield_unit.set(5usize, 27u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_getsockopt {
+#[inline]
+pub fn is_current(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_current(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn is_rnext(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_rnext(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn get_all(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_get_all(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 13u8) as u16) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 13u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(is_current: __u16, is_rnext: __u16, get_all: __u16, reserved: __u16) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let is_current: u16 = unsafe { ::core::mem::transmute(is_current) };
+is_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let is_rnext: u16 = unsafe { ::core::mem::transmute(is_rnext) };
+is_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let get_all: u16 = unsafe { ::core::mem::transmute(get_all) };
+get_all as u64
+});
+__bindgen_bitfield_unit.set(3usize, 13u8, {
+let reserved: u16 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
 });
 __bindgen_bitfield_unit
 }

--- a/src/riscv64/netlink.rs
+++ b/src/riscv64/netlink.rs
@@ -724,7 +724,8 @@ pub const RTAX_FEATURE_ECN: u32 = 1;
 pub const RTAX_FEATURE_SACK: u32 = 2;
 pub const RTAX_FEATURE_TIMESTAMP: u32 = 4;
 pub const RTAX_FEATURE_ALLFRAG: u32 = 8;
-pub const RTAX_FEATURE_MASK: u32 = 15;
+pub const RTAX_FEATURE_TCP_USEC_TS: u32 = 16;
+pub const RTAX_FEATURE_MASK: u32 = 31;
 pub const TCM_IFINDEX_MAGIC_BLOCK: u32 = 4294967295;
 pub const TCA_DUMP_FLAGS_TERSE: u32 = 1;
 pub const RTMGRP_LINK: u32 = 1;
@@ -821,6 +822,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_2 = _bindgen_ty_2::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_2 = _bindgen_ty_2::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_MASK;
@@ -889,6 +891,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_6 = _bindgen_ty_6::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_HAIRPIN;
@@ -936,6 +940,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_KIND;
@@ -997,501 +1002,510 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_17 = _bindgen_ty_17::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_18 = _bindgen_ty_18::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_21 = _bindgen_ty_21::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_44 = _bindgen_ty_44::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_DSA_MAX;
-pub const IFA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFA_UNSPEC;
-pub const IFA_ADDRESS: _bindgen_ty_54 = _bindgen_ty_54::IFA_ADDRESS;
-pub const IFA_LOCAL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LOCAL;
-pub const IFA_LABEL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LABEL;
-pub const IFA_BROADCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_BROADCAST;
-pub const IFA_ANYCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_ANYCAST;
-pub const IFA_CACHEINFO: _bindgen_ty_54 = _bindgen_ty_54::IFA_CACHEINFO;
-pub const IFA_MULTICAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_MULTICAST;
-pub const IFA_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFA_FLAGS;
-pub const IFA_RT_PRIORITY: _bindgen_ty_54 = _bindgen_ty_54::IFA_RT_PRIORITY;
-pub const IFA_TARGET_NETNSID: _bindgen_ty_54 = _bindgen_ty_54::IFA_TARGET_NETNSID;
-pub const IFA_PROTO: _bindgen_ty_54 = _bindgen_ty_54::IFA_PROTO;
-pub const __IFA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFA_MAX;
-pub const NDA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::NDA_UNSPEC;
-pub const NDA_DST: _bindgen_ty_55 = _bindgen_ty_55::NDA_DST;
-pub const NDA_LLADDR: _bindgen_ty_55 = _bindgen_ty_55::NDA_LLADDR;
-pub const NDA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::NDA_CACHEINFO;
-pub const NDA_PROBES: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROBES;
-pub const NDA_VLAN: _bindgen_ty_55 = _bindgen_ty_55::NDA_VLAN;
-pub const NDA_PORT: _bindgen_ty_55 = _bindgen_ty_55::NDA_PORT;
-pub const NDA_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_VNI;
-pub const NDA_IFINDEX: _bindgen_ty_55 = _bindgen_ty_55::NDA_IFINDEX;
-pub const NDA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::NDA_MASTER;
-pub const NDA_LINK_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::NDA_LINK_NETNSID;
-pub const NDA_SRC_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_SRC_VNI;
-pub const NDA_PROTOCOL: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROTOCOL;
-pub const NDA_NH_ID: _bindgen_ty_55 = _bindgen_ty_55::NDA_NH_ID;
-pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_55 = _bindgen_ty_55::NDA_FDB_EXT_ATTRS;
-pub const NDA_FLAGS_EXT: _bindgen_ty_55 = _bindgen_ty_55::NDA_FLAGS_EXT;
-pub const NDA_NDM_STATE_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_STATE_MASK;
-pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_FLAGS_MASK;
-pub const __NDA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__NDA_MAX;
-pub const NDTPA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UNSPEC;
-pub const NDTPA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_IFINDEX;
-pub const NDTPA_REFCNT: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REFCNT;
-pub const NDTPA_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REACHABLE_TIME;
-pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_BASE_REACHABLE_TIME;
-pub const NDTPA_RETRANS_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_RETRANS_TIME;
-pub const NDTPA_GC_STALETIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_GC_STALETIME;
-pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_DELAY_PROBE_TIME;
-pub const NDTPA_QUEUE_LEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LEN;
-pub const NDTPA_APP_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_APP_PROBES;
-pub const NDTPA_UCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UCAST_PROBES;
-pub const NDTPA_MCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_PROBES;
-pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_ANYCAST_DELAY;
-pub const NDTPA_PROXY_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_DELAY;
-pub const NDTPA_PROXY_QLEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_QLEN;
-pub const NDTPA_LOCKTIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_LOCKTIME;
-pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LENBYTES;
-pub const NDTPA_MCAST_REPROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_REPROBES;
-pub const NDTPA_PAD: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PAD;
-pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_INTERVAL_PROBE_TIME_MS;
-pub const __NDTPA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDTPA_MAX;
-pub const NDTA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTA_UNSPEC;
-pub const NDTA_NAME: _bindgen_ty_57 = _bindgen_ty_57::NDTA_NAME;
-pub const NDTA_THRESH1: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH1;
-pub const NDTA_THRESH2: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH2;
-pub const NDTA_THRESH3: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH3;
-pub const NDTA_CONFIG: _bindgen_ty_57 = _bindgen_ty_57::NDTA_CONFIG;
-pub const NDTA_PARMS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PARMS;
-pub const NDTA_STATS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_STATS;
-pub const NDTA_GC_INTERVAL: _bindgen_ty_57 = _bindgen_ty_57::NDTA_GC_INTERVAL;
-pub const NDTA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PAD;
-pub const __NDTA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTA_MAX;
-pub const FDB_NOTIFY_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_BIT;
-pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_INACTIVE_BIT;
-pub const NFEA_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::NFEA_UNSPEC;
-pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_59 = _bindgen_ty_59::NFEA_ACTIVITY_NOTIFY;
-pub const NFEA_DONT_REFRESH: _bindgen_ty_59 = _bindgen_ty_59::NFEA_DONT_REFRESH;
-pub const __NFEA_MAX: _bindgen_ty_59 = _bindgen_ty_59::__NFEA_MAX;
-pub const RTM_BASE: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_NEWLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_DELLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINK;
-pub const RTM_GETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINK;
-pub const RTM_SETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETLINK;
-pub const RTM_NEWADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDR;
-pub const RTM_DELADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDR;
-pub const RTM_GETADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDR;
-pub const RTM_NEWROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWROUTE;
-pub const RTM_DELROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELROUTE;
-pub const RTM_GETROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETROUTE;
-pub const RTM_NEWNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGH;
-pub const RTM_DELNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEIGH;
-pub const RTM_GETNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGH;
-pub const RTM_NEWRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWRULE;
-pub const RTM_DELRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELRULE;
-pub const RTM_GETRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETRULE;
-pub const RTM_NEWQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWQDISC;
-pub const RTM_DELQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELQDISC;
-pub const RTM_GETQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETQDISC;
-pub const RTM_NEWTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTCLASS;
-pub const RTM_DELTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTCLASS;
-pub const RTM_GETTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTCLASS;
-pub const RTM_NEWTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTFILTER;
-pub const RTM_DELTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTFILTER;
-pub const RTM_GETTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTFILTER;
-pub const RTM_NEWACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWACTION;
-pub const RTM_DELACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELACTION;
-pub const RTM_GETACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETACTION;
-pub const RTM_NEWPREFIX: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWPREFIX;
-pub const RTM_GETMULTICAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMULTICAST;
-pub const RTM_GETANYCAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETANYCAST;
-pub const RTM_NEWNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGHTBL;
-pub const RTM_GETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGHTBL;
-pub const RTM_SETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETNEIGHTBL;
-pub const RTM_NEWNDUSEROPT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNDUSEROPT;
-pub const RTM_NEWADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDRLABEL;
-pub const RTM_DELADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDRLABEL;
-pub const RTM_GETADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDRLABEL;
-pub const RTM_GETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETDCB;
-pub const RTM_SETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETDCB;
-pub const RTM_NEWNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNETCONF;
-pub const RTM_DELNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNETCONF;
-pub const RTM_GETNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNETCONF;
-pub const RTM_NEWMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWMDB;
-pub const RTM_DELMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELMDB;
-pub const RTM_GETMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMDB;
-pub const RTM_NEWNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNSID;
-pub const RTM_DELNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNSID;
-pub const RTM_GETNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNSID;
-pub const RTM_NEWSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWSTATS;
-pub const RTM_GETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETSTATS;
-pub const RTM_SETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETSTATS;
-pub const RTM_NEWCACHEREPORT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCACHEREPORT;
-pub const RTM_NEWCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCHAIN;
-pub const RTM_DELCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELCHAIN;
-pub const RTM_GETCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETCHAIN;
-pub const RTM_NEWNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOP;
-pub const RTM_DELNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOP;
-pub const RTM_GETNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOP;
-pub const RTM_NEWLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWLINKPROP;
-pub const RTM_DELLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINKPROP;
-pub const RTM_GETLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINKPROP;
-pub const RTM_NEWVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWVLAN;
-pub const RTM_DELVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELVLAN;
-pub const RTM_GETVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETVLAN;
-pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOPBUCKET;
-pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOPBUCKET;
-pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOPBUCKET;
-pub const RTM_NEWTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTUNNEL;
-pub const RTM_DELTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTUNNEL;
-pub const RTM_GETTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTUNNEL;
-pub const __RTM_MAX: _bindgen_ty_60 = _bindgen_ty_60::__RTM_MAX;
-pub const RTN_UNSPEC: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNSPEC;
-pub const RTN_UNICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNICAST;
-pub const RTN_LOCAL: _bindgen_ty_61 = _bindgen_ty_61::RTN_LOCAL;
-pub const RTN_BROADCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_BROADCAST;
-pub const RTN_ANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_ANYCAST;
-pub const RTN_MULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_MULTICAST;
-pub const RTN_BLACKHOLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_BLACKHOLE;
-pub const RTN_UNREACHABLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNREACHABLE;
-pub const RTN_PROHIBIT: _bindgen_ty_61 = _bindgen_ty_61::RTN_PROHIBIT;
-pub const RTN_THROW: _bindgen_ty_61 = _bindgen_ty_61::RTN_THROW;
-pub const RTN_NAT: _bindgen_ty_61 = _bindgen_ty_61::RTN_NAT;
-pub const RTN_XRESOLVE: _bindgen_ty_61 = _bindgen_ty_61::RTN_XRESOLVE;
-pub const __RTN_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTN_MAX;
-pub const RTAX_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTAX_UNSPEC;
-pub const RTAX_LOCK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_LOCK;
-pub const RTAX_MTU: _bindgen_ty_62 = _bindgen_ty_62::RTAX_MTU;
-pub const RTAX_WINDOW: _bindgen_ty_62 = _bindgen_ty_62::RTAX_WINDOW;
-pub const RTAX_RTT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTT;
-pub const RTAX_RTTVAR: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTTVAR;
-pub const RTAX_SSTHRESH: _bindgen_ty_62 = _bindgen_ty_62::RTAX_SSTHRESH;
-pub const RTAX_CWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CWND;
-pub const RTAX_ADVMSS: _bindgen_ty_62 = _bindgen_ty_62::RTAX_ADVMSS;
-pub const RTAX_REORDERING: _bindgen_ty_62 = _bindgen_ty_62::RTAX_REORDERING;
-pub const RTAX_HOPLIMIT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_HOPLIMIT;
-pub const RTAX_INITCWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITCWND;
-pub const RTAX_FEATURES: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FEATURES;
-pub const RTAX_RTO_MIN: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTO_MIN;
-pub const RTAX_INITRWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITRWND;
-pub const RTAX_QUICKACK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_QUICKACK;
-pub const RTAX_CC_ALGO: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CC_ALGO;
-pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FASTOPEN_NO_COOKIE;
-pub const __RTAX_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTAX_MAX;
-pub const PREFIX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_UNSPEC;
-pub const PREFIX_ADDRESS: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_ADDRESS;
-pub const PREFIX_CACHEINFO: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_CACHEINFO;
-pub const __PREFIX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__PREFIX_MAX;
-pub const TCA_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::TCA_UNSPEC;
-pub const TCA_KIND: _bindgen_ty_64 = _bindgen_ty_64::TCA_KIND;
-pub const TCA_OPTIONS: _bindgen_ty_64 = _bindgen_ty_64::TCA_OPTIONS;
-pub const TCA_STATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS;
-pub const TCA_XSTATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_XSTATS;
-pub const TCA_RATE: _bindgen_ty_64 = _bindgen_ty_64::TCA_RATE;
-pub const TCA_FCNT: _bindgen_ty_64 = _bindgen_ty_64::TCA_FCNT;
-pub const TCA_STATS2: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS2;
-pub const TCA_STAB: _bindgen_ty_64 = _bindgen_ty_64::TCA_STAB;
-pub const TCA_PAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_PAD;
-pub const TCA_DUMP_INVISIBLE: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_INVISIBLE;
-pub const TCA_CHAIN: _bindgen_ty_64 = _bindgen_ty_64::TCA_CHAIN;
-pub const TCA_HW_OFFLOAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_HW_OFFLOAD;
-pub const TCA_INGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_INGRESS_BLOCK;
-pub const TCA_EGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_EGRESS_BLOCK;
-pub const TCA_DUMP_FLAGS: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_FLAGS;
-pub const TCA_EXT_WARN_MSG: _bindgen_ty_64 = _bindgen_ty_64::TCA_EXT_WARN_MSG;
-pub const __TCA_MAX: _bindgen_ty_64 = _bindgen_ty_64::__TCA_MAX;
-pub const NDUSEROPT_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_UNSPEC;
-pub const NDUSEROPT_SRCADDR: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_SRCADDR;
-pub const __NDUSEROPT_MAX: _bindgen_ty_65 = _bindgen_ty_65::__NDUSEROPT_MAX;
-pub const TCA_ROOT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_UNSPEC;
-pub const TCA_ROOT_TAB: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TAB;
-pub const TCA_ROOT_FLAGS: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_FLAGS;
-pub const TCA_ROOT_COUNT: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_COUNT;
-pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TIME_DELTA;
-pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_EXT_WARN_MSG;
-pub const __TCA_ROOT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__TCA_ROOT_MAX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_18 = _bindgen_ty_18::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_39 = _bindgen_ty_39::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_45 = _bindgen_ty_45::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_DSA_MAX;
+pub const IFA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFA_UNSPEC;
+pub const IFA_ADDRESS: _bindgen_ty_55 = _bindgen_ty_55::IFA_ADDRESS;
+pub const IFA_LOCAL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LOCAL;
+pub const IFA_LABEL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LABEL;
+pub const IFA_BROADCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_BROADCAST;
+pub const IFA_ANYCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_ANYCAST;
+pub const IFA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::IFA_CACHEINFO;
+pub const IFA_MULTICAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_MULTICAST;
+pub const IFA_FLAGS: _bindgen_ty_55 = _bindgen_ty_55::IFA_FLAGS;
+pub const IFA_RT_PRIORITY: _bindgen_ty_55 = _bindgen_ty_55::IFA_RT_PRIORITY;
+pub const IFA_TARGET_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::IFA_TARGET_NETNSID;
+pub const IFA_PROTO: _bindgen_ty_55 = _bindgen_ty_55::IFA_PROTO;
+pub const __IFA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFA_MAX;
+pub const NDA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDA_UNSPEC;
+pub const NDA_DST: _bindgen_ty_56 = _bindgen_ty_56::NDA_DST;
+pub const NDA_LLADDR: _bindgen_ty_56 = _bindgen_ty_56::NDA_LLADDR;
+pub const NDA_CACHEINFO: _bindgen_ty_56 = _bindgen_ty_56::NDA_CACHEINFO;
+pub const NDA_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROBES;
+pub const NDA_VLAN: _bindgen_ty_56 = _bindgen_ty_56::NDA_VLAN;
+pub const NDA_PORT: _bindgen_ty_56 = _bindgen_ty_56::NDA_PORT;
+pub const NDA_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_VNI;
+pub const NDA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDA_IFINDEX;
+pub const NDA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::NDA_MASTER;
+pub const NDA_LINK_NETNSID: _bindgen_ty_56 = _bindgen_ty_56::NDA_LINK_NETNSID;
+pub const NDA_SRC_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_SRC_VNI;
+pub const NDA_PROTOCOL: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROTOCOL;
+pub const NDA_NH_ID: _bindgen_ty_56 = _bindgen_ty_56::NDA_NH_ID;
+pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_56 = _bindgen_ty_56::NDA_FDB_EXT_ATTRS;
+pub const NDA_FLAGS_EXT: _bindgen_ty_56 = _bindgen_ty_56::NDA_FLAGS_EXT;
+pub const NDA_NDM_STATE_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_STATE_MASK;
+pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_FLAGS_MASK;
+pub const __NDA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDA_MAX;
+pub const NDTPA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UNSPEC;
+pub const NDTPA_IFINDEX: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_IFINDEX;
+pub const NDTPA_REFCNT: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REFCNT;
+pub const NDTPA_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REACHABLE_TIME;
+pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_BASE_REACHABLE_TIME;
+pub const NDTPA_RETRANS_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_RETRANS_TIME;
+pub const NDTPA_GC_STALETIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_GC_STALETIME;
+pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_DELAY_PROBE_TIME;
+pub const NDTPA_QUEUE_LEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LEN;
+pub const NDTPA_APP_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_APP_PROBES;
+pub const NDTPA_UCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UCAST_PROBES;
+pub const NDTPA_MCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_PROBES;
+pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_ANYCAST_DELAY;
+pub const NDTPA_PROXY_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_DELAY;
+pub const NDTPA_PROXY_QLEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_QLEN;
+pub const NDTPA_LOCKTIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_LOCKTIME;
+pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LENBYTES;
+pub const NDTPA_MCAST_REPROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_REPROBES;
+pub const NDTPA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PAD;
+pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_INTERVAL_PROBE_TIME_MS;
+pub const __NDTPA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTPA_MAX;
+pub const NDTA_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDTA_UNSPEC;
+pub const NDTA_NAME: _bindgen_ty_58 = _bindgen_ty_58::NDTA_NAME;
+pub const NDTA_THRESH1: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH1;
+pub const NDTA_THRESH2: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH2;
+pub const NDTA_THRESH3: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH3;
+pub const NDTA_CONFIG: _bindgen_ty_58 = _bindgen_ty_58::NDTA_CONFIG;
+pub const NDTA_PARMS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PARMS;
+pub const NDTA_STATS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_STATS;
+pub const NDTA_GC_INTERVAL: _bindgen_ty_58 = _bindgen_ty_58::NDTA_GC_INTERVAL;
+pub const NDTA_PAD: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PAD;
+pub const __NDTA_MAX: _bindgen_ty_58 = _bindgen_ty_58::__NDTA_MAX;
+pub const FDB_NOTIFY_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_BIT;
+pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_INACTIVE_BIT;
+pub const NFEA_UNSPEC: _bindgen_ty_60 = _bindgen_ty_60::NFEA_UNSPEC;
+pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_60 = _bindgen_ty_60::NFEA_ACTIVITY_NOTIFY;
+pub const NFEA_DONT_REFRESH: _bindgen_ty_60 = _bindgen_ty_60::NFEA_DONT_REFRESH;
+pub const __NFEA_MAX: _bindgen_ty_60 = _bindgen_ty_60::__NFEA_MAX;
+pub const RTM_BASE: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_NEWLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_DELLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINK;
+pub const RTM_GETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINK;
+pub const RTM_SETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETLINK;
+pub const RTM_NEWADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDR;
+pub const RTM_DELADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDR;
+pub const RTM_GETADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDR;
+pub const RTM_NEWROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWROUTE;
+pub const RTM_DELROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELROUTE;
+pub const RTM_GETROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETROUTE;
+pub const RTM_NEWNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGH;
+pub const RTM_DELNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEIGH;
+pub const RTM_GETNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGH;
+pub const RTM_NEWRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWRULE;
+pub const RTM_DELRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELRULE;
+pub const RTM_GETRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETRULE;
+pub const RTM_NEWQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWQDISC;
+pub const RTM_DELQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELQDISC;
+pub const RTM_GETQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETQDISC;
+pub const RTM_NEWTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTCLASS;
+pub const RTM_DELTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTCLASS;
+pub const RTM_GETTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTCLASS;
+pub const RTM_NEWTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTFILTER;
+pub const RTM_DELTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTFILTER;
+pub const RTM_GETTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTFILTER;
+pub const RTM_NEWACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWACTION;
+pub const RTM_DELACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELACTION;
+pub const RTM_GETACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETACTION;
+pub const RTM_NEWPREFIX: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWPREFIX;
+pub const RTM_GETMULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMULTICAST;
+pub const RTM_GETANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETANYCAST;
+pub const RTM_NEWNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGHTBL;
+pub const RTM_GETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGHTBL;
+pub const RTM_SETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETNEIGHTBL;
+pub const RTM_NEWNDUSEROPT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNDUSEROPT;
+pub const RTM_NEWADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDRLABEL;
+pub const RTM_DELADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDRLABEL;
+pub const RTM_GETADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDRLABEL;
+pub const RTM_GETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETDCB;
+pub const RTM_SETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETDCB;
+pub const RTM_NEWNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNETCONF;
+pub const RTM_DELNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNETCONF;
+pub const RTM_GETNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNETCONF;
+pub const RTM_NEWMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWMDB;
+pub const RTM_DELMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELMDB;
+pub const RTM_GETMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMDB;
+pub const RTM_NEWNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNSID;
+pub const RTM_DELNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNSID;
+pub const RTM_GETNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNSID;
+pub const RTM_NEWSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWSTATS;
+pub const RTM_GETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETSTATS;
+pub const RTM_SETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETSTATS;
+pub const RTM_NEWCACHEREPORT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCACHEREPORT;
+pub const RTM_NEWCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCHAIN;
+pub const RTM_DELCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELCHAIN;
+pub const RTM_GETCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETCHAIN;
+pub const RTM_NEWNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOP;
+pub const RTM_DELNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOP;
+pub const RTM_GETNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOP;
+pub const RTM_NEWLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWLINKPROP;
+pub const RTM_DELLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINKPROP;
+pub const RTM_GETLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINKPROP;
+pub const RTM_NEWVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWVLAN;
+pub const RTM_DELVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELVLAN;
+pub const RTM_GETVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETVLAN;
+pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOPBUCKET;
+pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOPBUCKET;
+pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOPBUCKET;
+pub const RTM_NEWTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTUNNEL;
+pub const RTM_DELTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTUNNEL;
+pub const RTM_GETTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTUNNEL;
+pub const __RTM_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTM_MAX;
+pub const RTN_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNSPEC;
+pub const RTN_UNICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNICAST;
+pub const RTN_LOCAL: _bindgen_ty_62 = _bindgen_ty_62::RTN_LOCAL;
+pub const RTN_BROADCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_BROADCAST;
+pub const RTN_ANYCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_ANYCAST;
+pub const RTN_MULTICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_MULTICAST;
+pub const RTN_BLACKHOLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_BLACKHOLE;
+pub const RTN_UNREACHABLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNREACHABLE;
+pub const RTN_PROHIBIT: _bindgen_ty_62 = _bindgen_ty_62::RTN_PROHIBIT;
+pub const RTN_THROW: _bindgen_ty_62 = _bindgen_ty_62::RTN_THROW;
+pub const RTN_NAT: _bindgen_ty_62 = _bindgen_ty_62::RTN_NAT;
+pub const RTN_XRESOLVE: _bindgen_ty_62 = _bindgen_ty_62::RTN_XRESOLVE;
+pub const __RTN_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTN_MAX;
+pub const RTAX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::RTAX_UNSPEC;
+pub const RTAX_LOCK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_LOCK;
+pub const RTAX_MTU: _bindgen_ty_63 = _bindgen_ty_63::RTAX_MTU;
+pub const RTAX_WINDOW: _bindgen_ty_63 = _bindgen_ty_63::RTAX_WINDOW;
+pub const RTAX_RTT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTT;
+pub const RTAX_RTTVAR: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTTVAR;
+pub const RTAX_SSTHRESH: _bindgen_ty_63 = _bindgen_ty_63::RTAX_SSTHRESH;
+pub const RTAX_CWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CWND;
+pub const RTAX_ADVMSS: _bindgen_ty_63 = _bindgen_ty_63::RTAX_ADVMSS;
+pub const RTAX_REORDERING: _bindgen_ty_63 = _bindgen_ty_63::RTAX_REORDERING;
+pub const RTAX_HOPLIMIT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_HOPLIMIT;
+pub const RTAX_INITCWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITCWND;
+pub const RTAX_FEATURES: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FEATURES;
+pub const RTAX_RTO_MIN: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTO_MIN;
+pub const RTAX_INITRWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITRWND;
+pub const RTAX_QUICKACK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_QUICKACK;
+pub const RTAX_CC_ALGO: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CC_ALGO;
+pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FASTOPEN_NO_COOKIE;
+pub const __RTAX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__RTAX_MAX;
+pub const PREFIX_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_UNSPEC;
+pub const PREFIX_ADDRESS: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_ADDRESS;
+pub const PREFIX_CACHEINFO: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_CACHEINFO;
+pub const __PREFIX_MAX: _bindgen_ty_64 = _bindgen_ty_64::__PREFIX_MAX;
+pub const TCA_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::TCA_UNSPEC;
+pub const TCA_KIND: _bindgen_ty_65 = _bindgen_ty_65::TCA_KIND;
+pub const TCA_OPTIONS: _bindgen_ty_65 = _bindgen_ty_65::TCA_OPTIONS;
+pub const TCA_STATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS;
+pub const TCA_XSTATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_XSTATS;
+pub const TCA_RATE: _bindgen_ty_65 = _bindgen_ty_65::TCA_RATE;
+pub const TCA_FCNT: _bindgen_ty_65 = _bindgen_ty_65::TCA_FCNT;
+pub const TCA_STATS2: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS2;
+pub const TCA_STAB: _bindgen_ty_65 = _bindgen_ty_65::TCA_STAB;
+pub const TCA_PAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_PAD;
+pub const TCA_DUMP_INVISIBLE: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_INVISIBLE;
+pub const TCA_CHAIN: _bindgen_ty_65 = _bindgen_ty_65::TCA_CHAIN;
+pub const TCA_HW_OFFLOAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_HW_OFFLOAD;
+pub const TCA_INGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_INGRESS_BLOCK;
+pub const TCA_EGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_EGRESS_BLOCK;
+pub const TCA_DUMP_FLAGS: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_FLAGS;
+pub const TCA_EXT_WARN_MSG: _bindgen_ty_65 = _bindgen_ty_65::TCA_EXT_WARN_MSG;
+pub const __TCA_MAX: _bindgen_ty_65 = _bindgen_ty_65::__TCA_MAX;
+pub const NDUSEROPT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_UNSPEC;
+pub const NDUSEROPT_SRCADDR: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_SRCADDR;
+pub const __NDUSEROPT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__NDUSEROPT_MAX;
+pub const TCA_ROOT_UNSPEC: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_UNSPEC;
+pub const TCA_ROOT_TAB: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TAB;
+pub const TCA_ROOT_FLAGS: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_FLAGS;
+pub const TCA_ROOT_COUNT: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_COUNT;
+pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TIME_DELTA;
+pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_EXT_WARN_MSG;
+pub const __TCA_ROOT_MAX: _bindgen_ty_67 = _bindgen_ty_67::__TCA_ROOT_MAX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1542,6 +1556,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1631,7 +1647,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1727,7 +1744,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1784,7 +1803,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1937,10 +1957,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_18 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_19 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -1956,7 +2004,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_19 {
+pub enum _bindgen_ty_20 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -1968,7 +2016,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_20 {
+pub enum _bindgen_ty_21 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -1976,7 +2024,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2009,7 +2057,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2023,7 +2072,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_23 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2053,7 +2110,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2064,7 +2121,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum _bindgen_ty_25 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2079,7 +2136,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2092,7 +2149,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2130,7 +2187,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2142,7 +2199,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2158,7 +2215,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2166,7 +2223,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2186,7 +2243,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2194,7 +2251,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2203,7 +2260,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2218,7 +2275,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2226,7 +2283,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2240,7 +2297,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2249,7 +2306,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2267,7 +2324,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2277,14 +2334,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2292,7 +2349,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2306,7 +2363,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2318,7 +2375,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2327,7 +2384,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2336,7 +2393,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2346,7 +2403,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2355,7 +2412,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2365,7 +2422,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2380,7 +2437,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2392,7 +2449,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2408,7 +2465,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2417,7 +2474,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2425,15 +2482,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFA_UNSPEC = 0,
 IFA_ADDRESS = 1,
 IFA_LOCAL = 2,
@@ -2451,7 +2508,7 @@ __IFA_MAX = 12,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 NDA_UNSPEC = 0,
 NDA_DST = 1,
 NDA_LLADDR = 2,
@@ -2475,7 +2532,7 @@ __NDA_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 NDTPA_UNSPEC = 0,
 NDTPA_IFINDEX = 1,
 NDTPA_REFCNT = 2,
@@ -2501,7 +2558,7 @@ __NDTPA_MAX = 20,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_57 {
+pub enum _bindgen_ty_58 {
 NDTA_UNSPEC = 0,
 NDTA_NAME = 1,
 NDTA_THRESH1 = 2,
@@ -2517,14 +2574,14 @@ __NDTA_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_58 {
+pub enum _bindgen_ty_59 {
 FDB_NOTIFY_BIT = 1,
 FDB_NOTIFY_INACTIVE_BIT = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_59 {
+pub enum _bindgen_ty_60 {
 NFEA_UNSPEC = 0,
 NFEA_ACTIVITY_NOTIFY = 1,
 NFEA_DONT_REFRESH = 2,
@@ -2533,7 +2590,7 @@ __NFEA_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_60 {
+pub enum _bindgen_ty_61 {
 RTM_BASE = 16,
 RTM_DELLINK = 17,
 RTM_GETLINK = 18,
@@ -2610,7 +2667,7 @@ __RTM_MAX = 123,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_61 {
+pub enum _bindgen_ty_62 {
 RTN_UNSPEC = 0,
 RTN_UNICAST = 1,
 RTN_LOCAL = 2,
@@ -2686,7 +2743,7 @@ __RTA_MAX = 31,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_62 {
+pub enum _bindgen_ty_63 {
 RTAX_UNSPEC = 0,
 RTAX_LOCK = 1,
 RTAX_MTU = 2,
@@ -2710,7 +2767,7 @@ __RTAX_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_63 {
+pub enum _bindgen_ty_64 {
 PREFIX_UNSPEC = 0,
 PREFIX_ADDRESS = 1,
 PREFIX_CACHEINFO = 2,
@@ -2719,7 +2776,7 @@ __PREFIX_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_64 {
+pub enum _bindgen_ty_65 {
 TCA_UNSPEC = 0,
 TCA_KIND = 1,
 TCA_OPTIONS = 2,
@@ -2742,7 +2799,7 @@ __TCA_MAX = 17,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_65 {
+pub enum _bindgen_ty_66 {
 NDUSEROPT_UNSPEC = 0,
 NDUSEROPT_SRCADDR = 1,
 __NDUSEROPT_MAX = 2,
@@ -2793,7 +2850,7 @@ __RTNLGRP_MAX = 37,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_66 {
+pub enum _bindgen_ty_67 {
 TCA_ROOT_UNSPEC = 0,
 TCA_ROOT_TAB = 1,
 TCA_ROOT_FLAGS = 2,
@@ -2856,6 +2913,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/riscv64/prctl.rs
+++ b/src/riscv64/prctl.rs
@@ -218,6 +218,7 @@ pub const PR_SME_VL_LEN_MASK: u32 = 65535;
 pub const PR_SME_VL_INHERIT: u32 = 131072;
 pub const PR_SET_MDWE: u32 = 65;
 pub const PR_MDWE_REFUSE_EXEC_GAIN: u32 = 1;
+pub const PR_MDWE_NO_INHERIT: u32 = 2;
 pub const PR_GET_MDWE: u32 = 66;
 pub const PR_SET_VMA: u32 = 1398164801;
 pub const PR_SET_VMA_ANON_NAME: u32 = 0;

--- a/src/riscv64/xdp.rs
+++ b/src/riscv64/xdp.rs
@@ -83,6 +83,7 @@ pub len: __u64,
 pub chunk_size: __u32,
 pub headroom: __u32,
 pub flags: __u32,
+pub tx_metadata_len: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -98,6 +99,23 @@ pub tx_ring_empty_descs: __u64,
 #[derive(Debug, Copy, Clone)]
 pub struct xdp_options {
 pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct xsk_tx_metadata {
+pub flags: __u64,
+pub __bindgen_anon_1: xsk_tx_metadata__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1 {
+pub csum_start: __u16,
+pub csum_offset: __u16,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2 {
+pub tx_timestamp: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -140,7 +158,9 @@ pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
 pub const XDP_USE_NEED_WAKEUP: u32 = 8;
+pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
+pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;
@@ -157,5 +177,13 @@ pub const XDP_UMEM_PGOFF_FILL_RING: u64 = 4294967296;
 pub const XDP_UMEM_PGOFF_COMPLETION_RING: u64 = 6442450944;
 pub const XSK_UNALIGNED_BUF_OFFSET_SHIFT: u32 = 48;
 pub const XSK_UNALIGNED_BUF_ADDR_MASK: u64 = 281474976710655;
-pub const XDP_USE_SG: u32 = 16;
+pub const XDP_TXMD_FLAGS_TIMESTAMP: u32 = 1;
+pub const XDP_TXMD_FLAGS_CHECKSUM: u32 = 2;
 pub const XDP_PKT_CONTD: u32 = 1;
+pub const XDP_TX_METADATA: u32 = 2;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union xsk_tx_metadata__bindgen_ty_1 {
+pub request: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1,
+pub completion: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2,
+}

--- a/src/s390x/general.rs
+++ b/src/s390x/general.rs
@@ -198,7 +198,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -253,6 +254,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -311,6 +345,29 @@ pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
 pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -408,36 +465,6 @@ pub tv_usec: __s64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct timespec {
-pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: crate::ctypes::c_long,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timeval {
-pub tv_sec: __kernel_old_time_t,
-pub tv_usec: __kernel_suseconds_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerspec {
-pub it_interval: timespec,
-pub it_value: timespec,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerval {
-pub it_interval: timeval,
-pub it_value: timeval,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timezone {
-pub tz_minuteswest: crate::ctypes::c_int,
-pub tz_dsttime: crate::ctypes::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct rusage {
 pub ru_utime: __kernel_old_timeval,
 pub ru_stime: __kernel_old_timeval,
@@ -482,6 +509,36 @@ pub tls: __u64,
 pub set_tid: __u64,
 pub set_tid_size: __u64,
 pub cgroup: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timespec {
+pub tv_sec: __kernel_old_time_t,
+pub tv_nsec: crate::ctypes::c_long,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timeval {
+pub tv_sec: __kernel_old_time_t,
+pub tv_usec: __kernel_suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerspec {
+pub it_interval: timespec,
+pub it_value: timespec,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerval {
+pub it_interval: timeval,
+pub it_value: timeval,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timezone {
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -783,6 +840,22 @@ pub mode: __u64,
 pub mapped: __s64,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_poison {
+pub range: uffdio_range,
+pub mode: __u64,
+pub updated: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_move {
+pub dst: __u64,
+pub src: __u64,
+pub len: __u64,
+pub mode: __u64,
+pub move_: __s64,
+}
+#[repr(C)]
 #[derive(Debug)]
 pub struct linux_dirent64 {
 pub d_ino: crate::ctypes::c_ulong,
@@ -868,9 +941,9 @@ pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 394496;
+pub const LINUX_VERSION_CODE: u32 = 395264;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 5;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_VECTOR_SIZE_ARCH: u32 = 1;
@@ -1239,6 +1312,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1310,6 +1391,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const FUTEX_WAIT: u32 = 0;
 pub const FUTEX_WAKE: u32 = 1;
 pub const FUTEX_FD: u32 = 2;
@@ -1340,6 +1431,13 @@ pub const FUTEX_WAIT_BITSET_PRIVATE: u32 = 137;
 pub const FUTEX_WAKE_BITSET_PRIVATE: u32 = 138;
 pub const FUTEX_WAIT_REQUEUE_PI_PRIVATE: u32 = 139;
 pub const FUTEX_CMP_REQUEUE_PI_PRIVATE: u32 = 140;
+pub const FUTEX2_SIZE_U8: u32 = 0;
+pub const FUTEX2_SIZE_U16: u32 = 1;
+pub const FUTEX2_SIZE_U32: u32 = 2;
+pub const FUTEX2_SIZE_U64: u32 = 3;
+pub const FUTEX2_NUMA: u32 = 4;
+pub const FUTEX2_PRIVATE: u32 = 128;
+pub const FUTEX2_SIZE_MASK: u32 = 3;
 pub const FUTEX_32: u32 = 2;
 pub const FUTEX_WAITV_MAX: u32 = 128;
 pub const FUTEX_WAITERS: u32 = 2147483648;
@@ -1596,25 +1694,6 @@ pub const LINUX_REBOOT_CMD_POWER_OFF: u32 = 1126301404;
 pub const LINUX_REBOOT_CMD_RESTART2: u32 = 2712847316;
 pub const LINUX_REBOOT_CMD_SW_SUSPEND: u32 = 3489725666;
 pub const LINUX_REBOOT_CMD_KEXEC: u32 = 1163412803;
-pub const ITIMER_REAL: u32 = 0;
-pub const ITIMER_VIRTUAL: u32 = 1;
-pub const ITIMER_PROF: u32 = 2;
-pub const CLOCK_REALTIME: u32 = 0;
-pub const CLOCK_MONOTONIC: u32 = 1;
-pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
-pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
-pub const CLOCK_MONOTONIC_RAW: u32 = 4;
-pub const CLOCK_REALTIME_COARSE: u32 = 5;
-pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
-pub const CLOCK_BOOTTIME: u32 = 7;
-pub const CLOCK_REALTIME_ALARM: u32 = 8;
-pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
-pub const CLOCK_SGI_CYCLE: u32 = 10;
-pub const CLOCK_TAI: u32 = 11;
-pub const MAX_CLOCKS: u32 = 16;
-pub const CLOCKS_MASK: u32 = 1;
-pub const CLOCKS_MONO: u32 = 1;
-pub const TIMER_ABSTIME: u32 = 1;
 pub const RUSAGE_SELF: u32 = 0;
 pub const RUSAGE_CHILDREN: i32 = -1;
 pub const RUSAGE_BOTH: i32 = -2;
@@ -1693,6 +1772,25 @@ pub const SCHED_FLAG_UTIL_CLAMP_MAX: u32 = 64;
 pub const SCHED_FLAG_KEEP_ALL: u32 = 24;
 pub const SCHED_FLAG_UTIL_CLAMP: u32 = 96;
 pub const SCHED_FLAG_ALL: u32 = 127;
+pub const ITIMER_REAL: u32 = 0;
+pub const ITIMER_VIRTUAL: u32 = 1;
+pub const ITIMER_PROF: u32 = 2;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_SGI_CYCLE: u32 = 10;
+pub const CLOCK_TAI: u32 = 11;
+pub const MAX_CLOCKS: u32 = 16;
+pub const CLOCKS_MASK: u32 = 1;
+pub const CLOCKS_MONO: u32 = 1;
+pub const TIMER_ABSTIME: u32 = 1;
 pub const NSIG: u32 = 32;
 pub const SIGHUP: u32 = 1;
 pub const SIGINT: u32 = 2;
@@ -1794,7 +1892,8 @@ pub const SEGV_ADIDERR: u32 = 6;
 pub const SEGV_ADIPERR: u32 = 7;
 pub const SEGV_MTEAERR: u32 = 8;
 pub const SEGV_MTESERR: u32 = 9;
-pub const NSIGSEGV: u32 = 9;
+pub const SEGV_CPERR: u32 = 10;
+pub const NSIGSEGV: u32 = 10;
 pub const BUS_ADRALN: u32 = 1;
 pub const BUS_ADRERR: u32 = 2;
 pub const BUS_OBJERR: u32 = 3;
@@ -1875,6 +1974,7 @@ pub const STATX_BASIC_STATS: u32 = 2047;
 pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
+pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2424,6 +2524,16 @@ pub const __NR_process_mrelease: u32 = 448;
 pub const __NR_futex_waitv: u32 = 449;
 pub const __NR_set_mempolicy_home_node: u32 = 450;
 pub const __NR_cachestat: u32 = 451;
+pub const __NR_fchmodat2: u32 = 452;
+pub const __NR_map_shadow_stack: u32 = 453;
+pub const __NR_futex_wake: u32 = 454;
+pub const __NR_futex_wait: u32 = 455;
+pub const __NR_futex_requeue: u32 = 456;
+pub const __NR_statmount: u32 = 457;
+pub const __NR_listmount: u32 = 458;
+pub const __NR_lsm_get_self_attr: u32 = 459;
+pub const __NR_lsm_set_self_attr: u32 = 460;
+pub const __NR_lsm_list_modules: u32 = 461;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
 pub const WSTOPPED: u32 = 2;
@@ -2502,8 +2612,10 @@ pub const _UFFDIO_UNREGISTER: u32 = 1;
 pub const _UFFDIO_WAKE: u32 = 2;
 pub const _UFFDIO_COPY: u32 = 3;
 pub const _UFFDIO_ZEROPAGE: u32 = 4;
+pub const _UFFDIO_MOVE: u32 = 5;
 pub const _UFFDIO_WRITEPROTECT: u32 = 6;
 pub const _UFFDIO_CONTINUE: u32 = 7;
+pub const _UFFDIO_POISON: u32 = 8;
 pub const _UFFDIO_API: u32 = 63;
 pub const UFFDIO: u32 = 170;
 pub const UFFD_EVENT_PAGEFAULT: u32 = 18;
@@ -2528,6 +2640,9 @@ pub const UFFD_FEATURE_MINOR_SHMEM: u32 = 1024;
 pub const UFFD_FEATURE_EXACT_ADDRESS: u32 = 2048;
 pub const UFFD_FEATURE_WP_HUGETLBFS_SHMEM: u32 = 4096;
 pub const UFFD_FEATURE_WP_UNPOPULATED: u32 = 8192;
+pub const UFFD_FEATURE_POISON: u32 = 16384;
+pub const UFFD_FEATURE_WP_ASYNC: u32 = 32768;
+pub const UFFD_FEATURE_MOVE: u32 = 65536;
 pub const UFFD_USER_MODE_ONLY: u32 = 1;
 pub const DT_UNKNOWN: u32 = 0;
 pub const DT_FIFO: u32 = 1;
@@ -2603,6 +2718,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/s390x/if_arp.rs
+++ b/src/s390x/if_arp.rs
@@ -54,11 +54,6 @@ pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
-#[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
 #[repr(C, packed(4))]
 #[derive(Copy, Clone)]
 pub struct __vector128 {
@@ -189,6 +184,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -196,23 +192,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -1140,6 +1121,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_4 = _bindgen_ty_4::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_4 = _bindgen_ty_4::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_MASK;
@@ -1208,6 +1190,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_HAIRPIN;
@@ -1255,6 +1239,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_10 = _bindgen_ty_10::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_KIND;
@@ -1316,301 +1301,310 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_19 = _bindgen_ty_19::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_40 = _bindgen_ty_40::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_46 = _bindgen_ty_46::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_DSA_MAX;
-pub const IF_PORT_UNKNOWN: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_UNKNOWN;
-pub const IF_PORT_10BASE2: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASE2;
-pub const IF_PORT_10BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASET;
-pub const IF_PORT_AUI: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_AUI;
-pub const IF_PORT_100BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASET;
-pub const IF_PORT_100BASETX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASETX;
-pub const IF_PORT_100BASEFX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASEFX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_20 = _bindgen_ty_20::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_23 = _bindgen_ty_23::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_47 = _bindgen_ty_47::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__IFLA_DSA_MAX;
+pub const IF_PORT_UNKNOWN: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_UNKNOWN;
+pub const IF_PORT_10BASE2: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASE2;
+pub const IF_PORT_10BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASET;
+pub const IF_PORT_AUI: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_AUI;
+pub const IF_PORT_100BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASET;
+pub const IF_PORT_100BASETX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASETX;
+pub const IF_PORT_100BASEFX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASEFX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1713,6 +1707,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1802,7 +1798,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1898,7 +1895,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1955,7 +1954,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2108,10 +2108,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_20 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_21 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -2127,7 +2155,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -2139,7 +2167,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum _bindgen_ty_23 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -2147,7 +2175,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2180,7 +2208,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2194,7 +2223,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_25 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2224,7 +2261,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2235,7 +2272,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2250,7 +2287,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2263,7 +2300,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2301,7 +2338,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2313,7 +2350,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2329,7 +2366,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2337,7 +2374,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2357,7 +2394,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2365,7 +2402,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2374,7 +2411,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2389,7 +2426,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2397,7 +2434,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2411,7 +2448,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2420,7 +2457,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2438,7 +2475,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2448,14 +2485,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2463,7 +2500,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2477,7 +2514,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2489,7 +2526,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2498,7 +2535,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2507,7 +2544,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2517,7 +2554,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2526,7 +2563,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2536,7 +2573,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2551,7 +2588,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2563,7 +2600,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2579,7 +2616,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2588,7 +2625,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2596,15 +2633,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 IF_PORT_UNKNOWN = 0,
 IF_PORT_10BASE2 = 1,
 IF_PORT_10BASET = 2,
@@ -2693,74 +2730,6 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 impl nlmsgerr_attrs {
 pub const NLMSGERR_ATTR_MAX: nlmsgerr_attrs = nlmsgerr_attrs::NLMSGERR_ATTR_MISS_NEST;
 }
@@ -2775,6 +2744,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/s390x/if_packet.rs
+++ b/src/s390x/if_packet.rs
@@ -53,11 +53,6 @@ pub type __be64 = __u64;
 pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
-#[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
 #[repr(C, packed(4))]
 #[derive(Copy, Clone)]
 pub struct __vector128 {
@@ -77,6 +72,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -84,23 +80,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -347,71 +328,3 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}

--- a/src/s390x/io_uring.rs
+++ b/src/s390x/io_uring.rs
@@ -93,7 +93,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -148,6 +149,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -209,6 +243,29 @@ pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
 pub tv_nsec: crate::ctypes::c_longlong,
@@ -267,6 +324,12 @@ pub __pad1: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_sqe__bindgen_ty_2__bindgen_ty_1 {
+pub level: __u32,
+pub optname: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_sqe__bindgen_ty_5__bindgen_ty_1 {
 pub addr_len: __u16,
 pub __pad3: [__u16; 1usize],
@@ -274,6 +337,7 @@ pub __pad3: [__u16; 1usize],
 #[repr(C)]
 pub struct io_uring_sqe__bindgen_ty_6 {
 pub __bindgen_anon_1: __BindgenUnionField<io_uring_sqe__bindgen_ty_6__bindgen_ty_1>,
+pub optval: __BindgenUnionField<__u64>,
 pub cmd: __BindgenUnionField<[__u8; 0usize]>,
 pub bindgen_union_field: [u64; 2usize],
 }
@@ -435,6 +499,13 @@ pub resv: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_buf_status {
+pub buf_group: __u32,
+pub head: __u32,
+pub resv: [__u32; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -448,7 +519,9 @@ pub addr: __u64,
 pub fd: __s32,
 pub flags: __u32,
 pub timeout: __kernel_timespec,
-pub pad: [__u64; 4usize],
+pub opcode: __u8,
+pub pad: [__u8; 7usize],
+pub pad2: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -611,6 +684,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -682,6 +763,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const IORING_FILE_INDEX_ALLOC: i32 = -1;
 pub const IORING_SETUP_IOPOLL: u32 = 1;
 pub const IORING_SETUP_SQPOLL: u32 = 2;
@@ -699,8 +790,9 @@ pub const IORING_SETUP_SINGLE_ISSUER: u32 = 4096;
 pub const IORING_SETUP_DEFER_TASKRUN: u32 = 8192;
 pub const IORING_SETUP_NO_MMAP: u32 = 16384;
 pub const IORING_SETUP_REGISTERED_FD_ONLY: u32 = 32768;
+pub const IORING_SETUP_NO_SQARRAY: u32 = 65536;
 pub const IORING_URING_CMD_FIXED: u32 = 1;
-pub const IORING_URING_CMD_POLLED: u32 = 2147483648;
+pub const IORING_URING_CMD_MASK: u32 = 1;
 pub const IORING_FSYNC_DATASYNC: u32 = 1;
 pub const IORING_TIMEOUT_ABS: u32 = 1;
 pub const IORING_TIMEOUT_UPDATE: u32 = 2;
@@ -720,6 +812,8 @@ pub const IORING_ASYNC_CANCEL_ALL: u32 = 1;
 pub const IORING_ASYNC_CANCEL_FD: u32 = 2;
 pub const IORING_ASYNC_CANCEL_ANY: u32 = 4;
 pub const IORING_ASYNC_CANCEL_FD_FIXED: u32 = 8;
+pub const IORING_ASYNC_CANCEL_USERDATA: u32 = 16;
+pub const IORING_ASYNC_CANCEL_OP: u32 = 32;
 pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
@@ -728,6 +822,7 @@ pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
+pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
@@ -800,6 +895,7 @@ pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGIS
 pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
 pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
 pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
+pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
 pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
 pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
 pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
@@ -810,6 +906,10 @@ pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTR
 pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
 pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
 pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
+pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
+pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
+pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
+pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -822,6 +922,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -888,7 +989,13 @@ IORING_OP_SOCKET = 45,
 IORING_OP_URING_CMD = 46,
 IORING_OP_SEND_ZC = 47,
 IORING_OP_SENDMSG_ZC = 48,
-IORING_OP_LAST = 49,
+IORING_OP_READ_MULTISHOT = 49,
+IORING_OP_WAITID = 50,
+IORING_OP_FUTEX_WAIT = 51,
+IORING_OP_FUTEX_WAKE = 52,
+IORING_OP_FUTEX_WAITV = 53,
+IORING_OP_FIXED_FD_INSTALL = 54,
+IORING_OP_LAST = 55,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -933,7 +1040,8 @@ IORING_REGISTER_PBUF_RING = 22,
 IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
-IORING_REGISTER_LAST = 26,
+IORING_REGISTER_PBUF_STATUS = 26,
+IORING_REGISTER_LAST = 27,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
@@ -958,6 +1066,15 @@ IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
 IORING_RESTRICTION_SQE_FLAGS_REQUIRED = 3,
 IORING_RESTRICTION_LAST = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_8 {
+SOCKET_URING_OP_SIOCINQ = 0,
+SOCKET_URING_OP_SIOCOUTQ = 1,
+SOCKET_URING_OP_GETSOCKOPT = 2,
+SOCKET_URING_OP_SETSOCKOPT = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -991,6 +1108,7 @@ pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_1__bindgen_ty_1,
 pub union io_uring_sqe__bindgen_ty_2 {
 pub addr: __u64,
 pub splice_off_in: __u64,
+pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_2__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -1014,6 +1132,9 @@ pub hardlink_flags: __u32,
 pub xattr_flags: __u32,
 pub msg_ring_flags: __u32,
 pub uring_cmd_flags: __u32,
+pub waitid_flags: __u32,
+pub futex_flags: __u32,
+pub install_fd_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]
@@ -1026,6 +1147,7 @@ pub buf_group: __u16,
 pub union io_uring_sqe__bindgen_ty_5 {
 pub splice_fd_in: __s32,
 pub file_index: __u32,
+pub optlen: __u32,
 pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]

--- a/src/s390x/net.rs
+++ b/src/s390x/net.rs
@@ -443,6 +443,9 @@ pub tcpi_rcv_ooopack: __u32,
 pub tcpi_snd_wnd: __u32,
 pub tcpi_rcv_wnd: __u32,
 pub tcpi_rehash: __u32,
+pub tcpi_total_rto: __u16,
+pub tcpi_total_rto_recoveries: __u16,
+pub tcpi_total_rto_time: __u32,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -462,6 +465,80 @@ pub tcpm_prefixlen: __u8,
 pub tcpm_keylen: __u16,
 pub tcpm_addr: [__be32; 4usize],
 pub tcpm_key: [__u8; 80usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_add {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub key: [__u8; 80usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_del {
+pub addr: __kernel_sockaddr_storage,
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub current_key: __u8,
+pub rnext: __u8,
+pub keyflags: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_info_opt {
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub current_key: __u8,
+pub rnext: __u8,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+pub pkt_key_not_found: __u64,
+pub pkt_ao_required: __u64,
+pub pkt_dropped_icmp: __u64,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_getsockopt {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub key: [__u8; 80usize],
+pub nkeys: __u32,
+pub _bitfield_align_1: [u16; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub prefix: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub ifindex: __s32,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_repair {
+pub snt_isn: __be32,
+pub rcv_isn: __be32,
+pub snd_sne: __u32,
+pub rcv_sne: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1199,6 +1276,11 @@ pub const TCP_ZEROCOPY_RECEIVE: u32 = 35;
 pub const TCP_INQ: u32 = 36;
 pub const TCP_CM_INQ: u32 = 36;
 pub const TCP_TX_DELAY: u32 = 37;
+pub const TCP_AO_ADD_KEY: u32 = 38;
+pub const TCP_AO_DEL_KEY: u32 = 39;
+pub const TCP_AO_INFO: u32 = 40;
+pub const TCP_AO_GET_KEYS: u32 = 41;
+pub const TCP_AO_REPAIR: u32 = 42;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1208,9 +1290,13 @@ pub const TCPI_OPT_WSCALE: u32 = 4;
 pub const TCPI_OPT_ECN: u32 = 8;
 pub const TCPI_OPT_ECN_SEEN: u32 = 16;
 pub const TCPI_OPT_SYN_DATA: u32 = 32;
+pub const TCPI_OPT_USEC_TS: u32 = 64;
 pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
+pub const TCP_AO_MAXKEYLEN: u32 = 80;
+pub const TCP_AO_KEYF_IFINDEX: u32 = 1;
+pub const TCP_AO_KEYF_EXCLUDE_OPT: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
@@ -1575,6 +1661,7 @@ pub const DEVCONF_IOAM6_ID: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID;
 pub const DEVCONF_IOAM6_ID_WIDE: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID_WIDE;
 pub const DEVCONF_NDISC_EVICT_NOCARRIER: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_NDISC_EVICT_NOCARRIER;
 pub const DEVCONF_ACCEPT_UNTRACKED_NA: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_UNTRACKED_NA;
+pub const DEVCONF_ACCEPT_RA_MIN_LFT: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_RA_MIN_LFT;
 pub const DEVCONF_MAX: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_MAX;
 pub const TCP_FLAG_CWR: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_CWR;
 pub const TCP_FLAG_ECE: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_ECE;
@@ -1772,7 +1859,8 @@ DEVCONF_IOAM6_ID = 54,
 DEVCONF_IOAM6_ID_WIDE = 55,
 DEVCONF_NDISC_EVICT_NOCARRIER = 56,
 DEVCONF_ACCEPT_UNTRACKED_NA = 57,
-DEVCONF_MAX = 58,
+DEVCONF_ACCEPT_RA_MIN_LFT = 58,
+DEVCONF_MAX = 59,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2496,6 +2584,289 @@ tcpi_delivery_rate_app_limited as u64
 __bindgen_bitfield_unit.set(9usize, 2u8, {
 let tcpi_fastopen_client_fail: u8 = unsafe { ::core::mem::transmute(tcpi_fastopen_client_fail) };
 tcpi_fastopen_client_fail as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_add {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 30u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 30u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_del {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn del_async(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_del_async(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 29u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 29u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, del_async: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let del_async: u32 = unsafe { ::core::mem::transmute(del_async) };
+del_async as u64
+});
+__bindgen_bitfield_unit.set(3usize, 29u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_info_opt {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn ao_required(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_ao_required(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_counters(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_counters(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn accept_icmps(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_accept_icmps(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(4usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(5usize, 27u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(5usize, 27u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, ao_required: __u32, set_counters: __u32, accept_icmps: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let ao_required: u32 = unsafe { ::core::mem::transmute(ao_required) };
+ao_required as u64
+});
+__bindgen_bitfield_unit.set(3usize, 1u8, {
+let set_counters: u32 = unsafe { ::core::mem::transmute(set_counters) };
+set_counters as u64
+});
+__bindgen_bitfield_unit.set(4usize, 1u8, {
+let accept_icmps: u32 = unsafe { ::core::mem::transmute(accept_icmps) };
+accept_icmps as u64
+});
+__bindgen_bitfield_unit.set(5usize, 27u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_getsockopt {
+#[inline]
+pub fn is_current(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_current(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn is_rnext(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_rnext(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn get_all(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_get_all(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 13u8) as u16) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 13u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(is_current: __u16, is_rnext: __u16, get_all: __u16, reserved: __u16) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let is_current: u16 = unsafe { ::core::mem::transmute(is_current) };
+is_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let is_rnext: u16 = unsafe { ::core::mem::transmute(is_rnext) };
+is_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let get_all: u16 = unsafe { ::core::mem::transmute(get_all) };
+get_all as u64
+});
+__bindgen_bitfield_unit.set(3usize, 13u8, {
+let reserved: u16 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
 });
 __bindgen_bitfield_unit
 }

--- a/src/s390x/netlink.rs
+++ b/src/s390x/netlink.rs
@@ -738,7 +738,8 @@ pub const RTAX_FEATURE_ECN: u32 = 1;
 pub const RTAX_FEATURE_SACK: u32 = 2;
 pub const RTAX_FEATURE_TIMESTAMP: u32 = 4;
 pub const RTAX_FEATURE_ALLFRAG: u32 = 8;
-pub const RTAX_FEATURE_MASK: u32 = 15;
+pub const RTAX_FEATURE_TCP_USEC_TS: u32 = 16;
+pub const RTAX_FEATURE_MASK: u32 = 31;
 pub const TCM_IFINDEX_MAGIC_BLOCK: u32 = 4294967295;
 pub const TCA_DUMP_FLAGS_TERSE: u32 = 1;
 pub const RTMGRP_LINK: u32 = 1;
@@ -835,6 +836,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_2 = _bindgen_ty_2::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_2 = _bindgen_ty_2::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_MASK;
@@ -903,6 +905,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_6 = _bindgen_ty_6::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_HAIRPIN;
@@ -950,6 +954,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_KIND;
@@ -1011,501 +1016,510 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_17 = _bindgen_ty_17::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_18 = _bindgen_ty_18::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_21 = _bindgen_ty_21::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_44 = _bindgen_ty_44::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_DSA_MAX;
-pub const IFA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFA_UNSPEC;
-pub const IFA_ADDRESS: _bindgen_ty_54 = _bindgen_ty_54::IFA_ADDRESS;
-pub const IFA_LOCAL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LOCAL;
-pub const IFA_LABEL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LABEL;
-pub const IFA_BROADCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_BROADCAST;
-pub const IFA_ANYCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_ANYCAST;
-pub const IFA_CACHEINFO: _bindgen_ty_54 = _bindgen_ty_54::IFA_CACHEINFO;
-pub const IFA_MULTICAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_MULTICAST;
-pub const IFA_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFA_FLAGS;
-pub const IFA_RT_PRIORITY: _bindgen_ty_54 = _bindgen_ty_54::IFA_RT_PRIORITY;
-pub const IFA_TARGET_NETNSID: _bindgen_ty_54 = _bindgen_ty_54::IFA_TARGET_NETNSID;
-pub const IFA_PROTO: _bindgen_ty_54 = _bindgen_ty_54::IFA_PROTO;
-pub const __IFA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFA_MAX;
-pub const NDA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::NDA_UNSPEC;
-pub const NDA_DST: _bindgen_ty_55 = _bindgen_ty_55::NDA_DST;
-pub const NDA_LLADDR: _bindgen_ty_55 = _bindgen_ty_55::NDA_LLADDR;
-pub const NDA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::NDA_CACHEINFO;
-pub const NDA_PROBES: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROBES;
-pub const NDA_VLAN: _bindgen_ty_55 = _bindgen_ty_55::NDA_VLAN;
-pub const NDA_PORT: _bindgen_ty_55 = _bindgen_ty_55::NDA_PORT;
-pub const NDA_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_VNI;
-pub const NDA_IFINDEX: _bindgen_ty_55 = _bindgen_ty_55::NDA_IFINDEX;
-pub const NDA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::NDA_MASTER;
-pub const NDA_LINK_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::NDA_LINK_NETNSID;
-pub const NDA_SRC_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_SRC_VNI;
-pub const NDA_PROTOCOL: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROTOCOL;
-pub const NDA_NH_ID: _bindgen_ty_55 = _bindgen_ty_55::NDA_NH_ID;
-pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_55 = _bindgen_ty_55::NDA_FDB_EXT_ATTRS;
-pub const NDA_FLAGS_EXT: _bindgen_ty_55 = _bindgen_ty_55::NDA_FLAGS_EXT;
-pub const NDA_NDM_STATE_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_STATE_MASK;
-pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_FLAGS_MASK;
-pub const __NDA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__NDA_MAX;
-pub const NDTPA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UNSPEC;
-pub const NDTPA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_IFINDEX;
-pub const NDTPA_REFCNT: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REFCNT;
-pub const NDTPA_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REACHABLE_TIME;
-pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_BASE_REACHABLE_TIME;
-pub const NDTPA_RETRANS_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_RETRANS_TIME;
-pub const NDTPA_GC_STALETIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_GC_STALETIME;
-pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_DELAY_PROBE_TIME;
-pub const NDTPA_QUEUE_LEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LEN;
-pub const NDTPA_APP_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_APP_PROBES;
-pub const NDTPA_UCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UCAST_PROBES;
-pub const NDTPA_MCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_PROBES;
-pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_ANYCAST_DELAY;
-pub const NDTPA_PROXY_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_DELAY;
-pub const NDTPA_PROXY_QLEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_QLEN;
-pub const NDTPA_LOCKTIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_LOCKTIME;
-pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LENBYTES;
-pub const NDTPA_MCAST_REPROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_REPROBES;
-pub const NDTPA_PAD: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PAD;
-pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_INTERVAL_PROBE_TIME_MS;
-pub const __NDTPA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDTPA_MAX;
-pub const NDTA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTA_UNSPEC;
-pub const NDTA_NAME: _bindgen_ty_57 = _bindgen_ty_57::NDTA_NAME;
-pub const NDTA_THRESH1: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH1;
-pub const NDTA_THRESH2: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH2;
-pub const NDTA_THRESH3: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH3;
-pub const NDTA_CONFIG: _bindgen_ty_57 = _bindgen_ty_57::NDTA_CONFIG;
-pub const NDTA_PARMS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PARMS;
-pub const NDTA_STATS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_STATS;
-pub const NDTA_GC_INTERVAL: _bindgen_ty_57 = _bindgen_ty_57::NDTA_GC_INTERVAL;
-pub const NDTA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PAD;
-pub const __NDTA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTA_MAX;
-pub const FDB_NOTIFY_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_BIT;
-pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_INACTIVE_BIT;
-pub const NFEA_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::NFEA_UNSPEC;
-pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_59 = _bindgen_ty_59::NFEA_ACTIVITY_NOTIFY;
-pub const NFEA_DONT_REFRESH: _bindgen_ty_59 = _bindgen_ty_59::NFEA_DONT_REFRESH;
-pub const __NFEA_MAX: _bindgen_ty_59 = _bindgen_ty_59::__NFEA_MAX;
-pub const RTM_BASE: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_NEWLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_DELLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINK;
-pub const RTM_GETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINK;
-pub const RTM_SETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETLINK;
-pub const RTM_NEWADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDR;
-pub const RTM_DELADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDR;
-pub const RTM_GETADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDR;
-pub const RTM_NEWROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWROUTE;
-pub const RTM_DELROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELROUTE;
-pub const RTM_GETROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETROUTE;
-pub const RTM_NEWNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGH;
-pub const RTM_DELNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEIGH;
-pub const RTM_GETNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGH;
-pub const RTM_NEWRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWRULE;
-pub const RTM_DELRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELRULE;
-pub const RTM_GETRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETRULE;
-pub const RTM_NEWQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWQDISC;
-pub const RTM_DELQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELQDISC;
-pub const RTM_GETQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETQDISC;
-pub const RTM_NEWTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTCLASS;
-pub const RTM_DELTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTCLASS;
-pub const RTM_GETTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTCLASS;
-pub const RTM_NEWTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTFILTER;
-pub const RTM_DELTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTFILTER;
-pub const RTM_GETTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTFILTER;
-pub const RTM_NEWACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWACTION;
-pub const RTM_DELACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELACTION;
-pub const RTM_GETACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETACTION;
-pub const RTM_NEWPREFIX: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWPREFIX;
-pub const RTM_GETMULTICAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMULTICAST;
-pub const RTM_GETANYCAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETANYCAST;
-pub const RTM_NEWNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGHTBL;
-pub const RTM_GETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGHTBL;
-pub const RTM_SETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETNEIGHTBL;
-pub const RTM_NEWNDUSEROPT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNDUSEROPT;
-pub const RTM_NEWADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDRLABEL;
-pub const RTM_DELADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDRLABEL;
-pub const RTM_GETADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDRLABEL;
-pub const RTM_GETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETDCB;
-pub const RTM_SETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETDCB;
-pub const RTM_NEWNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNETCONF;
-pub const RTM_DELNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNETCONF;
-pub const RTM_GETNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNETCONF;
-pub const RTM_NEWMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWMDB;
-pub const RTM_DELMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELMDB;
-pub const RTM_GETMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMDB;
-pub const RTM_NEWNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNSID;
-pub const RTM_DELNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNSID;
-pub const RTM_GETNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNSID;
-pub const RTM_NEWSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWSTATS;
-pub const RTM_GETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETSTATS;
-pub const RTM_SETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETSTATS;
-pub const RTM_NEWCACHEREPORT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCACHEREPORT;
-pub const RTM_NEWCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCHAIN;
-pub const RTM_DELCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELCHAIN;
-pub const RTM_GETCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETCHAIN;
-pub const RTM_NEWNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOP;
-pub const RTM_DELNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOP;
-pub const RTM_GETNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOP;
-pub const RTM_NEWLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWLINKPROP;
-pub const RTM_DELLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINKPROP;
-pub const RTM_GETLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINKPROP;
-pub const RTM_NEWVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWVLAN;
-pub const RTM_DELVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELVLAN;
-pub const RTM_GETVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETVLAN;
-pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOPBUCKET;
-pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOPBUCKET;
-pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOPBUCKET;
-pub const RTM_NEWTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTUNNEL;
-pub const RTM_DELTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTUNNEL;
-pub const RTM_GETTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTUNNEL;
-pub const __RTM_MAX: _bindgen_ty_60 = _bindgen_ty_60::__RTM_MAX;
-pub const RTN_UNSPEC: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNSPEC;
-pub const RTN_UNICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNICAST;
-pub const RTN_LOCAL: _bindgen_ty_61 = _bindgen_ty_61::RTN_LOCAL;
-pub const RTN_BROADCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_BROADCAST;
-pub const RTN_ANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_ANYCAST;
-pub const RTN_MULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_MULTICAST;
-pub const RTN_BLACKHOLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_BLACKHOLE;
-pub const RTN_UNREACHABLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNREACHABLE;
-pub const RTN_PROHIBIT: _bindgen_ty_61 = _bindgen_ty_61::RTN_PROHIBIT;
-pub const RTN_THROW: _bindgen_ty_61 = _bindgen_ty_61::RTN_THROW;
-pub const RTN_NAT: _bindgen_ty_61 = _bindgen_ty_61::RTN_NAT;
-pub const RTN_XRESOLVE: _bindgen_ty_61 = _bindgen_ty_61::RTN_XRESOLVE;
-pub const __RTN_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTN_MAX;
-pub const RTAX_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTAX_UNSPEC;
-pub const RTAX_LOCK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_LOCK;
-pub const RTAX_MTU: _bindgen_ty_62 = _bindgen_ty_62::RTAX_MTU;
-pub const RTAX_WINDOW: _bindgen_ty_62 = _bindgen_ty_62::RTAX_WINDOW;
-pub const RTAX_RTT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTT;
-pub const RTAX_RTTVAR: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTTVAR;
-pub const RTAX_SSTHRESH: _bindgen_ty_62 = _bindgen_ty_62::RTAX_SSTHRESH;
-pub const RTAX_CWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CWND;
-pub const RTAX_ADVMSS: _bindgen_ty_62 = _bindgen_ty_62::RTAX_ADVMSS;
-pub const RTAX_REORDERING: _bindgen_ty_62 = _bindgen_ty_62::RTAX_REORDERING;
-pub const RTAX_HOPLIMIT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_HOPLIMIT;
-pub const RTAX_INITCWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITCWND;
-pub const RTAX_FEATURES: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FEATURES;
-pub const RTAX_RTO_MIN: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTO_MIN;
-pub const RTAX_INITRWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITRWND;
-pub const RTAX_QUICKACK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_QUICKACK;
-pub const RTAX_CC_ALGO: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CC_ALGO;
-pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FASTOPEN_NO_COOKIE;
-pub const __RTAX_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTAX_MAX;
-pub const PREFIX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_UNSPEC;
-pub const PREFIX_ADDRESS: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_ADDRESS;
-pub const PREFIX_CACHEINFO: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_CACHEINFO;
-pub const __PREFIX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__PREFIX_MAX;
-pub const TCA_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::TCA_UNSPEC;
-pub const TCA_KIND: _bindgen_ty_64 = _bindgen_ty_64::TCA_KIND;
-pub const TCA_OPTIONS: _bindgen_ty_64 = _bindgen_ty_64::TCA_OPTIONS;
-pub const TCA_STATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS;
-pub const TCA_XSTATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_XSTATS;
-pub const TCA_RATE: _bindgen_ty_64 = _bindgen_ty_64::TCA_RATE;
-pub const TCA_FCNT: _bindgen_ty_64 = _bindgen_ty_64::TCA_FCNT;
-pub const TCA_STATS2: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS2;
-pub const TCA_STAB: _bindgen_ty_64 = _bindgen_ty_64::TCA_STAB;
-pub const TCA_PAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_PAD;
-pub const TCA_DUMP_INVISIBLE: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_INVISIBLE;
-pub const TCA_CHAIN: _bindgen_ty_64 = _bindgen_ty_64::TCA_CHAIN;
-pub const TCA_HW_OFFLOAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_HW_OFFLOAD;
-pub const TCA_INGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_INGRESS_BLOCK;
-pub const TCA_EGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_EGRESS_BLOCK;
-pub const TCA_DUMP_FLAGS: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_FLAGS;
-pub const TCA_EXT_WARN_MSG: _bindgen_ty_64 = _bindgen_ty_64::TCA_EXT_WARN_MSG;
-pub const __TCA_MAX: _bindgen_ty_64 = _bindgen_ty_64::__TCA_MAX;
-pub const NDUSEROPT_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_UNSPEC;
-pub const NDUSEROPT_SRCADDR: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_SRCADDR;
-pub const __NDUSEROPT_MAX: _bindgen_ty_65 = _bindgen_ty_65::__NDUSEROPT_MAX;
-pub const TCA_ROOT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_UNSPEC;
-pub const TCA_ROOT_TAB: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TAB;
-pub const TCA_ROOT_FLAGS: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_FLAGS;
-pub const TCA_ROOT_COUNT: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_COUNT;
-pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TIME_DELTA;
-pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_EXT_WARN_MSG;
-pub const __TCA_ROOT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__TCA_ROOT_MAX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_18 = _bindgen_ty_18::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_39 = _bindgen_ty_39::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_45 = _bindgen_ty_45::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_DSA_MAX;
+pub const IFA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFA_UNSPEC;
+pub const IFA_ADDRESS: _bindgen_ty_55 = _bindgen_ty_55::IFA_ADDRESS;
+pub const IFA_LOCAL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LOCAL;
+pub const IFA_LABEL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LABEL;
+pub const IFA_BROADCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_BROADCAST;
+pub const IFA_ANYCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_ANYCAST;
+pub const IFA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::IFA_CACHEINFO;
+pub const IFA_MULTICAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_MULTICAST;
+pub const IFA_FLAGS: _bindgen_ty_55 = _bindgen_ty_55::IFA_FLAGS;
+pub const IFA_RT_PRIORITY: _bindgen_ty_55 = _bindgen_ty_55::IFA_RT_PRIORITY;
+pub const IFA_TARGET_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::IFA_TARGET_NETNSID;
+pub const IFA_PROTO: _bindgen_ty_55 = _bindgen_ty_55::IFA_PROTO;
+pub const __IFA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFA_MAX;
+pub const NDA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDA_UNSPEC;
+pub const NDA_DST: _bindgen_ty_56 = _bindgen_ty_56::NDA_DST;
+pub const NDA_LLADDR: _bindgen_ty_56 = _bindgen_ty_56::NDA_LLADDR;
+pub const NDA_CACHEINFO: _bindgen_ty_56 = _bindgen_ty_56::NDA_CACHEINFO;
+pub const NDA_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROBES;
+pub const NDA_VLAN: _bindgen_ty_56 = _bindgen_ty_56::NDA_VLAN;
+pub const NDA_PORT: _bindgen_ty_56 = _bindgen_ty_56::NDA_PORT;
+pub const NDA_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_VNI;
+pub const NDA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDA_IFINDEX;
+pub const NDA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::NDA_MASTER;
+pub const NDA_LINK_NETNSID: _bindgen_ty_56 = _bindgen_ty_56::NDA_LINK_NETNSID;
+pub const NDA_SRC_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_SRC_VNI;
+pub const NDA_PROTOCOL: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROTOCOL;
+pub const NDA_NH_ID: _bindgen_ty_56 = _bindgen_ty_56::NDA_NH_ID;
+pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_56 = _bindgen_ty_56::NDA_FDB_EXT_ATTRS;
+pub const NDA_FLAGS_EXT: _bindgen_ty_56 = _bindgen_ty_56::NDA_FLAGS_EXT;
+pub const NDA_NDM_STATE_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_STATE_MASK;
+pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_FLAGS_MASK;
+pub const __NDA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDA_MAX;
+pub const NDTPA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UNSPEC;
+pub const NDTPA_IFINDEX: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_IFINDEX;
+pub const NDTPA_REFCNT: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REFCNT;
+pub const NDTPA_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REACHABLE_TIME;
+pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_BASE_REACHABLE_TIME;
+pub const NDTPA_RETRANS_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_RETRANS_TIME;
+pub const NDTPA_GC_STALETIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_GC_STALETIME;
+pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_DELAY_PROBE_TIME;
+pub const NDTPA_QUEUE_LEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LEN;
+pub const NDTPA_APP_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_APP_PROBES;
+pub const NDTPA_UCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UCAST_PROBES;
+pub const NDTPA_MCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_PROBES;
+pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_ANYCAST_DELAY;
+pub const NDTPA_PROXY_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_DELAY;
+pub const NDTPA_PROXY_QLEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_QLEN;
+pub const NDTPA_LOCKTIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_LOCKTIME;
+pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LENBYTES;
+pub const NDTPA_MCAST_REPROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_REPROBES;
+pub const NDTPA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PAD;
+pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_INTERVAL_PROBE_TIME_MS;
+pub const __NDTPA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTPA_MAX;
+pub const NDTA_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDTA_UNSPEC;
+pub const NDTA_NAME: _bindgen_ty_58 = _bindgen_ty_58::NDTA_NAME;
+pub const NDTA_THRESH1: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH1;
+pub const NDTA_THRESH2: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH2;
+pub const NDTA_THRESH3: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH3;
+pub const NDTA_CONFIG: _bindgen_ty_58 = _bindgen_ty_58::NDTA_CONFIG;
+pub const NDTA_PARMS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PARMS;
+pub const NDTA_STATS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_STATS;
+pub const NDTA_GC_INTERVAL: _bindgen_ty_58 = _bindgen_ty_58::NDTA_GC_INTERVAL;
+pub const NDTA_PAD: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PAD;
+pub const __NDTA_MAX: _bindgen_ty_58 = _bindgen_ty_58::__NDTA_MAX;
+pub const FDB_NOTIFY_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_BIT;
+pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_INACTIVE_BIT;
+pub const NFEA_UNSPEC: _bindgen_ty_60 = _bindgen_ty_60::NFEA_UNSPEC;
+pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_60 = _bindgen_ty_60::NFEA_ACTIVITY_NOTIFY;
+pub const NFEA_DONT_REFRESH: _bindgen_ty_60 = _bindgen_ty_60::NFEA_DONT_REFRESH;
+pub const __NFEA_MAX: _bindgen_ty_60 = _bindgen_ty_60::__NFEA_MAX;
+pub const RTM_BASE: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_NEWLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_DELLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINK;
+pub const RTM_GETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINK;
+pub const RTM_SETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETLINK;
+pub const RTM_NEWADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDR;
+pub const RTM_DELADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDR;
+pub const RTM_GETADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDR;
+pub const RTM_NEWROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWROUTE;
+pub const RTM_DELROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELROUTE;
+pub const RTM_GETROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETROUTE;
+pub const RTM_NEWNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGH;
+pub const RTM_DELNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEIGH;
+pub const RTM_GETNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGH;
+pub const RTM_NEWRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWRULE;
+pub const RTM_DELRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELRULE;
+pub const RTM_GETRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETRULE;
+pub const RTM_NEWQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWQDISC;
+pub const RTM_DELQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELQDISC;
+pub const RTM_GETQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETQDISC;
+pub const RTM_NEWTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTCLASS;
+pub const RTM_DELTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTCLASS;
+pub const RTM_GETTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTCLASS;
+pub const RTM_NEWTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTFILTER;
+pub const RTM_DELTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTFILTER;
+pub const RTM_GETTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTFILTER;
+pub const RTM_NEWACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWACTION;
+pub const RTM_DELACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELACTION;
+pub const RTM_GETACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETACTION;
+pub const RTM_NEWPREFIX: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWPREFIX;
+pub const RTM_GETMULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMULTICAST;
+pub const RTM_GETANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETANYCAST;
+pub const RTM_NEWNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGHTBL;
+pub const RTM_GETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGHTBL;
+pub const RTM_SETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETNEIGHTBL;
+pub const RTM_NEWNDUSEROPT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNDUSEROPT;
+pub const RTM_NEWADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDRLABEL;
+pub const RTM_DELADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDRLABEL;
+pub const RTM_GETADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDRLABEL;
+pub const RTM_GETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETDCB;
+pub const RTM_SETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETDCB;
+pub const RTM_NEWNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNETCONF;
+pub const RTM_DELNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNETCONF;
+pub const RTM_GETNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNETCONF;
+pub const RTM_NEWMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWMDB;
+pub const RTM_DELMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELMDB;
+pub const RTM_GETMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMDB;
+pub const RTM_NEWNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNSID;
+pub const RTM_DELNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNSID;
+pub const RTM_GETNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNSID;
+pub const RTM_NEWSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWSTATS;
+pub const RTM_GETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETSTATS;
+pub const RTM_SETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETSTATS;
+pub const RTM_NEWCACHEREPORT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCACHEREPORT;
+pub const RTM_NEWCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCHAIN;
+pub const RTM_DELCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELCHAIN;
+pub const RTM_GETCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETCHAIN;
+pub const RTM_NEWNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOP;
+pub const RTM_DELNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOP;
+pub const RTM_GETNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOP;
+pub const RTM_NEWLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWLINKPROP;
+pub const RTM_DELLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINKPROP;
+pub const RTM_GETLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINKPROP;
+pub const RTM_NEWVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWVLAN;
+pub const RTM_DELVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELVLAN;
+pub const RTM_GETVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETVLAN;
+pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOPBUCKET;
+pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOPBUCKET;
+pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOPBUCKET;
+pub const RTM_NEWTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTUNNEL;
+pub const RTM_DELTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTUNNEL;
+pub const RTM_GETTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTUNNEL;
+pub const __RTM_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTM_MAX;
+pub const RTN_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNSPEC;
+pub const RTN_UNICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNICAST;
+pub const RTN_LOCAL: _bindgen_ty_62 = _bindgen_ty_62::RTN_LOCAL;
+pub const RTN_BROADCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_BROADCAST;
+pub const RTN_ANYCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_ANYCAST;
+pub const RTN_MULTICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_MULTICAST;
+pub const RTN_BLACKHOLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_BLACKHOLE;
+pub const RTN_UNREACHABLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNREACHABLE;
+pub const RTN_PROHIBIT: _bindgen_ty_62 = _bindgen_ty_62::RTN_PROHIBIT;
+pub const RTN_THROW: _bindgen_ty_62 = _bindgen_ty_62::RTN_THROW;
+pub const RTN_NAT: _bindgen_ty_62 = _bindgen_ty_62::RTN_NAT;
+pub const RTN_XRESOLVE: _bindgen_ty_62 = _bindgen_ty_62::RTN_XRESOLVE;
+pub const __RTN_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTN_MAX;
+pub const RTAX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::RTAX_UNSPEC;
+pub const RTAX_LOCK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_LOCK;
+pub const RTAX_MTU: _bindgen_ty_63 = _bindgen_ty_63::RTAX_MTU;
+pub const RTAX_WINDOW: _bindgen_ty_63 = _bindgen_ty_63::RTAX_WINDOW;
+pub const RTAX_RTT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTT;
+pub const RTAX_RTTVAR: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTTVAR;
+pub const RTAX_SSTHRESH: _bindgen_ty_63 = _bindgen_ty_63::RTAX_SSTHRESH;
+pub const RTAX_CWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CWND;
+pub const RTAX_ADVMSS: _bindgen_ty_63 = _bindgen_ty_63::RTAX_ADVMSS;
+pub const RTAX_REORDERING: _bindgen_ty_63 = _bindgen_ty_63::RTAX_REORDERING;
+pub const RTAX_HOPLIMIT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_HOPLIMIT;
+pub const RTAX_INITCWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITCWND;
+pub const RTAX_FEATURES: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FEATURES;
+pub const RTAX_RTO_MIN: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTO_MIN;
+pub const RTAX_INITRWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITRWND;
+pub const RTAX_QUICKACK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_QUICKACK;
+pub const RTAX_CC_ALGO: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CC_ALGO;
+pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FASTOPEN_NO_COOKIE;
+pub const __RTAX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__RTAX_MAX;
+pub const PREFIX_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_UNSPEC;
+pub const PREFIX_ADDRESS: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_ADDRESS;
+pub const PREFIX_CACHEINFO: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_CACHEINFO;
+pub const __PREFIX_MAX: _bindgen_ty_64 = _bindgen_ty_64::__PREFIX_MAX;
+pub const TCA_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::TCA_UNSPEC;
+pub const TCA_KIND: _bindgen_ty_65 = _bindgen_ty_65::TCA_KIND;
+pub const TCA_OPTIONS: _bindgen_ty_65 = _bindgen_ty_65::TCA_OPTIONS;
+pub const TCA_STATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS;
+pub const TCA_XSTATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_XSTATS;
+pub const TCA_RATE: _bindgen_ty_65 = _bindgen_ty_65::TCA_RATE;
+pub const TCA_FCNT: _bindgen_ty_65 = _bindgen_ty_65::TCA_FCNT;
+pub const TCA_STATS2: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS2;
+pub const TCA_STAB: _bindgen_ty_65 = _bindgen_ty_65::TCA_STAB;
+pub const TCA_PAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_PAD;
+pub const TCA_DUMP_INVISIBLE: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_INVISIBLE;
+pub const TCA_CHAIN: _bindgen_ty_65 = _bindgen_ty_65::TCA_CHAIN;
+pub const TCA_HW_OFFLOAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_HW_OFFLOAD;
+pub const TCA_INGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_INGRESS_BLOCK;
+pub const TCA_EGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_EGRESS_BLOCK;
+pub const TCA_DUMP_FLAGS: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_FLAGS;
+pub const TCA_EXT_WARN_MSG: _bindgen_ty_65 = _bindgen_ty_65::TCA_EXT_WARN_MSG;
+pub const __TCA_MAX: _bindgen_ty_65 = _bindgen_ty_65::__TCA_MAX;
+pub const NDUSEROPT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_UNSPEC;
+pub const NDUSEROPT_SRCADDR: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_SRCADDR;
+pub const __NDUSEROPT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__NDUSEROPT_MAX;
+pub const TCA_ROOT_UNSPEC: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_UNSPEC;
+pub const TCA_ROOT_TAB: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TAB;
+pub const TCA_ROOT_FLAGS: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_FLAGS;
+pub const TCA_ROOT_COUNT: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_COUNT;
+pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TIME_DELTA;
+pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_EXT_WARN_MSG;
+pub const __TCA_ROOT_MAX: _bindgen_ty_67 = _bindgen_ty_67::__TCA_ROOT_MAX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1556,6 +1570,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1645,7 +1661,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1741,7 +1758,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1798,7 +1817,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1951,10 +1971,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_18 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_19 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -1970,7 +2018,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_19 {
+pub enum _bindgen_ty_20 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -1982,7 +2030,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_20 {
+pub enum _bindgen_ty_21 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -1990,7 +2038,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2023,7 +2071,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2037,7 +2086,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_23 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2067,7 +2124,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2078,7 +2135,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum _bindgen_ty_25 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2093,7 +2150,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2106,7 +2163,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2144,7 +2201,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2156,7 +2213,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2172,7 +2229,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2180,7 +2237,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2200,7 +2257,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2208,7 +2265,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2217,7 +2274,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2232,7 +2289,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2240,7 +2297,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2254,7 +2311,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2263,7 +2320,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2281,7 +2338,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2291,14 +2348,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2306,7 +2363,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2320,7 +2377,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2332,7 +2389,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2341,7 +2398,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2350,7 +2407,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2360,7 +2417,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2369,7 +2426,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2379,7 +2436,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2394,7 +2451,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2406,7 +2463,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2422,7 +2479,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2431,7 +2488,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2439,15 +2496,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFA_UNSPEC = 0,
 IFA_ADDRESS = 1,
 IFA_LOCAL = 2,
@@ -2465,7 +2522,7 @@ __IFA_MAX = 12,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 NDA_UNSPEC = 0,
 NDA_DST = 1,
 NDA_LLADDR = 2,
@@ -2489,7 +2546,7 @@ __NDA_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 NDTPA_UNSPEC = 0,
 NDTPA_IFINDEX = 1,
 NDTPA_REFCNT = 2,
@@ -2515,7 +2572,7 @@ __NDTPA_MAX = 20,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_57 {
+pub enum _bindgen_ty_58 {
 NDTA_UNSPEC = 0,
 NDTA_NAME = 1,
 NDTA_THRESH1 = 2,
@@ -2531,14 +2588,14 @@ __NDTA_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_58 {
+pub enum _bindgen_ty_59 {
 FDB_NOTIFY_BIT = 1,
 FDB_NOTIFY_INACTIVE_BIT = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_59 {
+pub enum _bindgen_ty_60 {
 NFEA_UNSPEC = 0,
 NFEA_ACTIVITY_NOTIFY = 1,
 NFEA_DONT_REFRESH = 2,
@@ -2547,7 +2604,7 @@ __NFEA_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_60 {
+pub enum _bindgen_ty_61 {
 RTM_BASE = 16,
 RTM_DELLINK = 17,
 RTM_GETLINK = 18,
@@ -2624,7 +2681,7 @@ __RTM_MAX = 123,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_61 {
+pub enum _bindgen_ty_62 {
 RTN_UNSPEC = 0,
 RTN_UNICAST = 1,
 RTN_LOCAL = 2,
@@ -2700,7 +2757,7 @@ __RTA_MAX = 31,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_62 {
+pub enum _bindgen_ty_63 {
 RTAX_UNSPEC = 0,
 RTAX_LOCK = 1,
 RTAX_MTU = 2,
@@ -2724,7 +2781,7 @@ __RTAX_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_63 {
+pub enum _bindgen_ty_64 {
 PREFIX_UNSPEC = 0,
 PREFIX_ADDRESS = 1,
 PREFIX_CACHEINFO = 2,
@@ -2733,7 +2790,7 @@ __PREFIX_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_64 {
+pub enum _bindgen_ty_65 {
 TCA_UNSPEC = 0,
 TCA_KIND = 1,
 TCA_OPTIONS = 2,
@@ -2756,7 +2813,7 @@ __TCA_MAX = 17,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_65 {
+pub enum _bindgen_ty_66 {
 NDUSEROPT_UNSPEC = 0,
 NDUSEROPT_SRCADDR = 1,
 __NDUSEROPT_MAX = 2,
@@ -2807,7 +2864,7 @@ __RTNLGRP_MAX = 37,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_66 {
+pub enum _bindgen_ty_67 {
 TCA_ROOT_UNSPEC = 0,
 TCA_ROOT_TAB = 1,
 TCA_ROOT_FLAGS = 2,
@@ -2876,6 +2933,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/s390x/prctl.rs
+++ b/src/s390x/prctl.rs
@@ -232,6 +232,7 @@ pub const PR_SME_VL_LEN_MASK: u32 = 65535;
 pub const PR_SME_VL_INHERIT: u32 = 131072;
 pub const PR_SET_MDWE: u32 = 65;
 pub const PR_MDWE_REFUSE_EXEC_GAIN: u32 = 1;
+pub const PR_MDWE_NO_INHERIT: u32 = 2;
 pub const PR_GET_MDWE: u32 = 66;
 pub const PR_SET_VMA: u32 = 1398164801;
 pub const PR_SET_VMA_ANON_NAME: u32 = 0;

--- a/src/s390x/xdp.rs
+++ b/src/s390x/xdp.rs
@@ -97,6 +97,7 @@ pub len: __u64,
 pub chunk_size: __u32,
 pub headroom: __u32,
 pub flags: __u32,
+pub tx_metadata_len: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -112,6 +113,23 @@ pub tx_ring_empty_descs: __u64,
 #[derive(Debug, Copy, Clone)]
 pub struct xdp_options {
 pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct xsk_tx_metadata {
+pub flags: __u64,
+pub __bindgen_anon_1: xsk_tx_metadata__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1 {
+pub csum_start: __u16,
+pub csum_offset: __u16,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2 {
+pub tx_timestamp: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -154,7 +172,9 @@ pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
 pub const XDP_USE_NEED_WAKEUP: u32 = 8;
+pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
+pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;
@@ -171,11 +191,19 @@ pub const XDP_UMEM_PGOFF_FILL_RING: u64 = 4294967296;
 pub const XDP_UMEM_PGOFF_COMPLETION_RING: u64 = 6442450944;
 pub const XSK_UNALIGNED_BUF_OFFSET_SHIFT: u32 = 48;
 pub const XSK_UNALIGNED_BUF_ADDR_MASK: u64 = 281474976710655;
-pub const XDP_USE_SG: u32 = 16;
+pub const XDP_TXMD_FLAGS_TIMESTAMP: u32 = 1;
+pub const XDP_TXMD_FLAGS_CHECKSUM: u32 = 2;
 pub const XDP_PKT_CONTD: u32 = 1;
+pub const XDP_TX_METADATA: u32 = 2;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __vector128__bindgen_ty_1 {
 pub __bindgen_anon_1: __vector128__bindgen_ty_1__bindgen_ty_1,
 pub u: [__u32; 4usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union xsk_tx_metadata__bindgen_ty_1 {
+pub request: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1,
+pub completion: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2,
 }

--- a/src/sparc/general.rs
+++ b/src/sparc/general.rs
@@ -183,7 +183,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -238,6 +239,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -296,6 +330,29 @@ pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
 pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -390,36 +447,6 @@ pub it_value: __kernel_old_timeval,
 pub struct __kernel_sock_timeval {
 pub tv_sec: __s64,
 pub tv_usec: __s64,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timespec {
-pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: crate::ctypes::c_long,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timeval {
-pub tv_sec: __kernel_old_time_t,
-pub tv_usec: __kernel_suseconds_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerspec {
-pub it_interval: timespec,
-pub it_value: timespec,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerval {
-pub it_interval: timeval,
-pub it_value: timeval,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timezone {
-pub tz_minuteswest: crate::ctypes::c_int,
-pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -687,6 +714,36 @@ pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct timespec {
+pub tv_sec: __kernel_old_time_t,
+pub tv_nsec: crate::ctypes::c_long,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timeval {
+pub tv_sec: __kernel_old_time_t,
+pub tv_usec: __kernel_suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerspec {
+pub it_interval: timespec,
+pub it_value: timespec,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerval {
+pub it_interval: timeval,
+pub it_value: timeval,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timezone {
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct iovec {
 pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
@@ -780,6 +837,22 @@ pub struct uffdio_continue {
 pub range: uffdio_range,
 pub mode: __u64,
 pub mapped: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_poison {
+pub range: uffdio_range,
+pub mode: __u64,
+pub updated: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_move {
+pub dst: __u64,
+pub src: __u64,
+pub len: __u64,
+pub mode: __u64,
+pub move_: __s64,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -905,9 +978,9 @@ pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 394496;
+pub const LINUX_VERSION_CODE: u32 = 395264;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 5;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_ADI_BLKSZ: u32 = 48;
@@ -1283,6 +1356,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1354,6 +1435,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const FUTEX_WAIT: u32 = 0;
 pub const FUTEX_WAKE: u32 = 1;
 pub const FUTEX_FD: u32 = 2;
@@ -1384,6 +1475,13 @@ pub const FUTEX_WAIT_BITSET_PRIVATE: u32 = 137;
 pub const FUTEX_WAKE_BITSET_PRIVATE: u32 = 138;
 pub const FUTEX_WAIT_REQUEUE_PI_PRIVATE: u32 = 139;
 pub const FUTEX_CMP_REQUEUE_PI_PRIVATE: u32 = 140;
+pub const FUTEX2_SIZE_U8: u32 = 0;
+pub const FUTEX2_SIZE_U16: u32 = 1;
+pub const FUTEX2_SIZE_U32: u32 = 2;
+pub const FUTEX2_SIZE_U64: u32 = 3;
+pub const FUTEX2_NUMA: u32 = 4;
+pub const FUTEX2_PRIVATE: u32 = 128;
+pub const FUTEX2_SIZE_MASK: u32 = 3;
 pub const FUTEX_32: u32 = 2;
 pub const FUTEX_WAITV_MAX: u32 = 128;
 pub const FUTEX_WAITERS: u32 = 2147483648;
@@ -1643,25 +1741,6 @@ pub const LINUX_REBOOT_CMD_POWER_OFF: u32 = 1126301404;
 pub const LINUX_REBOOT_CMD_RESTART2: u32 = 2712847316;
 pub const LINUX_REBOOT_CMD_SW_SUSPEND: u32 = 3489725666;
 pub const LINUX_REBOOT_CMD_KEXEC: u32 = 1163412803;
-pub const ITIMER_REAL: u32 = 0;
-pub const ITIMER_VIRTUAL: u32 = 1;
-pub const ITIMER_PROF: u32 = 2;
-pub const CLOCK_REALTIME: u32 = 0;
-pub const CLOCK_MONOTONIC: u32 = 1;
-pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
-pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
-pub const CLOCK_MONOTONIC_RAW: u32 = 4;
-pub const CLOCK_REALTIME_COARSE: u32 = 5;
-pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
-pub const CLOCK_BOOTTIME: u32 = 7;
-pub const CLOCK_REALTIME_ALARM: u32 = 8;
-pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
-pub const CLOCK_SGI_CYCLE: u32 = 10;
-pub const CLOCK_TAI: u32 = 11;
-pub const MAX_CLOCKS: u32 = 16;
-pub const CLOCKS_MASK: u32 = 1;
-pub const CLOCKS_MONO: u32 = 1;
-pub const TIMER_ABSTIME: u32 = 1;
 pub const RUSAGE_SELF: u32 = 0;
 pub const RUSAGE_CHILDREN: i32 = -1;
 pub const RUSAGE_BOTH: i32 = -2;
@@ -1871,7 +1950,8 @@ pub const SEGV_ADIDERR: u32 = 6;
 pub const SEGV_ADIPERR: u32 = 7;
 pub const SEGV_MTEAERR: u32 = 8;
 pub const SEGV_MTESERR: u32 = 9;
-pub const NSIGSEGV: u32 = 9;
+pub const SEGV_CPERR: u32 = 10;
+pub const NSIGSEGV: u32 = 10;
 pub const BUS_ADRALN: u32 = 1;
 pub const BUS_ADRERR: u32 = 2;
 pub const BUS_OBJERR: u32 = 3;
@@ -1953,6 +2033,7 @@ pub const STATX_BASIC_STATS: u32 = 2047;
 pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
+pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2134,6 +2215,25 @@ pub const TIOCSER_TEMT: u32 = 1;
 pub const TCSANOW: u32 = 0;
 pub const TCSADRAIN: u32 = 1;
 pub const TCSAFLUSH: u32 = 2;
+pub const ITIMER_REAL: u32 = 0;
+pub const ITIMER_VIRTUAL: u32 = 1;
+pub const ITIMER_PROF: u32 = 2;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_SGI_CYCLE: u32 = 10;
+pub const CLOCK_TAI: u32 = 11;
+pub const MAX_CLOCKS: u32 = 16;
+pub const CLOCKS_MASK: u32 = 1;
+pub const CLOCKS_MONO: u32 = 1;
+pub const TIMER_ABSTIME: u32 = 1;
 pub const UIO_FASTIOV: u32 = 8;
 pub const UIO_MAXIOV: u32 = 1024;
 pub const __NR_restart_syscall: u32 = 0;
@@ -2556,6 +2656,16 @@ pub const __NR_process_mrelease: u32 = 448;
 pub const __NR_futex_waitv: u32 = 449;
 pub const __NR_set_mempolicy_home_node: u32 = 450;
 pub const __NR_cachestat: u32 = 451;
+pub const __NR_fchmodat2: u32 = 452;
+pub const __NR_map_shadow_stack: u32 = 453;
+pub const __NR_futex_wake: u32 = 454;
+pub const __NR_futex_wait: u32 = 455;
+pub const __NR_futex_requeue: u32 = 456;
+pub const __NR_statmount: u32 = 457;
+pub const __NR_listmount: u32 = 458;
+pub const __NR_lsm_get_self_attr: u32 = 459;
+pub const __NR_lsm_set_self_attr: u32 = 460;
+pub const __NR_lsm_list_modules: u32 = 461;
 pub const KERN_FEATURE_MIXED_MODE_STACK: u32 = 1;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
@@ -2635,8 +2745,10 @@ pub const _UFFDIO_UNREGISTER: u32 = 1;
 pub const _UFFDIO_WAKE: u32 = 2;
 pub const _UFFDIO_COPY: u32 = 3;
 pub const _UFFDIO_ZEROPAGE: u32 = 4;
+pub const _UFFDIO_MOVE: u32 = 5;
 pub const _UFFDIO_WRITEPROTECT: u32 = 6;
 pub const _UFFDIO_CONTINUE: u32 = 7;
+pub const _UFFDIO_POISON: u32 = 8;
 pub const _UFFDIO_API: u32 = 63;
 pub const UFFDIO: u32 = 170;
 pub const UFFD_EVENT_PAGEFAULT: u32 = 18;
@@ -2661,6 +2773,9 @@ pub const UFFD_FEATURE_MINOR_SHMEM: u32 = 1024;
 pub const UFFD_FEATURE_EXACT_ADDRESS: u32 = 2048;
 pub const UFFD_FEATURE_WP_HUGETLBFS_SHMEM: u32 = 4096;
 pub const UFFD_FEATURE_WP_UNPOPULATED: u32 = 8192;
+pub const UFFD_FEATURE_POISON: u32 = 16384;
+pub const UFFD_FEATURE_WP_ASYNC: u32 = 32768;
+pub const UFFD_FEATURE_MOVE: u32 = 65536;
 pub const UFFD_USER_MODE_ONLY: u32 = 1;
 pub const DT_UNKNOWN: u32 = 0;
 pub const DT_FIFO: u32 = 1;
@@ -2735,6 +2850,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/sparc/if_arp.rs
+++ b/src/sparc/if_arp.rs
@@ -50,11 +50,6 @@ pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
@@ -173,6 +168,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -180,23 +176,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -1340,6 +1321,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_4 = _bindgen_ty_4::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_4 = _bindgen_ty_4::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_MASK;
@@ -1408,6 +1390,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_HAIRPIN;
@@ -1455,6 +1439,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_10 = _bindgen_ty_10::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_KIND;
@@ -1516,301 +1501,310 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_19 = _bindgen_ty_19::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_40 = _bindgen_ty_40::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_46 = _bindgen_ty_46::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_DSA_MAX;
-pub const IF_PORT_UNKNOWN: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_UNKNOWN;
-pub const IF_PORT_10BASE2: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASE2;
-pub const IF_PORT_10BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASET;
-pub const IF_PORT_AUI: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_AUI;
-pub const IF_PORT_100BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASET;
-pub const IF_PORT_100BASETX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASETX;
-pub const IF_PORT_100BASEFX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASEFX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_20 = _bindgen_ty_20::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_23 = _bindgen_ty_23::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_47 = _bindgen_ty_47::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__IFLA_DSA_MAX;
+pub const IF_PORT_UNKNOWN: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_UNKNOWN;
+pub const IF_PORT_10BASE2: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASE2;
+pub const IF_PORT_10BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASET;
+pub const IF_PORT_AUI: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_AUI;
+pub const IF_PORT_100BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASET;
+pub const IF_PORT_100BASETX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASETX;
+pub const IF_PORT_100BASEFX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASEFX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1913,6 +1907,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2002,7 +1998,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2098,7 +2095,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2155,7 +2154,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2308,10 +2308,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_20 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_21 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -2327,7 +2355,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -2339,7 +2367,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum _bindgen_ty_23 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -2347,7 +2375,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2380,7 +2408,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2394,7 +2423,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_25 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2424,7 +2461,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2435,7 +2472,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2450,7 +2487,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2463,7 +2500,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2501,7 +2538,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2513,7 +2550,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2529,7 +2566,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2537,7 +2574,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2557,7 +2594,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2565,7 +2602,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2574,7 +2611,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2589,7 +2626,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2597,7 +2634,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2611,7 +2648,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2620,7 +2657,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2638,7 +2675,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2648,14 +2685,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2663,7 +2700,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2677,7 +2714,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2689,7 +2726,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2698,7 +2735,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2707,7 +2744,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2717,7 +2754,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2726,7 +2763,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2736,7 +2773,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2751,7 +2788,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2763,7 +2800,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2779,7 +2816,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2788,7 +2825,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2796,15 +2833,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 IF_PORT_UNKNOWN = 0,
 IF_PORT_10BASE2 = 1,
 IF_PORT_10BASET = 2,
@@ -2887,74 +2924,6 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 impl nlmsgerr_attrs {
 pub const NLMSGERR_ATTR_MAX: nlmsgerr_attrs = nlmsgerr_attrs::NLMSGERR_ATTR_MISS_NEST;
 }
@@ -2969,6 +2938,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/sparc/if_packet.rs
+++ b/src/sparc/if_packet.rs
@@ -49,11 +49,6 @@ pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_pkt {
 pub spkt_family: crate::ctypes::c_ushort,
@@ -61,6 +56,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -68,23 +64,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -541,71 +522,3 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}

--- a/src/sparc/io_uring.rs
+++ b/src/sparc/io_uring.rs
@@ -77,7 +77,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -132,6 +133,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -193,6 +227,29 @@ pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
 pub tv_nsec: crate::ctypes::c_longlong,
@@ -251,6 +308,12 @@ pub __pad1: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_sqe__bindgen_ty_2__bindgen_ty_1 {
+pub level: __u32,
+pub optname: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_sqe__bindgen_ty_5__bindgen_ty_1 {
 pub addr_len: __u16,
 pub __pad3: [__u16; 1usize],
@@ -258,6 +321,7 @@ pub __pad3: [__u16; 1usize],
 #[repr(C)]
 pub struct io_uring_sqe__bindgen_ty_6 {
 pub __bindgen_anon_1: __BindgenUnionField<io_uring_sqe__bindgen_ty_6__bindgen_ty_1>,
+pub optval: __BindgenUnionField<__u64>,
 pub cmd: __BindgenUnionField<[__u8; 0usize]>,
 pub bindgen_union_field: [u64; 2usize],
 }
@@ -419,6 +483,13 @@ pub resv: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_buf_status {
+pub buf_group: __u32,
+pub head: __u32,
+pub resv: [__u32; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -432,7 +503,9 @@ pub addr: __u64,
 pub fd: __s32,
 pub flags: __u32,
 pub timeout: __kernel_timespec,
-pub pad: [__u64; 4usize],
+pub opcode: __u8,
+pub pad: [__u8; 7usize],
+pub pad2: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -596,6 +669,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -667,6 +748,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const IORING_FILE_INDEX_ALLOC: i32 = -1;
 pub const IORING_SETUP_IOPOLL: u32 = 1;
 pub const IORING_SETUP_SQPOLL: u32 = 2;
@@ -684,8 +775,9 @@ pub const IORING_SETUP_SINGLE_ISSUER: u32 = 4096;
 pub const IORING_SETUP_DEFER_TASKRUN: u32 = 8192;
 pub const IORING_SETUP_NO_MMAP: u32 = 16384;
 pub const IORING_SETUP_REGISTERED_FD_ONLY: u32 = 32768;
+pub const IORING_SETUP_NO_SQARRAY: u32 = 65536;
 pub const IORING_URING_CMD_FIXED: u32 = 1;
-pub const IORING_URING_CMD_POLLED: u32 = 2147483648;
+pub const IORING_URING_CMD_MASK: u32 = 1;
 pub const IORING_FSYNC_DATASYNC: u32 = 1;
 pub const IORING_TIMEOUT_ABS: u32 = 1;
 pub const IORING_TIMEOUT_UPDATE: u32 = 2;
@@ -705,6 +797,8 @@ pub const IORING_ASYNC_CANCEL_ALL: u32 = 1;
 pub const IORING_ASYNC_CANCEL_FD: u32 = 2;
 pub const IORING_ASYNC_CANCEL_ANY: u32 = 4;
 pub const IORING_ASYNC_CANCEL_FD_FIXED: u32 = 8;
+pub const IORING_ASYNC_CANCEL_USERDATA: u32 = 16;
+pub const IORING_ASYNC_CANCEL_OP: u32 = 32;
 pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
@@ -713,6 +807,7 @@ pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
+pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
@@ -785,6 +880,7 @@ pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGIS
 pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
 pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
 pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
+pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
 pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
 pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
 pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
@@ -795,6 +891,10 @@ pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTR
 pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
 pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
 pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
+pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
+pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
+pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
+pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -807,6 +907,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -873,7 +974,13 @@ IORING_OP_SOCKET = 45,
 IORING_OP_URING_CMD = 46,
 IORING_OP_SEND_ZC = 47,
 IORING_OP_SENDMSG_ZC = 48,
-IORING_OP_LAST = 49,
+IORING_OP_READ_MULTISHOT = 49,
+IORING_OP_WAITID = 50,
+IORING_OP_FUTEX_WAIT = 51,
+IORING_OP_FUTEX_WAKE = 52,
+IORING_OP_FUTEX_WAITV = 53,
+IORING_OP_FIXED_FD_INSTALL = 54,
+IORING_OP_LAST = 55,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -918,7 +1025,8 @@ IORING_REGISTER_PBUF_RING = 22,
 IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
-IORING_REGISTER_LAST = 26,
+IORING_REGISTER_PBUF_STATUS = 26,
+IORING_REGISTER_LAST = 27,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
@@ -943,6 +1051,15 @@ IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
 IORING_RESTRICTION_SQE_FLAGS_REQUIRED = 3,
 IORING_RESTRICTION_LAST = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_8 {
+SOCKET_URING_OP_SIOCINQ = 0,
+SOCKET_URING_OP_SIOCOUTQ = 1,
+SOCKET_URING_OP_GETSOCKOPT = 2,
+SOCKET_URING_OP_SETSOCKOPT = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -970,6 +1087,7 @@ pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_1__bindgen_ty_1,
 pub union io_uring_sqe__bindgen_ty_2 {
 pub addr: __u64,
 pub splice_off_in: __u64,
+pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_2__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -993,6 +1111,9 @@ pub hardlink_flags: __u32,
 pub xattr_flags: __u32,
 pub msg_ring_flags: __u32,
 pub uring_cmd_flags: __u32,
+pub waitid_flags: __u32,
+pub futex_flags: __u32,
+pub install_fd_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]
@@ -1005,6 +1126,7 @@ pub buf_group: __u16,
 pub union io_uring_sqe__bindgen_ty_5 {
 pub splice_fd_in: __s32,
 pub file_index: __u32,
+pub optlen: __u32,
 pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]

--- a/src/sparc/net.rs
+++ b/src/sparc/net.rs
@@ -427,6 +427,9 @@ pub tcpi_rcv_ooopack: __u32,
 pub tcpi_snd_wnd: __u32,
 pub tcpi_rcv_wnd: __u32,
 pub tcpi_rehash: __u32,
+pub tcpi_total_rto: __u16,
+pub tcpi_total_rto_recoveries: __u16,
+pub tcpi_total_rto_time: __u32,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -446,6 +449,82 @@ pub tcpm_prefixlen: __u8,
 pub tcpm_keylen: __u16,
 pub tcpm_addr: [__be32; 4usize],
 pub tcpm_key: [__u8; 80usize],
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_add {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub key: [__u8; 80usize],
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_del {
+pub addr: __kernel_sockaddr_storage,
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub current_key: __u8,
+pub rnext: __u8,
+pub keyflags: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_info_opt {
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub current_key: __u8,
+pub rnext: __u8,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+pub pkt_key_not_found: __u64,
+pub pkt_ao_required: __u64,
+pub pkt_dropped_icmp: __u64,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_getsockopt {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub key: [__u8; 80usize],
+pub nkeys: __u32,
+pub _bitfield_align_1: [u16; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub prefix: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub ifindex: __s32,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_repair {
+pub snt_isn: __be32,
+pub rcv_isn: __be32,
+pub snd_sne: __u32,
+pub rcv_sne: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1391,6 +1470,11 @@ pub const TCP_ZEROCOPY_RECEIVE: u32 = 35;
 pub const TCP_INQ: u32 = 36;
 pub const TCP_CM_INQ: u32 = 36;
 pub const TCP_TX_DELAY: u32 = 37;
+pub const TCP_AO_ADD_KEY: u32 = 38;
+pub const TCP_AO_DEL_KEY: u32 = 39;
+pub const TCP_AO_INFO: u32 = 40;
+pub const TCP_AO_GET_KEYS: u32 = 41;
+pub const TCP_AO_REPAIR: u32 = 42;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1400,9 +1484,13 @@ pub const TCPI_OPT_WSCALE: u32 = 4;
 pub const TCPI_OPT_ECN: u32 = 8;
 pub const TCPI_OPT_ECN_SEEN: u32 = 16;
 pub const TCPI_OPT_SYN_DATA: u32 = 32;
+pub const TCPI_OPT_USEC_TS: u32 = 64;
 pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
+pub const TCP_AO_MAXKEYLEN: u32 = 80;
+pub const TCP_AO_KEYF_IFINDEX: u32 = 1;
+pub const TCP_AO_KEYF_EXCLUDE_OPT: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
@@ -1767,6 +1855,7 @@ pub const DEVCONF_IOAM6_ID: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID;
 pub const DEVCONF_IOAM6_ID_WIDE: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID_WIDE;
 pub const DEVCONF_NDISC_EVICT_NOCARRIER: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_NDISC_EVICT_NOCARRIER;
 pub const DEVCONF_ACCEPT_UNTRACKED_NA: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_UNTRACKED_NA;
+pub const DEVCONF_ACCEPT_RA_MIN_LFT: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_RA_MIN_LFT;
 pub const DEVCONF_MAX: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_MAX;
 pub const TCP_FLAG_CWR: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_CWR;
 pub const TCP_FLAG_ECE: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_ECE;
@@ -1964,7 +2053,8 @@ DEVCONF_IOAM6_ID = 54,
 DEVCONF_IOAM6_ID_WIDE = 55,
 DEVCONF_NDISC_EVICT_NOCARRIER = 56,
 DEVCONF_ACCEPT_UNTRACKED_NA = 57,
-DEVCONF_MAX = 58,
+DEVCONF_ACCEPT_RA_MIN_LFT = 58,
+DEVCONF_MAX = 59,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2682,6 +2772,289 @@ tcpi_delivery_rate_app_limited as u64
 __bindgen_bitfield_unit.set(9usize, 2u8, {
 let tcpi_fastopen_client_fail: u8 = unsafe { ::core::mem::transmute(tcpi_fastopen_client_fail) };
 tcpi_fastopen_client_fail as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_add {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 30u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 30u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_del {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn del_async(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_del_async(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 29u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 29u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, del_async: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let del_async: u32 = unsafe { ::core::mem::transmute(del_async) };
+del_async as u64
+});
+__bindgen_bitfield_unit.set(3usize, 29u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_info_opt {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn ao_required(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_ao_required(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_counters(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_counters(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn accept_icmps(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_accept_icmps(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(4usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(5usize, 27u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(5usize, 27u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, ao_required: __u32, set_counters: __u32, accept_icmps: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let ao_required: u32 = unsafe { ::core::mem::transmute(ao_required) };
+ao_required as u64
+});
+__bindgen_bitfield_unit.set(3usize, 1u8, {
+let set_counters: u32 = unsafe { ::core::mem::transmute(set_counters) };
+set_counters as u64
+});
+__bindgen_bitfield_unit.set(4usize, 1u8, {
+let accept_icmps: u32 = unsafe { ::core::mem::transmute(accept_icmps) };
+accept_icmps as u64
+});
+__bindgen_bitfield_unit.set(5usize, 27u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_getsockopt {
+#[inline]
+pub fn is_current(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_current(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn is_rnext(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_rnext(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn get_all(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_get_all(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 13u8) as u16) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 13u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(is_current: __u16, is_rnext: __u16, get_all: __u16, reserved: __u16) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let is_current: u16 = unsafe { ::core::mem::transmute(is_current) };
+is_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let is_rnext: u16 = unsafe { ::core::mem::transmute(is_rnext) };
+is_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let get_all: u16 = unsafe { ::core::mem::transmute(get_all) };
+get_all as u64
+});
+__bindgen_bitfield_unit.set(3usize, 13u8, {
+let reserved: u16 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
 });
 __bindgen_bitfield_unit
 }

--- a/src/sparc/netlink.rs
+++ b/src/sparc/netlink.rs
@@ -722,7 +722,8 @@ pub const RTAX_FEATURE_ECN: u32 = 1;
 pub const RTAX_FEATURE_SACK: u32 = 2;
 pub const RTAX_FEATURE_TIMESTAMP: u32 = 4;
 pub const RTAX_FEATURE_ALLFRAG: u32 = 8;
-pub const RTAX_FEATURE_MASK: u32 = 15;
+pub const RTAX_FEATURE_TCP_USEC_TS: u32 = 16;
+pub const RTAX_FEATURE_MASK: u32 = 31;
 pub const TCM_IFINDEX_MAGIC_BLOCK: u32 = 4294967295;
 pub const TCA_DUMP_FLAGS_TERSE: u32 = 1;
 pub const RTMGRP_LINK: u32 = 1;
@@ -819,6 +820,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_2 = _bindgen_ty_2::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_2 = _bindgen_ty_2::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_MASK;
@@ -887,6 +889,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_6 = _bindgen_ty_6::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_HAIRPIN;
@@ -934,6 +938,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_KIND;
@@ -995,501 +1000,510 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_17 = _bindgen_ty_17::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_18 = _bindgen_ty_18::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_21 = _bindgen_ty_21::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_44 = _bindgen_ty_44::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_DSA_MAX;
-pub const IFA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFA_UNSPEC;
-pub const IFA_ADDRESS: _bindgen_ty_54 = _bindgen_ty_54::IFA_ADDRESS;
-pub const IFA_LOCAL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LOCAL;
-pub const IFA_LABEL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LABEL;
-pub const IFA_BROADCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_BROADCAST;
-pub const IFA_ANYCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_ANYCAST;
-pub const IFA_CACHEINFO: _bindgen_ty_54 = _bindgen_ty_54::IFA_CACHEINFO;
-pub const IFA_MULTICAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_MULTICAST;
-pub const IFA_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFA_FLAGS;
-pub const IFA_RT_PRIORITY: _bindgen_ty_54 = _bindgen_ty_54::IFA_RT_PRIORITY;
-pub const IFA_TARGET_NETNSID: _bindgen_ty_54 = _bindgen_ty_54::IFA_TARGET_NETNSID;
-pub const IFA_PROTO: _bindgen_ty_54 = _bindgen_ty_54::IFA_PROTO;
-pub const __IFA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFA_MAX;
-pub const NDA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::NDA_UNSPEC;
-pub const NDA_DST: _bindgen_ty_55 = _bindgen_ty_55::NDA_DST;
-pub const NDA_LLADDR: _bindgen_ty_55 = _bindgen_ty_55::NDA_LLADDR;
-pub const NDA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::NDA_CACHEINFO;
-pub const NDA_PROBES: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROBES;
-pub const NDA_VLAN: _bindgen_ty_55 = _bindgen_ty_55::NDA_VLAN;
-pub const NDA_PORT: _bindgen_ty_55 = _bindgen_ty_55::NDA_PORT;
-pub const NDA_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_VNI;
-pub const NDA_IFINDEX: _bindgen_ty_55 = _bindgen_ty_55::NDA_IFINDEX;
-pub const NDA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::NDA_MASTER;
-pub const NDA_LINK_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::NDA_LINK_NETNSID;
-pub const NDA_SRC_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_SRC_VNI;
-pub const NDA_PROTOCOL: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROTOCOL;
-pub const NDA_NH_ID: _bindgen_ty_55 = _bindgen_ty_55::NDA_NH_ID;
-pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_55 = _bindgen_ty_55::NDA_FDB_EXT_ATTRS;
-pub const NDA_FLAGS_EXT: _bindgen_ty_55 = _bindgen_ty_55::NDA_FLAGS_EXT;
-pub const NDA_NDM_STATE_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_STATE_MASK;
-pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_FLAGS_MASK;
-pub const __NDA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__NDA_MAX;
-pub const NDTPA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UNSPEC;
-pub const NDTPA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_IFINDEX;
-pub const NDTPA_REFCNT: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REFCNT;
-pub const NDTPA_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REACHABLE_TIME;
-pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_BASE_REACHABLE_TIME;
-pub const NDTPA_RETRANS_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_RETRANS_TIME;
-pub const NDTPA_GC_STALETIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_GC_STALETIME;
-pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_DELAY_PROBE_TIME;
-pub const NDTPA_QUEUE_LEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LEN;
-pub const NDTPA_APP_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_APP_PROBES;
-pub const NDTPA_UCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UCAST_PROBES;
-pub const NDTPA_MCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_PROBES;
-pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_ANYCAST_DELAY;
-pub const NDTPA_PROXY_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_DELAY;
-pub const NDTPA_PROXY_QLEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_QLEN;
-pub const NDTPA_LOCKTIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_LOCKTIME;
-pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LENBYTES;
-pub const NDTPA_MCAST_REPROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_REPROBES;
-pub const NDTPA_PAD: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PAD;
-pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_INTERVAL_PROBE_TIME_MS;
-pub const __NDTPA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDTPA_MAX;
-pub const NDTA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTA_UNSPEC;
-pub const NDTA_NAME: _bindgen_ty_57 = _bindgen_ty_57::NDTA_NAME;
-pub const NDTA_THRESH1: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH1;
-pub const NDTA_THRESH2: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH2;
-pub const NDTA_THRESH3: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH3;
-pub const NDTA_CONFIG: _bindgen_ty_57 = _bindgen_ty_57::NDTA_CONFIG;
-pub const NDTA_PARMS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PARMS;
-pub const NDTA_STATS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_STATS;
-pub const NDTA_GC_INTERVAL: _bindgen_ty_57 = _bindgen_ty_57::NDTA_GC_INTERVAL;
-pub const NDTA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PAD;
-pub const __NDTA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTA_MAX;
-pub const FDB_NOTIFY_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_BIT;
-pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_INACTIVE_BIT;
-pub const NFEA_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::NFEA_UNSPEC;
-pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_59 = _bindgen_ty_59::NFEA_ACTIVITY_NOTIFY;
-pub const NFEA_DONT_REFRESH: _bindgen_ty_59 = _bindgen_ty_59::NFEA_DONT_REFRESH;
-pub const __NFEA_MAX: _bindgen_ty_59 = _bindgen_ty_59::__NFEA_MAX;
-pub const RTM_BASE: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_NEWLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_DELLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINK;
-pub const RTM_GETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINK;
-pub const RTM_SETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETLINK;
-pub const RTM_NEWADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDR;
-pub const RTM_DELADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDR;
-pub const RTM_GETADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDR;
-pub const RTM_NEWROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWROUTE;
-pub const RTM_DELROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELROUTE;
-pub const RTM_GETROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETROUTE;
-pub const RTM_NEWNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGH;
-pub const RTM_DELNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEIGH;
-pub const RTM_GETNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGH;
-pub const RTM_NEWRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWRULE;
-pub const RTM_DELRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELRULE;
-pub const RTM_GETRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETRULE;
-pub const RTM_NEWQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWQDISC;
-pub const RTM_DELQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELQDISC;
-pub const RTM_GETQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETQDISC;
-pub const RTM_NEWTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTCLASS;
-pub const RTM_DELTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTCLASS;
-pub const RTM_GETTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTCLASS;
-pub const RTM_NEWTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTFILTER;
-pub const RTM_DELTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTFILTER;
-pub const RTM_GETTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTFILTER;
-pub const RTM_NEWACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWACTION;
-pub const RTM_DELACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELACTION;
-pub const RTM_GETACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETACTION;
-pub const RTM_NEWPREFIX: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWPREFIX;
-pub const RTM_GETMULTICAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMULTICAST;
-pub const RTM_GETANYCAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETANYCAST;
-pub const RTM_NEWNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGHTBL;
-pub const RTM_GETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGHTBL;
-pub const RTM_SETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETNEIGHTBL;
-pub const RTM_NEWNDUSEROPT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNDUSEROPT;
-pub const RTM_NEWADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDRLABEL;
-pub const RTM_DELADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDRLABEL;
-pub const RTM_GETADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDRLABEL;
-pub const RTM_GETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETDCB;
-pub const RTM_SETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETDCB;
-pub const RTM_NEWNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNETCONF;
-pub const RTM_DELNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNETCONF;
-pub const RTM_GETNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNETCONF;
-pub const RTM_NEWMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWMDB;
-pub const RTM_DELMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELMDB;
-pub const RTM_GETMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMDB;
-pub const RTM_NEWNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNSID;
-pub const RTM_DELNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNSID;
-pub const RTM_GETNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNSID;
-pub const RTM_NEWSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWSTATS;
-pub const RTM_GETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETSTATS;
-pub const RTM_SETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETSTATS;
-pub const RTM_NEWCACHEREPORT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCACHEREPORT;
-pub const RTM_NEWCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCHAIN;
-pub const RTM_DELCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELCHAIN;
-pub const RTM_GETCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETCHAIN;
-pub const RTM_NEWNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOP;
-pub const RTM_DELNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOP;
-pub const RTM_GETNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOP;
-pub const RTM_NEWLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWLINKPROP;
-pub const RTM_DELLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINKPROP;
-pub const RTM_GETLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINKPROP;
-pub const RTM_NEWVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWVLAN;
-pub const RTM_DELVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELVLAN;
-pub const RTM_GETVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETVLAN;
-pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOPBUCKET;
-pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOPBUCKET;
-pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOPBUCKET;
-pub const RTM_NEWTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTUNNEL;
-pub const RTM_DELTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTUNNEL;
-pub const RTM_GETTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTUNNEL;
-pub const __RTM_MAX: _bindgen_ty_60 = _bindgen_ty_60::__RTM_MAX;
-pub const RTN_UNSPEC: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNSPEC;
-pub const RTN_UNICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNICAST;
-pub const RTN_LOCAL: _bindgen_ty_61 = _bindgen_ty_61::RTN_LOCAL;
-pub const RTN_BROADCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_BROADCAST;
-pub const RTN_ANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_ANYCAST;
-pub const RTN_MULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_MULTICAST;
-pub const RTN_BLACKHOLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_BLACKHOLE;
-pub const RTN_UNREACHABLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNREACHABLE;
-pub const RTN_PROHIBIT: _bindgen_ty_61 = _bindgen_ty_61::RTN_PROHIBIT;
-pub const RTN_THROW: _bindgen_ty_61 = _bindgen_ty_61::RTN_THROW;
-pub const RTN_NAT: _bindgen_ty_61 = _bindgen_ty_61::RTN_NAT;
-pub const RTN_XRESOLVE: _bindgen_ty_61 = _bindgen_ty_61::RTN_XRESOLVE;
-pub const __RTN_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTN_MAX;
-pub const RTAX_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTAX_UNSPEC;
-pub const RTAX_LOCK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_LOCK;
-pub const RTAX_MTU: _bindgen_ty_62 = _bindgen_ty_62::RTAX_MTU;
-pub const RTAX_WINDOW: _bindgen_ty_62 = _bindgen_ty_62::RTAX_WINDOW;
-pub const RTAX_RTT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTT;
-pub const RTAX_RTTVAR: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTTVAR;
-pub const RTAX_SSTHRESH: _bindgen_ty_62 = _bindgen_ty_62::RTAX_SSTHRESH;
-pub const RTAX_CWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CWND;
-pub const RTAX_ADVMSS: _bindgen_ty_62 = _bindgen_ty_62::RTAX_ADVMSS;
-pub const RTAX_REORDERING: _bindgen_ty_62 = _bindgen_ty_62::RTAX_REORDERING;
-pub const RTAX_HOPLIMIT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_HOPLIMIT;
-pub const RTAX_INITCWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITCWND;
-pub const RTAX_FEATURES: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FEATURES;
-pub const RTAX_RTO_MIN: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTO_MIN;
-pub const RTAX_INITRWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITRWND;
-pub const RTAX_QUICKACK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_QUICKACK;
-pub const RTAX_CC_ALGO: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CC_ALGO;
-pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FASTOPEN_NO_COOKIE;
-pub const __RTAX_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTAX_MAX;
-pub const PREFIX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_UNSPEC;
-pub const PREFIX_ADDRESS: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_ADDRESS;
-pub const PREFIX_CACHEINFO: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_CACHEINFO;
-pub const __PREFIX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__PREFIX_MAX;
-pub const TCA_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::TCA_UNSPEC;
-pub const TCA_KIND: _bindgen_ty_64 = _bindgen_ty_64::TCA_KIND;
-pub const TCA_OPTIONS: _bindgen_ty_64 = _bindgen_ty_64::TCA_OPTIONS;
-pub const TCA_STATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS;
-pub const TCA_XSTATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_XSTATS;
-pub const TCA_RATE: _bindgen_ty_64 = _bindgen_ty_64::TCA_RATE;
-pub const TCA_FCNT: _bindgen_ty_64 = _bindgen_ty_64::TCA_FCNT;
-pub const TCA_STATS2: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS2;
-pub const TCA_STAB: _bindgen_ty_64 = _bindgen_ty_64::TCA_STAB;
-pub const TCA_PAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_PAD;
-pub const TCA_DUMP_INVISIBLE: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_INVISIBLE;
-pub const TCA_CHAIN: _bindgen_ty_64 = _bindgen_ty_64::TCA_CHAIN;
-pub const TCA_HW_OFFLOAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_HW_OFFLOAD;
-pub const TCA_INGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_INGRESS_BLOCK;
-pub const TCA_EGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_EGRESS_BLOCK;
-pub const TCA_DUMP_FLAGS: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_FLAGS;
-pub const TCA_EXT_WARN_MSG: _bindgen_ty_64 = _bindgen_ty_64::TCA_EXT_WARN_MSG;
-pub const __TCA_MAX: _bindgen_ty_64 = _bindgen_ty_64::__TCA_MAX;
-pub const NDUSEROPT_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_UNSPEC;
-pub const NDUSEROPT_SRCADDR: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_SRCADDR;
-pub const __NDUSEROPT_MAX: _bindgen_ty_65 = _bindgen_ty_65::__NDUSEROPT_MAX;
-pub const TCA_ROOT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_UNSPEC;
-pub const TCA_ROOT_TAB: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TAB;
-pub const TCA_ROOT_FLAGS: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_FLAGS;
-pub const TCA_ROOT_COUNT: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_COUNT;
-pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TIME_DELTA;
-pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_EXT_WARN_MSG;
-pub const __TCA_ROOT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__TCA_ROOT_MAX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_18 = _bindgen_ty_18::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_39 = _bindgen_ty_39::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_45 = _bindgen_ty_45::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_DSA_MAX;
+pub const IFA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFA_UNSPEC;
+pub const IFA_ADDRESS: _bindgen_ty_55 = _bindgen_ty_55::IFA_ADDRESS;
+pub const IFA_LOCAL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LOCAL;
+pub const IFA_LABEL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LABEL;
+pub const IFA_BROADCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_BROADCAST;
+pub const IFA_ANYCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_ANYCAST;
+pub const IFA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::IFA_CACHEINFO;
+pub const IFA_MULTICAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_MULTICAST;
+pub const IFA_FLAGS: _bindgen_ty_55 = _bindgen_ty_55::IFA_FLAGS;
+pub const IFA_RT_PRIORITY: _bindgen_ty_55 = _bindgen_ty_55::IFA_RT_PRIORITY;
+pub const IFA_TARGET_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::IFA_TARGET_NETNSID;
+pub const IFA_PROTO: _bindgen_ty_55 = _bindgen_ty_55::IFA_PROTO;
+pub const __IFA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFA_MAX;
+pub const NDA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDA_UNSPEC;
+pub const NDA_DST: _bindgen_ty_56 = _bindgen_ty_56::NDA_DST;
+pub const NDA_LLADDR: _bindgen_ty_56 = _bindgen_ty_56::NDA_LLADDR;
+pub const NDA_CACHEINFO: _bindgen_ty_56 = _bindgen_ty_56::NDA_CACHEINFO;
+pub const NDA_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROBES;
+pub const NDA_VLAN: _bindgen_ty_56 = _bindgen_ty_56::NDA_VLAN;
+pub const NDA_PORT: _bindgen_ty_56 = _bindgen_ty_56::NDA_PORT;
+pub const NDA_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_VNI;
+pub const NDA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDA_IFINDEX;
+pub const NDA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::NDA_MASTER;
+pub const NDA_LINK_NETNSID: _bindgen_ty_56 = _bindgen_ty_56::NDA_LINK_NETNSID;
+pub const NDA_SRC_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_SRC_VNI;
+pub const NDA_PROTOCOL: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROTOCOL;
+pub const NDA_NH_ID: _bindgen_ty_56 = _bindgen_ty_56::NDA_NH_ID;
+pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_56 = _bindgen_ty_56::NDA_FDB_EXT_ATTRS;
+pub const NDA_FLAGS_EXT: _bindgen_ty_56 = _bindgen_ty_56::NDA_FLAGS_EXT;
+pub const NDA_NDM_STATE_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_STATE_MASK;
+pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_FLAGS_MASK;
+pub const __NDA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDA_MAX;
+pub const NDTPA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UNSPEC;
+pub const NDTPA_IFINDEX: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_IFINDEX;
+pub const NDTPA_REFCNT: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REFCNT;
+pub const NDTPA_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REACHABLE_TIME;
+pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_BASE_REACHABLE_TIME;
+pub const NDTPA_RETRANS_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_RETRANS_TIME;
+pub const NDTPA_GC_STALETIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_GC_STALETIME;
+pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_DELAY_PROBE_TIME;
+pub const NDTPA_QUEUE_LEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LEN;
+pub const NDTPA_APP_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_APP_PROBES;
+pub const NDTPA_UCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UCAST_PROBES;
+pub const NDTPA_MCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_PROBES;
+pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_ANYCAST_DELAY;
+pub const NDTPA_PROXY_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_DELAY;
+pub const NDTPA_PROXY_QLEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_QLEN;
+pub const NDTPA_LOCKTIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_LOCKTIME;
+pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LENBYTES;
+pub const NDTPA_MCAST_REPROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_REPROBES;
+pub const NDTPA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PAD;
+pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_INTERVAL_PROBE_TIME_MS;
+pub const __NDTPA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTPA_MAX;
+pub const NDTA_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDTA_UNSPEC;
+pub const NDTA_NAME: _bindgen_ty_58 = _bindgen_ty_58::NDTA_NAME;
+pub const NDTA_THRESH1: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH1;
+pub const NDTA_THRESH2: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH2;
+pub const NDTA_THRESH3: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH3;
+pub const NDTA_CONFIG: _bindgen_ty_58 = _bindgen_ty_58::NDTA_CONFIG;
+pub const NDTA_PARMS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PARMS;
+pub const NDTA_STATS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_STATS;
+pub const NDTA_GC_INTERVAL: _bindgen_ty_58 = _bindgen_ty_58::NDTA_GC_INTERVAL;
+pub const NDTA_PAD: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PAD;
+pub const __NDTA_MAX: _bindgen_ty_58 = _bindgen_ty_58::__NDTA_MAX;
+pub const FDB_NOTIFY_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_BIT;
+pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_INACTIVE_BIT;
+pub const NFEA_UNSPEC: _bindgen_ty_60 = _bindgen_ty_60::NFEA_UNSPEC;
+pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_60 = _bindgen_ty_60::NFEA_ACTIVITY_NOTIFY;
+pub const NFEA_DONT_REFRESH: _bindgen_ty_60 = _bindgen_ty_60::NFEA_DONT_REFRESH;
+pub const __NFEA_MAX: _bindgen_ty_60 = _bindgen_ty_60::__NFEA_MAX;
+pub const RTM_BASE: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_NEWLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_DELLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINK;
+pub const RTM_GETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINK;
+pub const RTM_SETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETLINK;
+pub const RTM_NEWADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDR;
+pub const RTM_DELADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDR;
+pub const RTM_GETADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDR;
+pub const RTM_NEWROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWROUTE;
+pub const RTM_DELROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELROUTE;
+pub const RTM_GETROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETROUTE;
+pub const RTM_NEWNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGH;
+pub const RTM_DELNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEIGH;
+pub const RTM_GETNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGH;
+pub const RTM_NEWRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWRULE;
+pub const RTM_DELRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELRULE;
+pub const RTM_GETRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETRULE;
+pub const RTM_NEWQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWQDISC;
+pub const RTM_DELQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELQDISC;
+pub const RTM_GETQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETQDISC;
+pub const RTM_NEWTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTCLASS;
+pub const RTM_DELTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTCLASS;
+pub const RTM_GETTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTCLASS;
+pub const RTM_NEWTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTFILTER;
+pub const RTM_DELTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTFILTER;
+pub const RTM_GETTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTFILTER;
+pub const RTM_NEWACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWACTION;
+pub const RTM_DELACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELACTION;
+pub const RTM_GETACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETACTION;
+pub const RTM_NEWPREFIX: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWPREFIX;
+pub const RTM_GETMULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMULTICAST;
+pub const RTM_GETANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETANYCAST;
+pub const RTM_NEWNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGHTBL;
+pub const RTM_GETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGHTBL;
+pub const RTM_SETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETNEIGHTBL;
+pub const RTM_NEWNDUSEROPT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNDUSEROPT;
+pub const RTM_NEWADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDRLABEL;
+pub const RTM_DELADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDRLABEL;
+pub const RTM_GETADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDRLABEL;
+pub const RTM_GETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETDCB;
+pub const RTM_SETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETDCB;
+pub const RTM_NEWNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNETCONF;
+pub const RTM_DELNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNETCONF;
+pub const RTM_GETNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNETCONF;
+pub const RTM_NEWMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWMDB;
+pub const RTM_DELMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELMDB;
+pub const RTM_GETMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMDB;
+pub const RTM_NEWNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNSID;
+pub const RTM_DELNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNSID;
+pub const RTM_GETNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNSID;
+pub const RTM_NEWSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWSTATS;
+pub const RTM_GETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETSTATS;
+pub const RTM_SETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETSTATS;
+pub const RTM_NEWCACHEREPORT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCACHEREPORT;
+pub const RTM_NEWCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCHAIN;
+pub const RTM_DELCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELCHAIN;
+pub const RTM_GETCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETCHAIN;
+pub const RTM_NEWNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOP;
+pub const RTM_DELNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOP;
+pub const RTM_GETNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOP;
+pub const RTM_NEWLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWLINKPROP;
+pub const RTM_DELLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINKPROP;
+pub const RTM_GETLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINKPROP;
+pub const RTM_NEWVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWVLAN;
+pub const RTM_DELVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELVLAN;
+pub const RTM_GETVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETVLAN;
+pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOPBUCKET;
+pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOPBUCKET;
+pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOPBUCKET;
+pub const RTM_NEWTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTUNNEL;
+pub const RTM_DELTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTUNNEL;
+pub const RTM_GETTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTUNNEL;
+pub const __RTM_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTM_MAX;
+pub const RTN_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNSPEC;
+pub const RTN_UNICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNICAST;
+pub const RTN_LOCAL: _bindgen_ty_62 = _bindgen_ty_62::RTN_LOCAL;
+pub const RTN_BROADCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_BROADCAST;
+pub const RTN_ANYCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_ANYCAST;
+pub const RTN_MULTICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_MULTICAST;
+pub const RTN_BLACKHOLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_BLACKHOLE;
+pub const RTN_UNREACHABLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNREACHABLE;
+pub const RTN_PROHIBIT: _bindgen_ty_62 = _bindgen_ty_62::RTN_PROHIBIT;
+pub const RTN_THROW: _bindgen_ty_62 = _bindgen_ty_62::RTN_THROW;
+pub const RTN_NAT: _bindgen_ty_62 = _bindgen_ty_62::RTN_NAT;
+pub const RTN_XRESOLVE: _bindgen_ty_62 = _bindgen_ty_62::RTN_XRESOLVE;
+pub const __RTN_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTN_MAX;
+pub const RTAX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::RTAX_UNSPEC;
+pub const RTAX_LOCK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_LOCK;
+pub const RTAX_MTU: _bindgen_ty_63 = _bindgen_ty_63::RTAX_MTU;
+pub const RTAX_WINDOW: _bindgen_ty_63 = _bindgen_ty_63::RTAX_WINDOW;
+pub const RTAX_RTT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTT;
+pub const RTAX_RTTVAR: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTTVAR;
+pub const RTAX_SSTHRESH: _bindgen_ty_63 = _bindgen_ty_63::RTAX_SSTHRESH;
+pub const RTAX_CWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CWND;
+pub const RTAX_ADVMSS: _bindgen_ty_63 = _bindgen_ty_63::RTAX_ADVMSS;
+pub const RTAX_REORDERING: _bindgen_ty_63 = _bindgen_ty_63::RTAX_REORDERING;
+pub const RTAX_HOPLIMIT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_HOPLIMIT;
+pub const RTAX_INITCWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITCWND;
+pub const RTAX_FEATURES: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FEATURES;
+pub const RTAX_RTO_MIN: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTO_MIN;
+pub const RTAX_INITRWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITRWND;
+pub const RTAX_QUICKACK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_QUICKACK;
+pub const RTAX_CC_ALGO: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CC_ALGO;
+pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FASTOPEN_NO_COOKIE;
+pub const __RTAX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__RTAX_MAX;
+pub const PREFIX_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_UNSPEC;
+pub const PREFIX_ADDRESS: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_ADDRESS;
+pub const PREFIX_CACHEINFO: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_CACHEINFO;
+pub const __PREFIX_MAX: _bindgen_ty_64 = _bindgen_ty_64::__PREFIX_MAX;
+pub const TCA_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::TCA_UNSPEC;
+pub const TCA_KIND: _bindgen_ty_65 = _bindgen_ty_65::TCA_KIND;
+pub const TCA_OPTIONS: _bindgen_ty_65 = _bindgen_ty_65::TCA_OPTIONS;
+pub const TCA_STATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS;
+pub const TCA_XSTATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_XSTATS;
+pub const TCA_RATE: _bindgen_ty_65 = _bindgen_ty_65::TCA_RATE;
+pub const TCA_FCNT: _bindgen_ty_65 = _bindgen_ty_65::TCA_FCNT;
+pub const TCA_STATS2: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS2;
+pub const TCA_STAB: _bindgen_ty_65 = _bindgen_ty_65::TCA_STAB;
+pub const TCA_PAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_PAD;
+pub const TCA_DUMP_INVISIBLE: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_INVISIBLE;
+pub const TCA_CHAIN: _bindgen_ty_65 = _bindgen_ty_65::TCA_CHAIN;
+pub const TCA_HW_OFFLOAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_HW_OFFLOAD;
+pub const TCA_INGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_INGRESS_BLOCK;
+pub const TCA_EGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_EGRESS_BLOCK;
+pub const TCA_DUMP_FLAGS: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_FLAGS;
+pub const TCA_EXT_WARN_MSG: _bindgen_ty_65 = _bindgen_ty_65::TCA_EXT_WARN_MSG;
+pub const __TCA_MAX: _bindgen_ty_65 = _bindgen_ty_65::__TCA_MAX;
+pub const NDUSEROPT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_UNSPEC;
+pub const NDUSEROPT_SRCADDR: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_SRCADDR;
+pub const __NDUSEROPT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__NDUSEROPT_MAX;
+pub const TCA_ROOT_UNSPEC: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_UNSPEC;
+pub const TCA_ROOT_TAB: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TAB;
+pub const TCA_ROOT_FLAGS: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_FLAGS;
+pub const TCA_ROOT_COUNT: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_COUNT;
+pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TIME_DELTA;
+pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_EXT_WARN_MSG;
+pub const __TCA_ROOT_MAX: _bindgen_ty_67 = _bindgen_ty_67::__TCA_ROOT_MAX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1540,6 +1554,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1629,7 +1645,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1725,7 +1742,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1782,7 +1801,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1935,10 +1955,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_18 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_19 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -1954,7 +2002,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_19 {
+pub enum _bindgen_ty_20 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -1966,7 +2014,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_20 {
+pub enum _bindgen_ty_21 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -1974,7 +2022,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2007,7 +2055,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2021,7 +2070,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_23 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2051,7 +2108,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2062,7 +2119,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum _bindgen_ty_25 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2077,7 +2134,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2090,7 +2147,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2128,7 +2185,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2140,7 +2197,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2156,7 +2213,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2164,7 +2221,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2184,7 +2241,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2192,7 +2249,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2201,7 +2258,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2216,7 +2273,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2224,7 +2281,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2238,7 +2295,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2247,7 +2304,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2265,7 +2322,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2275,14 +2332,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2290,7 +2347,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2304,7 +2361,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2316,7 +2373,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2325,7 +2382,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2334,7 +2391,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2344,7 +2401,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2353,7 +2410,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2363,7 +2420,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2378,7 +2435,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2390,7 +2447,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2406,7 +2463,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2415,7 +2472,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2423,15 +2480,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFA_UNSPEC = 0,
 IFA_ADDRESS = 1,
 IFA_LOCAL = 2,
@@ -2449,7 +2506,7 @@ __IFA_MAX = 12,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 NDA_UNSPEC = 0,
 NDA_DST = 1,
 NDA_LLADDR = 2,
@@ -2473,7 +2530,7 @@ __NDA_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 NDTPA_UNSPEC = 0,
 NDTPA_IFINDEX = 1,
 NDTPA_REFCNT = 2,
@@ -2499,7 +2556,7 @@ __NDTPA_MAX = 20,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_57 {
+pub enum _bindgen_ty_58 {
 NDTA_UNSPEC = 0,
 NDTA_NAME = 1,
 NDTA_THRESH1 = 2,
@@ -2515,14 +2572,14 @@ __NDTA_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_58 {
+pub enum _bindgen_ty_59 {
 FDB_NOTIFY_BIT = 1,
 FDB_NOTIFY_INACTIVE_BIT = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_59 {
+pub enum _bindgen_ty_60 {
 NFEA_UNSPEC = 0,
 NFEA_ACTIVITY_NOTIFY = 1,
 NFEA_DONT_REFRESH = 2,
@@ -2531,7 +2588,7 @@ __NFEA_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_60 {
+pub enum _bindgen_ty_61 {
 RTM_BASE = 16,
 RTM_DELLINK = 17,
 RTM_GETLINK = 18,
@@ -2608,7 +2665,7 @@ __RTM_MAX = 123,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_61 {
+pub enum _bindgen_ty_62 {
 RTN_UNSPEC = 0,
 RTN_UNICAST = 1,
 RTN_LOCAL = 2,
@@ -2684,7 +2741,7 @@ __RTA_MAX = 31,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_62 {
+pub enum _bindgen_ty_63 {
 RTAX_UNSPEC = 0,
 RTAX_LOCK = 1,
 RTAX_MTU = 2,
@@ -2708,7 +2765,7 @@ __RTAX_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_63 {
+pub enum _bindgen_ty_64 {
 PREFIX_UNSPEC = 0,
 PREFIX_ADDRESS = 1,
 PREFIX_CACHEINFO = 2,
@@ -2717,7 +2774,7 @@ __PREFIX_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_64 {
+pub enum _bindgen_ty_65 {
 TCA_UNSPEC = 0,
 TCA_KIND = 1,
 TCA_OPTIONS = 2,
@@ -2740,7 +2797,7 @@ __TCA_MAX = 17,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_65 {
+pub enum _bindgen_ty_66 {
 NDUSEROPT_UNSPEC = 0,
 NDUSEROPT_SRCADDR = 1,
 __NDUSEROPT_MAX = 2,
@@ -2791,7 +2848,7 @@ __RTNLGRP_MAX = 37,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_66 {
+pub enum _bindgen_ty_67 {
 TCA_ROOT_UNSPEC = 0,
 TCA_ROOT_TAB = 1,
 TCA_ROOT_FLAGS = 2,
@@ -2854,6 +2911,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/sparc/prctl.rs
+++ b/src/sparc/prctl.rs
@@ -216,6 +216,7 @@ pub const PR_SME_VL_LEN_MASK: u32 = 65535;
 pub const PR_SME_VL_INHERIT: u32 = 131072;
 pub const PR_SET_MDWE: u32 = 65;
 pub const PR_MDWE_REFUSE_EXEC_GAIN: u32 = 1;
+pub const PR_MDWE_NO_INHERIT: u32 = 2;
 pub const PR_GET_MDWE: u32 = 66;
 pub const PR_SET_VMA: u32 = 1398164801;
 pub const PR_SET_VMA_ANON_NAME: u32 = 0;

--- a/src/sparc/xdp.rs
+++ b/src/sparc/xdp.rs
@@ -81,6 +81,7 @@ pub len: __u64,
 pub chunk_size: __u32,
 pub headroom: __u32,
 pub flags: __u32,
+pub tx_metadata_len: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -96,6 +97,23 @@ pub tx_ring_empty_descs: __u64,
 #[derive(Debug, Copy, Clone)]
 pub struct xdp_options {
 pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct xsk_tx_metadata {
+pub flags: __u64,
+pub __bindgen_anon_1: xsk_tx_metadata__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1 {
+pub csum_start: __u16,
+pub csum_offset: __u16,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2 {
+pub tx_timestamp: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -138,7 +156,9 @@ pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
 pub const XDP_USE_NEED_WAKEUP: u32 = 8;
+pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
+pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;
@@ -155,5 +175,13 @@ pub const XDP_UMEM_PGOFF_FILL_RING: u64 = 4294967296;
 pub const XDP_UMEM_PGOFF_COMPLETION_RING: u64 = 6442450944;
 pub const XSK_UNALIGNED_BUF_OFFSET_SHIFT: u32 = 48;
 pub const XSK_UNALIGNED_BUF_ADDR_MASK: u64 = 281474976710655;
-pub const XDP_USE_SG: u32 = 16;
+pub const XDP_TXMD_FLAGS_TIMESTAMP: u32 = 1;
+pub const XDP_TXMD_FLAGS_CHECKSUM: u32 = 2;
 pub const XDP_PKT_CONTD: u32 = 1;
+pub const XDP_TX_METADATA: u32 = 2;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union xsk_tx_metadata__bindgen_ty_1 {
+pub request: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1,
+pub completion: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2,
+}

--- a/src/sparc64/general.rs
+++ b/src/sparc64/general.rs
@@ -191,7 +191,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -246,6 +247,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -304,6 +338,29 @@ pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
 pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -392,36 +449,6 @@ pub it_value: __kernel_old_timeval,
 pub struct __kernel_sock_timeval {
 pub tv_sec: __s64,
 pub tv_usec: __s64,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timespec {
-pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: crate::ctypes::c_long,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timeval {
-pub tv_sec: __kernel_old_time_t,
-pub tv_usec: __kernel_suseconds_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerspec {
-pub it_interval: timespec,
-pub it_value: timespec,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerval {
-pub it_interval: timeval,
-pub it_value: timeval,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timezone {
-pub tz_minuteswest: crate::ctypes::c_int,
-pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -689,6 +716,36 @@ pub ws_ypixel: crate::ctypes::c_ushort,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct timespec {
+pub tv_sec: __kernel_old_time_t,
+pub tv_nsec: crate::ctypes::c_long,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timeval {
+pub tv_sec: __kernel_old_time_t,
+pub tv_usec: __kernel_suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerspec {
+pub it_interval: timespec,
+pub it_value: timespec,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerval {
+pub it_interval: timeval,
+pub it_value: timeval,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timezone {
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct iovec {
 pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
@@ -782,6 +839,22 @@ pub struct uffdio_continue {
 pub range: uffdio_range,
 pub mode: __u64,
 pub mapped: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_poison {
+pub range: uffdio_range,
+pub mode: __u64,
+pub updated: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_move {
+pub dst: __u64,
+pub src: __u64,
+pub len: __u64,
+pub mode: __u64,
+pub move_: __s64,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -902,9 +975,9 @@ pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 394496;
+pub const LINUX_VERSION_CODE: u32 = 395264;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 5;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_ADI_BLKSZ: u32 = 48;
@@ -1277,6 +1350,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1348,6 +1429,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const FUTEX_WAIT: u32 = 0;
 pub const FUTEX_WAKE: u32 = 1;
 pub const FUTEX_FD: u32 = 2;
@@ -1378,6 +1469,13 @@ pub const FUTEX_WAIT_BITSET_PRIVATE: u32 = 137;
 pub const FUTEX_WAKE_BITSET_PRIVATE: u32 = 138;
 pub const FUTEX_WAIT_REQUEUE_PI_PRIVATE: u32 = 139;
 pub const FUTEX_CMP_REQUEUE_PI_PRIVATE: u32 = 140;
+pub const FUTEX2_SIZE_U8: u32 = 0;
+pub const FUTEX2_SIZE_U16: u32 = 1;
+pub const FUTEX2_SIZE_U32: u32 = 2;
+pub const FUTEX2_SIZE_U64: u32 = 3;
+pub const FUTEX2_NUMA: u32 = 4;
+pub const FUTEX2_PRIVATE: u32 = 128;
+pub const FUTEX2_SIZE_MASK: u32 = 3;
 pub const FUTEX_32: u32 = 2;
 pub const FUTEX_WAITV_MAX: u32 = 128;
 pub const FUTEX_WAITERS: u32 = 2147483648;
@@ -1637,25 +1735,6 @@ pub const LINUX_REBOOT_CMD_POWER_OFF: u32 = 1126301404;
 pub const LINUX_REBOOT_CMD_RESTART2: u32 = 2712847316;
 pub const LINUX_REBOOT_CMD_SW_SUSPEND: u32 = 3489725666;
 pub const LINUX_REBOOT_CMD_KEXEC: u32 = 1163412803;
-pub const ITIMER_REAL: u32 = 0;
-pub const ITIMER_VIRTUAL: u32 = 1;
-pub const ITIMER_PROF: u32 = 2;
-pub const CLOCK_REALTIME: u32 = 0;
-pub const CLOCK_MONOTONIC: u32 = 1;
-pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
-pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
-pub const CLOCK_MONOTONIC_RAW: u32 = 4;
-pub const CLOCK_REALTIME_COARSE: u32 = 5;
-pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
-pub const CLOCK_BOOTTIME: u32 = 7;
-pub const CLOCK_REALTIME_ALARM: u32 = 8;
-pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
-pub const CLOCK_SGI_CYCLE: u32 = 10;
-pub const CLOCK_TAI: u32 = 11;
-pub const MAX_CLOCKS: u32 = 16;
-pub const CLOCKS_MASK: u32 = 1;
-pub const CLOCKS_MONO: u32 = 1;
-pub const TIMER_ABSTIME: u32 = 1;
 pub const RUSAGE_SELF: u32 = 0;
 pub const RUSAGE_CHILDREN: i32 = -1;
 pub const RUSAGE_BOTH: i32 = -2;
@@ -1865,7 +1944,8 @@ pub const SEGV_ADIDERR: u32 = 6;
 pub const SEGV_ADIPERR: u32 = 7;
 pub const SEGV_MTEAERR: u32 = 8;
 pub const SEGV_MTESERR: u32 = 9;
-pub const NSIGSEGV: u32 = 9;
+pub const SEGV_CPERR: u32 = 10;
+pub const NSIGSEGV: u32 = 10;
 pub const BUS_ADRALN: u32 = 1;
 pub const BUS_ADRERR: u32 = 2;
 pub const BUS_OBJERR: u32 = 3;
@@ -1947,6 +2027,7 @@ pub const STATX_BASIC_STATS: u32 = 2047;
 pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
+pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2128,6 +2209,25 @@ pub const TIOCSER_TEMT: u32 = 1;
 pub const TCSANOW: u32 = 0;
 pub const TCSADRAIN: u32 = 1;
 pub const TCSAFLUSH: u32 = 2;
+pub const ITIMER_REAL: u32 = 0;
+pub const ITIMER_VIRTUAL: u32 = 1;
+pub const ITIMER_PROF: u32 = 2;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_SGI_CYCLE: u32 = 10;
+pub const CLOCK_TAI: u32 = 11;
+pub const MAX_CLOCKS: u32 = 16;
+pub const CLOCKS_MASK: u32 = 1;
+pub const CLOCKS_MONO: u32 = 1;
+pub const TIMER_ABSTIME: u32 = 1;
 pub const UIO_FASTIOV: u32 = 8;
 pub const UIO_MAXIOV: u32 = 1024;
 pub const __NR_restart_syscall: u32 = 0;
@@ -2513,6 +2613,16 @@ pub const __NR_process_mrelease: u32 = 448;
 pub const __NR_futex_waitv: u32 = 449;
 pub const __NR_set_mempolicy_home_node: u32 = 450;
 pub const __NR_cachestat: u32 = 451;
+pub const __NR_fchmodat2: u32 = 452;
+pub const __NR_map_shadow_stack: u32 = 453;
+pub const __NR_futex_wake: u32 = 454;
+pub const __NR_futex_wait: u32 = 455;
+pub const __NR_futex_requeue: u32 = 456;
+pub const __NR_statmount: u32 = 457;
+pub const __NR_listmount: u32 = 458;
+pub const __NR_lsm_get_self_attr: u32 = 459;
+pub const __NR_lsm_set_self_attr: u32 = 460;
+pub const __NR_lsm_list_modules: u32 = 461;
 pub const KERN_FEATURE_MIXED_MODE_STACK: u32 = 1;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
@@ -2592,8 +2702,10 @@ pub const _UFFDIO_UNREGISTER: u32 = 1;
 pub const _UFFDIO_WAKE: u32 = 2;
 pub const _UFFDIO_COPY: u32 = 3;
 pub const _UFFDIO_ZEROPAGE: u32 = 4;
+pub const _UFFDIO_MOVE: u32 = 5;
 pub const _UFFDIO_WRITEPROTECT: u32 = 6;
 pub const _UFFDIO_CONTINUE: u32 = 7;
+pub const _UFFDIO_POISON: u32 = 8;
 pub const _UFFDIO_API: u32 = 63;
 pub const UFFDIO: u32 = 170;
 pub const UFFD_EVENT_PAGEFAULT: u32 = 18;
@@ -2618,6 +2730,9 @@ pub const UFFD_FEATURE_MINOR_SHMEM: u32 = 1024;
 pub const UFFD_FEATURE_EXACT_ADDRESS: u32 = 2048;
 pub const UFFD_FEATURE_WP_HUGETLBFS_SHMEM: u32 = 4096;
 pub const UFFD_FEATURE_WP_UNPOPULATED: u32 = 8192;
+pub const UFFD_FEATURE_POISON: u32 = 16384;
+pub const UFFD_FEATURE_WP_ASYNC: u32 = 32768;
+pub const UFFD_FEATURE_MOVE: u32 = 65536;
 pub const UFFD_USER_MODE_ONLY: u32 = 1;
 pub const DT_UNKNOWN: u32 = 0;
 pub const DT_FIFO: u32 = 1;
@@ -2691,6 +2806,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/sparc64/if_arp.rs
+++ b/src/sparc64/if_arp.rs
@@ -52,11 +52,6 @@ pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_old_timeval {
 pub tv_sec: __kernel_long_t,
@@ -181,6 +176,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -188,23 +184,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -1348,6 +1329,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_4 = _bindgen_ty_4::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_4 = _bindgen_ty_4::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_MASK;
@@ -1416,6 +1398,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_HAIRPIN;
@@ -1463,6 +1447,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_10 = _bindgen_ty_10::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_KIND;
@@ -1524,301 +1509,310 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_19 = _bindgen_ty_19::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_40 = _bindgen_ty_40::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_46 = _bindgen_ty_46::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_DSA_MAX;
-pub const IF_PORT_UNKNOWN: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_UNKNOWN;
-pub const IF_PORT_10BASE2: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASE2;
-pub const IF_PORT_10BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASET;
-pub const IF_PORT_AUI: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_AUI;
-pub const IF_PORT_100BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASET;
-pub const IF_PORT_100BASETX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASETX;
-pub const IF_PORT_100BASEFX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASEFX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_20 = _bindgen_ty_20::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_23 = _bindgen_ty_23::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_47 = _bindgen_ty_47::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__IFLA_DSA_MAX;
+pub const IF_PORT_UNKNOWN: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_UNKNOWN;
+pub const IF_PORT_10BASE2: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASE2;
+pub const IF_PORT_10BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASET;
+pub const IF_PORT_AUI: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_AUI;
+pub const IF_PORT_100BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASET;
+pub const IF_PORT_100BASETX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASETX;
+pub const IF_PORT_100BASEFX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASEFX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1921,6 +1915,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2010,7 +2006,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2106,7 +2103,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2163,7 +2162,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2316,10 +2316,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_20 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_21 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -2335,7 +2363,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -2347,7 +2375,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum _bindgen_ty_23 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -2355,7 +2383,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2388,7 +2416,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2402,7 +2431,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_25 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2432,7 +2469,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2443,7 +2480,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2458,7 +2495,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2471,7 +2508,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2509,7 +2546,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2521,7 +2558,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2537,7 +2574,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2545,7 +2582,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2565,7 +2602,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2573,7 +2610,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2582,7 +2619,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2597,7 +2634,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2605,7 +2642,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2619,7 +2656,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2628,7 +2665,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2646,7 +2683,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2656,14 +2693,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2671,7 +2708,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2685,7 +2722,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2697,7 +2734,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2706,7 +2743,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2715,7 +2752,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2725,7 +2762,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2734,7 +2771,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2744,7 +2781,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2759,7 +2796,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2771,7 +2808,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2787,7 +2824,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2796,7 +2833,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2804,15 +2841,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 IF_PORT_UNKNOWN = 0,
 IF_PORT_10BASE2 = 1,
 IF_PORT_10BASET = 2,
@@ -2895,74 +2932,6 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 impl nlmsgerr_attrs {
 pub const NLMSGERR_ATTR_MAX: nlmsgerr_attrs = nlmsgerr_attrs::NLMSGERR_ATTR_MISS_NEST;
 }
@@ -2977,6 +2946,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/sparc64/if_packet.rs
+++ b/src/sparc64/if_packet.rs
@@ -51,11 +51,6 @@ pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __kernel_old_timeval {
 pub tv_sec: __kernel_long_t,
@@ -69,6 +64,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -76,23 +72,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -549,71 +530,3 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}

--- a/src/sparc64/io_uring.rs
+++ b/src/sparc64/io_uring.rs
@@ -85,7 +85,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -140,6 +141,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -201,6 +235,29 @@ pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
 pub tv_nsec: crate::ctypes::c_longlong,
@@ -253,6 +310,12 @@ pub __pad1: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_sqe__bindgen_ty_2__bindgen_ty_1 {
+pub level: __u32,
+pub optname: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_sqe__bindgen_ty_5__bindgen_ty_1 {
 pub addr_len: __u16,
 pub __pad3: [__u16; 1usize],
@@ -260,6 +323,7 @@ pub __pad3: [__u16; 1usize],
 #[repr(C)]
 pub struct io_uring_sqe__bindgen_ty_6 {
 pub __bindgen_anon_1: __BindgenUnionField<io_uring_sqe__bindgen_ty_6__bindgen_ty_1>,
+pub optval: __BindgenUnionField<__u64>,
 pub cmd: __BindgenUnionField<[__u8; 0usize]>,
 pub bindgen_union_field: [u64; 2usize],
 }
@@ -421,6 +485,13 @@ pub resv: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_buf_status {
+pub buf_group: __u32,
+pub head: __u32,
+pub resv: [__u32; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -434,7 +505,9 @@ pub addr: __u64,
 pub fd: __s32,
 pub flags: __u32,
 pub timeout: __kernel_timespec,
-pub pad: [__u64; 4usize],
+pub opcode: __u8,
+pub pad: [__u8; 7usize],
+pub pad2: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -598,6 +671,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -669,6 +750,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const IORING_FILE_INDEX_ALLOC: i32 = -1;
 pub const IORING_SETUP_IOPOLL: u32 = 1;
 pub const IORING_SETUP_SQPOLL: u32 = 2;
@@ -686,8 +777,9 @@ pub const IORING_SETUP_SINGLE_ISSUER: u32 = 4096;
 pub const IORING_SETUP_DEFER_TASKRUN: u32 = 8192;
 pub const IORING_SETUP_NO_MMAP: u32 = 16384;
 pub const IORING_SETUP_REGISTERED_FD_ONLY: u32 = 32768;
+pub const IORING_SETUP_NO_SQARRAY: u32 = 65536;
 pub const IORING_URING_CMD_FIXED: u32 = 1;
-pub const IORING_URING_CMD_POLLED: u32 = 2147483648;
+pub const IORING_URING_CMD_MASK: u32 = 1;
 pub const IORING_FSYNC_DATASYNC: u32 = 1;
 pub const IORING_TIMEOUT_ABS: u32 = 1;
 pub const IORING_TIMEOUT_UPDATE: u32 = 2;
@@ -707,6 +799,8 @@ pub const IORING_ASYNC_CANCEL_ALL: u32 = 1;
 pub const IORING_ASYNC_CANCEL_FD: u32 = 2;
 pub const IORING_ASYNC_CANCEL_ANY: u32 = 4;
 pub const IORING_ASYNC_CANCEL_FD_FIXED: u32 = 8;
+pub const IORING_ASYNC_CANCEL_USERDATA: u32 = 16;
+pub const IORING_ASYNC_CANCEL_OP: u32 = 32;
 pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
@@ -715,6 +809,7 @@ pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
+pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
@@ -787,6 +882,7 @@ pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGIS
 pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
 pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
 pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
+pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
 pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
 pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
 pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
@@ -797,6 +893,10 @@ pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTR
 pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
 pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
 pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
+pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
+pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
+pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
+pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -809,6 +909,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -875,7 +976,13 @@ IORING_OP_SOCKET = 45,
 IORING_OP_URING_CMD = 46,
 IORING_OP_SEND_ZC = 47,
 IORING_OP_SENDMSG_ZC = 48,
-IORING_OP_LAST = 49,
+IORING_OP_READ_MULTISHOT = 49,
+IORING_OP_WAITID = 50,
+IORING_OP_FUTEX_WAIT = 51,
+IORING_OP_FUTEX_WAKE = 52,
+IORING_OP_FUTEX_WAITV = 53,
+IORING_OP_FIXED_FD_INSTALL = 54,
+IORING_OP_LAST = 55,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -920,7 +1027,8 @@ IORING_REGISTER_PBUF_RING = 22,
 IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
-IORING_REGISTER_LAST = 26,
+IORING_REGISTER_PBUF_STATUS = 26,
+IORING_REGISTER_LAST = 27,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
@@ -945,6 +1053,15 @@ IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
 IORING_RESTRICTION_SQE_FLAGS_REQUIRED = 3,
 IORING_RESTRICTION_LAST = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_8 {
+SOCKET_URING_OP_SIOCINQ = 0,
+SOCKET_URING_OP_SIOCOUTQ = 1,
+SOCKET_URING_OP_GETSOCKOPT = 2,
+SOCKET_URING_OP_SETSOCKOPT = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -972,6 +1089,7 @@ pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_1__bindgen_ty_1,
 pub union io_uring_sqe__bindgen_ty_2 {
 pub addr: __u64,
 pub splice_off_in: __u64,
+pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_2__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -995,6 +1113,9 @@ pub hardlink_flags: __u32,
 pub xattr_flags: __u32,
 pub msg_ring_flags: __u32,
 pub uring_cmd_flags: __u32,
+pub waitid_flags: __u32,
+pub futex_flags: __u32,
+pub install_fd_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]
@@ -1007,6 +1128,7 @@ pub buf_group: __u16,
 pub union io_uring_sqe__bindgen_ty_5 {
 pub splice_fd_in: __s32,
 pub file_index: __u32,
+pub optlen: __u32,
 pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]

--- a/src/sparc64/net.rs
+++ b/src/sparc64/net.rs
@@ -435,6 +435,9 @@ pub tcpi_rcv_ooopack: __u32,
 pub tcpi_snd_wnd: __u32,
 pub tcpi_rcv_wnd: __u32,
 pub tcpi_rehash: __u32,
+pub tcpi_total_rto: __u16,
+pub tcpi_total_rto_recoveries: __u16,
+pub tcpi_total_rto_time: __u32,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -454,6 +457,80 @@ pub tcpm_prefixlen: __u8,
 pub tcpm_keylen: __u16,
 pub tcpm_addr: [__be32; 4usize],
 pub tcpm_key: [__u8; 80usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_add {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub key: [__u8; 80usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_del {
+pub addr: __kernel_sockaddr_storage,
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub current_key: __u8,
+pub rnext: __u8,
+pub keyflags: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_info_opt {
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub current_key: __u8,
+pub rnext: __u8,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+pub pkt_key_not_found: __u64,
+pub pkt_ao_required: __u64,
+pub pkt_dropped_icmp: __u64,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_getsockopt {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub key: [__u8; 80usize],
+pub nkeys: __u32,
+pub _bitfield_align_1: [u16; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub prefix: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub ifindex: __s32,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_repair {
+pub snt_isn: __be32,
+pub rcv_isn: __be32,
+pub snd_sne: __u32,
+pub rcv_sne: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1407,6 +1484,11 @@ pub const TCP_ZEROCOPY_RECEIVE: u32 = 35;
 pub const TCP_INQ: u32 = 36;
 pub const TCP_CM_INQ: u32 = 36;
 pub const TCP_TX_DELAY: u32 = 37;
+pub const TCP_AO_ADD_KEY: u32 = 38;
+pub const TCP_AO_DEL_KEY: u32 = 39;
+pub const TCP_AO_INFO: u32 = 40;
+pub const TCP_AO_GET_KEYS: u32 = 41;
+pub const TCP_AO_REPAIR: u32 = 42;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1416,9 +1498,13 @@ pub const TCPI_OPT_WSCALE: u32 = 4;
 pub const TCPI_OPT_ECN: u32 = 8;
 pub const TCPI_OPT_ECN_SEEN: u32 = 16;
 pub const TCPI_OPT_SYN_DATA: u32 = 32;
+pub const TCPI_OPT_USEC_TS: u32 = 64;
 pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
+pub const TCP_AO_MAXKEYLEN: u32 = 80;
+pub const TCP_AO_KEYF_IFINDEX: u32 = 1;
+pub const TCP_AO_KEYF_EXCLUDE_OPT: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
@@ -1783,6 +1869,7 @@ pub const DEVCONF_IOAM6_ID: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID;
 pub const DEVCONF_IOAM6_ID_WIDE: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID_WIDE;
 pub const DEVCONF_NDISC_EVICT_NOCARRIER: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_NDISC_EVICT_NOCARRIER;
 pub const DEVCONF_ACCEPT_UNTRACKED_NA: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_UNTRACKED_NA;
+pub const DEVCONF_ACCEPT_RA_MIN_LFT: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_RA_MIN_LFT;
 pub const DEVCONF_MAX: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_MAX;
 pub const TCP_FLAG_CWR: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_CWR;
 pub const TCP_FLAG_ECE: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_ECE;
@@ -1980,7 +2067,8 @@ DEVCONF_IOAM6_ID = 54,
 DEVCONF_IOAM6_ID_WIDE = 55,
 DEVCONF_NDISC_EVICT_NOCARRIER = 56,
 DEVCONF_ACCEPT_UNTRACKED_NA = 57,
-DEVCONF_MAX = 58,
+DEVCONF_ACCEPT_RA_MIN_LFT = 58,
+DEVCONF_MAX = 59,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2698,6 +2786,289 @@ tcpi_delivery_rate_app_limited as u64
 __bindgen_bitfield_unit.set(9usize, 2u8, {
 let tcpi_fastopen_client_fail: u8 = unsafe { ::core::mem::transmute(tcpi_fastopen_client_fail) };
 tcpi_fastopen_client_fail as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_add {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 30u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 30u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_del {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn del_async(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_del_async(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 29u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 29u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, del_async: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let del_async: u32 = unsafe { ::core::mem::transmute(del_async) };
+del_async as u64
+});
+__bindgen_bitfield_unit.set(3usize, 29u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_info_opt {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn ao_required(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_ao_required(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_counters(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_counters(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn accept_icmps(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_accept_icmps(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(4usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(5usize, 27u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(5usize, 27u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, ao_required: __u32, set_counters: __u32, accept_icmps: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let ao_required: u32 = unsafe { ::core::mem::transmute(ao_required) };
+ao_required as u64
+});
+__bindgen_bitfield_unit.set(3usize, 1u8, {
+let set_counters: u32 = unsafe { ::core::mem::transmute(set_counters) };
+set_counters as u64
+});
+__bindgen_bitfield_unit.set(4usize, 1u8, {
+let accept_icmps: u32 = unsafe { ::core::mem::transmute(accept_icmps) };
+accept_icmps as u64
+});
+__bindgen_bitfield_unit.set(5usize, 27u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_getsockopt {
+#[inline]
+pub fn is_current(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_current(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn is_rnext(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_rnext(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn get_all(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_get_all(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 13u8) as u16) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 13u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(is_current: __u16, is_rnext: __u16, get_all: __u16, reserved: __u16) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let is_current: u16 = unsafe { ::core::mem::transmute(is_current) };
+is_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let is_rnext: u16 = unsafe { ::core::mem::transmute(is_rnext) };
+is_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let get_all: u16 = unsafe { ::core::mem::transmute(get_all) };
+get_all as u64
+});
+__bindgen_bitfield_unit.set(3usize, 13u8, {
+let reserved: u16 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
 });
 __bindgen_bitfield_unit
 }

--- a/src/sparc64/netlink.rs
+++ b/src/sparc64/netlink.rs
@@ -730,7 +730,8 @@ pub const RTAX_FEATURE_ECN: u32 = 1;
 pub const RTAX_FEATURE_SACK: u32 = 2;
 pub const RTAX_FEATURE_TIMESTAMP: u32 = 4;
 pub const RTAX_FEATURE_ALLFRAG: u32 = 8;
-pub const RTAX_FEATURE_MASK: u32 = 15;
+pub const RTAX_FEATURE_TCP_USEC_TS: u32 = 16;
+pub const RTAX_FEATURE_MASK: u32 = 31;
 pub const TCM_IFINDEX_MAGIC_BLOCK: u32 = 4294967295;
 pub const TCA_DUMP_FLAGS_TERSE: u32 = 1;
 pub const RTMGRP_LINK: u32 = 1;
@@ -827,6 +828,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_2 = _bindgen_ty_2::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_2 = _bindgen_ty_2::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_MASK;
@@ -895,6 +897,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_6 = _bindgen_ty_6::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_HAIRPIN;
@@ -942,6 +946,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_KIND;
@@ -1003,501 +1008,510 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_17 = _bindgen_ty_17::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_18 = _bindgen_ty_18::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_21 = _bindgen_ty_21::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_44 = _bindgen_ty_44::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_DSA_MAX;
-pub const IFA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFA_UNSPEC;
-pub const IFA_ADDRESS: _bindgen_ty_54 = _bindgen_ty_54::IFA_ADDRESS;
-pub const IFA_LOCAL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LOCAL;
-pub const IFA_LABEL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LABEL;
-pub const IFA_BROADCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_BROADCAST;
-pub const IFA_ANYCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_ANYCAST;
-pub const IFA_CACHEINFO: _bindgen_ty_54 = _bindgen_ty_54::IFA_CACHEINFO;
-pub const IFA_MULTICAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_MULTICAST;
-pub const IFA_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFA_FLAGS;
-pub const IFA_RT_PRIORITY: _bindgen_ty_54 = _bindgen_ty_54::IFA_RT_PRIORITY;
-pub const IFA_TARGET_NETNSID: _bindgen_ty_54 = _bindgen_ty_54::IFA_TARGET_NETNSID;
-pub const IFA_PROTO: _bindgen_ty_54 = _bindgen_ty_54::IFA_PROTO;
-pub const __IFA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFA_MAX;
-pub const NDA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::NDA_UNSPEC;
-pub const NDA_DST: _bindgen_ty_55 = _bindgen_ty_55::NDA_DST;
-pub const NDA_LLADDR: _bindgen_ty_55 = _bindgen_ty_55::NDA_LLADDR;
-pub const NDA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::NDA_CACHEINFO;
-pub const NDA_PROBES: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROBES;
-pub const NDA_VLAN: _bindgen_ty_55 = _bindgen_ty_55::NDA_VLAN;
-pub const NDA_PORT: _bindgen_ty_55 = _bindgen_ty_55::NDA_PORT;
-pub const NDA_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_VNI;
-pub const NDA_IFINDEX: _bindgen_ty_55 = _bindgen_ty_55::NDA_IFINDEX;
-pub const NDA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::NDA_MASTER;
-pub const NDA_LINK_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::NDA_LINK_NETNSID;
-pub const NDA_SRC_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_SRC_VNI;
-pub const NDA_PROTOCOL: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROTOCOL;
-pub const NDA_NH_ID: _bindgen_ty_55 = _bindgen_ty_55::NDA_NH_ID;
-pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_55 = _bindgen_ty_55::NDA_FDB_EXT_ATTRS;
-pub const NDA_FLAGS_EXT: _bindgen_ty_55 = _bindgen_ty_55::NDA_FLAGS_EXT;
-pub const NDA_NDM_STATE_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_STATE_MASK;
-pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_FLAGS_MASK;
-pub const __NDA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__NDA_MAX;
-pub const NDTPA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UNSPEC;
-pub const NDTPA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_IFINDEX;
-pub const NDTPA_REFCNT: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REFCNT;
-pub const NDTPA_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REACHABLE_TIME;
-pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_BASE_REACHABLE_TIME;
-pub const NDTPA_RETRANS_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_RETRANS_TIME;
-pub const NDTPA_GC_STALETIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_GC_STALETIME;
-pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_DELAY_PROBE_TIME;
-pub const NDTPA_QUEUE_LEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LEN;
-pub const NDTPA_APP_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_APP_PROBES;
-pub const NDTPA_UCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UCAST_PROBES;
-pub const NDTPA_MCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_PROBES;
-pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_ANYCAST_DELAY;
-pub const NDTPA_PROXY_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_DELAY;
-pub const NDTPA_PROXY_QLEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_QLEN;
-pub const NDTPA_LOCKTIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_LOCKTIME;
-pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LENBYTES;
-pub const NDTPA_MCAST_REPROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_REPROBES;
-pub const NDTPA_PAD: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PAD;
-pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_INTERVAL_PROBE_TIME_MS;
-pub const __NDTPA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDTPA_MAX;
-pub const NDTA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTA_UNSPEC;
-pub const NDTA_NAME: _bindgen_ty_57 = _bindgen_ty_57::NDTA_NAME;
-pub const NDTA_THRESH1: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH1;
-pub const NDTA_THRESH2: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH2;
-pub const NDTA_THRESH3: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH3;
-pub const NDTA_CONFIG: _bindgen_ty_57 = _bindgen_ty_57::NDTA_CONFIG;
-pub const NDTA_PARMS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PARMS;
-pub const NDTA_STATS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_STATS;
-pub const NDTA_GC_INTERVAL: _bindgen_ty_57 = _bindgen_ty_57::NDTA_GC_INTERVAL;
-pub const NDTA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PAD;
-pub const __NDTA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTA_MAX;
-pub const FDB_NOTIFY_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_BIT;
-pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_INACTIVE_BIT;
-pub const NFEA_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::NFEA_UNSPEC;
-pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_59 = _bindgen_ty_59::NFEA_ACTIVITY_NOTIFY;
-pub const NFEA_DONT_REFRESH: _bindgen_ty_59 = _bindgen_ty_59::NFEA_DONT_REFRESH;
-pub const __NFEA_MAX: _bindgen_ty_59 = _bindgen_ty_59::__NFEA_MAX;
-pub const RTM_BASE: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_NEWLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_DELLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINK;
-pub const RTM_GETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINK;
-pub const RTM_SETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETLINK;
-pub const RTM_NEWADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDR;
-pub const RTM_DELADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDR;
-pub const RTM_GETADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDR;
-pub const RTM_NEWROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWROUTE;
-pub const RTM_DELROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELROUTE;
-pub const RTM_GETROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETROUTE;
-pub const RTM_NEWNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGH;
-pub const RTM_DELNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEIGH;
-pub const RTM_GETNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGH;
-pub const RTM_NEWRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWRULE;
-pub const RTM_DELRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELRULE;
-pub const RTM_GETRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETRULE;
-pub const RTM_NEWQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWQDISC;
-pub const RTM_DELQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELQDISC;
-pub const RTM_GETQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETQDISC;
-pub const RTM_NEWTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTCLASS;
-pub const RTM_DELTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTCLASS;
-pub const RTM_GETTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTCLASS;
-pub const RTM_NEWTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTFILTER;
-pub const RTM_DELTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTFILTER;
-pub const RTM_GETTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTFILTER;
-pub const RTM_NEWACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWACTION;
-pub const RTM_DELACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELACTION;
-pub const RTM_GETACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETACTION;
-pub const RTM_NEWPREFIX: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWPREFIX;
-pub const RTM_GETMULTICAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMULTICAST;
-pub const RTM_GETANYCAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETANYCAST;
-pub const RTM_NEWNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGHTBL;
-pub const RTM_GETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGHTBL;
-pub const RTM_SETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETNEIGHTBL;
-pub const RTM_NEWNDUSEROPT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNDUSEROPT;
-pub const RTM_NEWADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDRLABEL;
-pub const RTM_DELADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDRLABEL;
-pub const RTM_GETADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDRLABEL;
-pub const RTM_GETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETDCB;
-pub const RTM_SETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETDCB;
-pub const RTM_NEWNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNETCONF;
-pub const RTM_DELNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNETCONF;
-pub const RTM_GETNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNETCONF;
-pub const RTM_NEWMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWMDB;
-pub const RTM_DELMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELMDB;
-pub const RTM_GETMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMDB;
-pub const RTM_NEWNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNSID;
-pub const RTM_DELNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNSID;
-pub const RTM_GETNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNSID;
-pub const RTM_NEWSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWSTATS;
-pub const RTM_GETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETSTATS;
-pub const RTM_SETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETSTATS;
-pub const RTM_NEWCACHEREPORT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCACHEREPORT;
-pub const RTM_NEWCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCHAIN;
-pub const RTM_DELCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELCHAIN;
-pub const RTM_GETCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETCHAIN;
-pub const RTM_NEWNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOP;
-pub const RTM_DELNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOP;
-pub const RTM_GETNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOP;
-pub const RTM_NEWLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWLINKPROP;
-pub const RTM_DELLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINKPROP;
-pub const RTM_GETLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINKPROP;
-pub const RTM_NEWVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWVLAN;
-pub const RTM_DELVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELVLAN;
-pub const RTM_GETVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETVLAN;
-pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOPBUCKET;
-pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOPBUCKET;
-pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOPBUCKET;
-pub const RTM_NEWTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTUNNEL;
-pub const RTM_DELTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTUNNEL;
-pub const RTM_GETTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTUNNEL;
-pub const __RTM_MAX: _bindgen_ty_60 = _bindgen_ty_60::__RTM_MAX;
-pub const RTN_UNSPEC: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNSPEC;
-pub const RTN_UNICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNICAST;
-pub const RTN_LOCAL: _bindgen_ty_61 = _bindgen_ty_61::RTN_LOCAL;
-pub const RTN_BROADCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_BROADCAST;
-pub const RTN_ANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_ANYCAST;
-pub const RTN_MULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_MULTICAST;
-pub const RTN_BLACKHOLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_BLACKHOLE;
-pub const RTN_UNREACHABLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNREACHABLE;
-pub const RTN_PROHIBIT: _bindgen_ty_61 = _bindgen_ty_61::RTN_PROHIBIT;
-pub const RTN_THROW: _bindgen_ty_61 = _bindgen_ty_61::RTN_THROW;
-pub const RTN_NAT: _bindgen_ty_61 = _bindgen_ty_61::RTN_NAT;
-pub const RTN_XRESOLVE: _bindgen_ty_61 = _bindgen_ty_61::RTN_XRESOLVE;
-pub const __RTN_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTN_MAX;
-pub const RTAX_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTAX_UNSPEC;
-pub const RTAX_LOCK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_LOCK;
-pub const RTAX_MTU: _bindgen_ty_62 = _bindgen_ty_62::RTAX_MTU;
-pub const RTAX_WINDOW: _bindgen_ty_62 = _bindgen_ty_62::RTAX_WINDOW;
-pub const RTAX_RTT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTT;
-pub const RTAX_RTTVAR: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTTVAR;
-pub const RTAX_SSTHRESH: _bindgen_ty_62 = _bindgen_ty_62::RTAX_SSTHRESH;
-pub const RTAX_CWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CWND;
-pub const RTAX_ADVMSS: _bindgen_ty_62 = _bindgen_ty_62::RTAX_ADVMSS;
-pub const RTAX_REORDERING: _bindgen_ty_62 = _bindgen_ty_62::RTAX_REORDERING;
-pub const RTAX_HOPLIMIT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_HOPLIMIT;
-pub const RTAX_INITCWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITCWND;
-pub const RTAX_FEATURES: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FEATURES;
-pub const RTAX_RTO_MIN: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTO_MIN;
-pub const RTAX_INITRWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITRWND;
-pub const RTAX_QUICKACK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_QUICKACK;
-pub const RTAX_CC_ALGO: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CC_ALGO;
-pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FASTOPEN_NO_COOKIE;
-pub const __RTAX_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTAX_MAX;
-pub const PREFIX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_UNSPEC;
-pub const PREFIX_ADDRESS: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_ADDRESS;
-pub const PREFIX_CACHEINFO: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_CACHEINFO;
-pub const __PREFIX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__PREFIX_MAX;
-pub const TCA_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::TCA_UNSPEC;
-pub const TCA_KIND: _bindgen_ty_64 = _bindgen_ty_64::TCA_KIND;
-pub const TCA_OPTIONS: _bindgen_ty_64 = _bindgen_ty_64::TCA_OPTIONS;
-pub const TCA_STATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS;
-pub const TCA_XSTATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_XSTATS;
-pub const TCA_RATE: _bindgen_ty_64 = _bindgen_ty_64::TCA_RATE;
-pub const TCA_FCNT: _bindgen_ty_64 = _bindgen_ty_64::TCA_FCNT;
-pub const TCA_STATS2: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS2;
-pub const TCA_STAB: _bindgen_ty_64 = _bindgen_ty_64::TCA_STAB;
-pub const TCA_PAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_PAD;
-pub const TCA_DUMP_INVISIBLE: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_INVISIBLE;
-pub const TCA_CHAIN: _bindgen_ty_64 = _bindgen_ty_64::TCA_CHAIN;
-pub const TCA_HW_OFFLOAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_HW_OFFLOAD;
-pub const TCA_INGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_INGRESS_BLOCK;
-pub const TCA_EGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_EGRESS_BLOCK;
-pub const TCA_DUMP_FLAGS: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_FLAGS;
-pub const TCA_EXT_WARN_MSG: _bindgen_ty_64 = _bindgen_ty_64::TCA_EXT_WARN_MSG;
-pub const __TCA_MAX: _bindgen_ty_64 = _bindgen_ty_64::__TCA_MAX;
-pub const NDUSEROPT_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_UNSPEC;
-pub const NDUSEROPT_SRCADDR: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_SRCADDR;
-pub const __NDUSEROPT_MAX: _bindgen_ty_65 = _bindgen_ty_65::__NDUSEROPT_MAX;
-pub const TCA_ROOT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_UNSPEC;
-pub const TCA_ROOT_TAB: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TAB;
-pub const TCA_ROOT_FLAGS: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_FLAGS;
-pub const TCA_ROOT_COUNT: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_COUNT;
-pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TIME_DELTA;
-pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_EXT_WARN_MSG;
-pub const __TCA_ROOT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__TCA_ROOT_MAX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_18 = _bindgen_ty_18::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_39 = _bindgen_ty_39::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_45 = _bindgen_ty_45::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_DSA_MAX;
+pub const IFA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFA_UNSPEC;
+pub const IFA_ADDRESS: _bindgen_ty_55 = _bindgen_ty_55::IFA_ADDRESS;
+pub const IFA_LOCAL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LOCAL;
+pub const IFA_LABEL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LABEL;
+pub const IFA_BROADCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_BROADCAST;
+pub const IFA_ANYCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_ANYCAST;
+pub const IFA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::IFA_CACHEINFO;
+pub const IFA_MULTICAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_MULTICAST;
+pub const IFA_FLAGS: _bindgen_ty_55 = _bindgen_ty_55::IFA_FLAGS;
+pub const IFA_RT_PRIORITY: _bindgen_ty_55 = _bindgen_ty_55::IFA_RT_PRIORITY;
+pub const IFA_TARGET_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::IFA_TARGET_NETNSID;
+pub const IFA_PROTO: _bindgen_ty_55 = _bindgen_ty_55::IFA_PROTO;
+pub const __IFA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFA_MAX;
+pub const NDA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDA_UNSPEC;
+pub const NDA_DST: _bindgen_ty_56 = _bindgen_ty_56::NDA_DST;
+pub const NDA_LLADDR: _bindgen_ty_56 = _bindgen_ty_56::NDA_LLADDR;
+pub const NDA_CACHEINFO: _bindgen_ty_56 = _bindgen_ty_56::NDA_CACHEINFO;
+pub const NDA_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROBES;
+pub const NDA_VLAN: _bindgen_ty_56 = _bindgen_ty_56::NDA_VLAN;
+pub const NDA_PORT: _bindgen_ty_56 = _bindgen_ty_56::NDA_PORT;
+pub const NDA_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_VNI;
+pub const NDA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDA_IFINDEX;
+pub const NDA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::NDA_MASTER;
+pub const NDA_LINK_NETNSID: _bindgen_ty_56 = _bindgen_ty_56::NDA_LINK_NETNSID;
+pub const NDA_SRC_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_SRC_VNI;
+pub const NDA_PROTOCOL: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROTOCOL;
+pub const NDA_NH_ID: _bindgen_ty_56 = _bindgen_ty_56::NDA_NH_ID;
+pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_56 = _bindgen_ty_56::NDA_FDB_EXT_ATTRS;
+pub const NDA_FLAGS_EXT: _bindgen_ty_56 = _bindgen_ty_56::NDA_FLAGS_EXT;
+pub const NDA_NDM_STATE_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_STATE_MASK;
+pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_FLAGS_MASK;
+pub const __NDA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDA_MAX;
+pub const NDTPA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UNSPEC;
+pub const NDTPA_IFINDEX: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_IFINDEX;
+pub const NDTPA_REFCNT: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REFCNT;
+pub const NDTPA_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REACHABLE_TIME;
+pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_BASE_REACHABLE_TIME;
+pub const NDTPA_RETRANS_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_RETRANS_TIME;
+pub const NDTPA_GC_STALETIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_GC_STALETIME;
+pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_DELAY_PROBE_TIME;
+pub const NDTPA_QUEUE_LEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LEN;
+pub const NDTPA_APP_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_APP_PROBES;
+pub const NDTPA_UCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UCAST_PROBES;
+pub const NDTPA_MCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_PROBES;
+pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_ANYCAST_DELAY;
+pub const NDTPA_PROXY_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_DELAY;
+pub const NDTPA_PROXY_QLEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_QLEN;
+pub const NDTPA_LOCKTIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_LOCKTIME;
+pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LENBYTES;
+pub const NDTPA_MCAST_REPROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_REPROBES;
+pub const NDTPA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PAD;
+pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_INTERVAL_PROBE_TIME_MS;
+pub const __NDTPA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTPA_MAX;
+pub const NDTA_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDTA_UNSPEC;
+pub const NDTA_NAME: _bindgen_ty_58 = _bindgen_ty_58::NDTA_NAME;
+pub const NDTA_THRESH1: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH1;
+pub const NDTA_THRESH2: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH2;
+pub const NDTA_THRESH3: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH3;
+pub const NDTA_CONFIG: _bindgen_ty_58 = _bindgen_ty_58::NDTA_CONFIG;
+pub const NDTA_PARMS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PARMS;
+pub const NDTA_STATS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_STATS;
+pub const NDTA_GC_INTERVAL: _bindgen_ty_58 = _bindgen_ty_58::NDTA_GC_INTERVAL;
+pub const NDTA_PAD: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PAD;
+pub const __NDTA_MAX: _bindgen_ty_58 = _bindgen_ty_58::__NDTA_MAX;
+pub const FDB_NOTIFY_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_BIT;
+pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_INACTIVE_BIT;
+pub const NFEA_UNSPEC: _bindgen_ty_60 = _bindgen_ty_60::NFEA_UNSPEC;
+pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_60 = _bindgen_ty_60::NFEA_ACTIVITY_NOTIFY;
+pub const NFEA_DONT_REFRESH: _bindgen_ty_60 = _bindgen_ty_60::NFEA_DONT_REFRESH;
+pub const __NFEA_MAX: _bindgen_ty_60 = _bindgen_ty_60::__NFEA_MAX;
+pub const RTM_BASE: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_NEWLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_DELLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINK;
+pub const RTM_GETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINK;
+pub const RTM_SETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETLINK;
+pub const RTM_NEWADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDR;
+pub const RTM_DELADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDR;
+pub const RTM_GETADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDR;
+pub const RTM_NEWROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWROUTE;
+pub const RTM_DELROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELROUTE;
+pub const RTM_GETROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETROUTE;
+pub const RTM_NEWNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGH;
+pub const RTM_DELNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEIGH;
+pub const RTM_GETNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGH;
+pub const RTM_NEWRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWRULE;
+pub const RTM_DELRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELRULE;
+pub const RTM_GETRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETRULE;
+pub const RTM_NEWQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWQDISC;
+pub const RTM_DELQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELQDISC;
+pub const RTM_GETQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETQDISC;
+pub const RTM_NEWTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTCLASS;
+pub const RTM_DELTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTCLASS;
+pub const RTM_GETTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTCLASS;
+pub const RTM_NEWTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTFILTER;
+pub const RTM_DELTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTFILTER;
+pub const RTM_GETTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTFILTER;
+pub const RTM_NEWACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWACTION;
+pub const RTM_DELACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELACTION;
+pub const RTM_GETACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETACTION;
+pub const RTM_NEWPREFIX: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWPREFIX;
+pub const RTM_GETMULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMULTICAST;
+pub const RTM_GETANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETANYCAST;
+pub const RTM_NEWNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGHTBL;
+pub const RTM_GETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGHTBL;
+pub const RTM_SETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETNEIGHTBL;
+pub const RTM_NEWNDUSEROPT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNDUSEROPT;
+pub const RTM_NEWADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDRLABEL;
+pub const RTM_DELADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDRLABEL;
+pub const RTM_GETADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDRLABEL;
+pub const RTM_GETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETDCB;
+pub const RTM_SETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETDCB;
+pub const RTM_NEWNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNETCONF;
+pub const RTM_DELNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNETCONF;
+pub const RTM_GETNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNETCONF;
+pub const RTM_NEWMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWMDB;
+pub const RTM_DELMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELMDB;
+pub const RTM_GETMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMDB;
+pub const RTM_NEWNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNSID;
+pub const RTM_DELNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNSID;
+pub const RTM_GETNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNSID;
+pub const RTM_NEWSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWSTATS;
+pub const RTM_GETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETSTATS;
+pub const RTM_SETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETSTATS;
+pub const RTM_NEWCACHEREPORT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCACHEREPORT;
+pub const RTM_NEWCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCHAIN;
+pub const RTM_DELCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELCHAIN;
+pub const RTM_GETCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETCHAIN;
+pub const RTM_NEWNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOP;
+pub const RTM_DELNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOP;
+pub const RTM_GETNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOP;
+pub const RTM_NEWLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWLINKPROP;
+pub const RTM_DELLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINKPROP;
+pub const RTM_GETLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINKPROP;
+pub const RTM_NEWVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWVLAN;
+pub const RTM_DELVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELVLAN;
+pub const RTM_GETVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETVLAN;
+pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOPBUCKET;
+pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOPBUCKET;
+pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOPBUCKET;
+pub const RTM_NEWTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTUNNEL;
+pub const RTM_DELTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTUNNEL;
+pub const RTM_GETTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTUNNEL;
+pub const __RTM_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTM_MAX;
+pub const RTN_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNSPEC;
+pub const RTN_UNICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNICAST;
+pub const RTN_LOCAL: _bindgen_ty_62 = _bindgen_ty_62::RTN_LOCAL;
+pub const RTN_BROADCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_BROADCAST;
+pub const RTN_ANYCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_ANYCAST;
+pub const RTN_MULTICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_MULTICAST;
+pub const RTN_BLACKHOLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_BLACKHOLE;
+pub const RTN_UNREACHABLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNREACHABLE;
+pub const RTN_PROHIBIT: _bindgen_ty_62 = _bindgen_ty_62::RTN_PROHIBIT;
+pub const RTN_THROW: _bindgen_ty_62 = _bindgen_ty_62::RTN_THROW;
+pub const RTN_NAT: _bindgen_ty_62 = _bindgen_ty_62::RTN_NAT;
+pub const RTN_XRESOLVE: _bindgen_ty_62 = _bindgen_ty_62::RTN_XRESOLVE;
+pub const __RTN_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTN_MAX;
+pub const RTAX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::RTAX_UNSPEC;
+pub const RTAX_LOCK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_LOCK;
+pub const RTAX_MTU: _bindgen_ty_63 = _bindgen_ty_63::RTAX_MTU;
+pub const RTAX_WINDOW: _bindgen_ty_63 = _bindgen_ty_63::RTAX_WINDOW;
+pub const RTAX_RTT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTT;
+pub const RTAX_RTTVAR: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTTVAR;
+pub const RTAX_SSTHRESH: _bindgen_ty_63 = _bindgen_ty_63::RTAX_SSTHRESH;
+pub const RTAX_CWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CWND;
+pub const RTAX_ADVMSS: _bindgen_ty_63 = _bindgen_ty_63::RTAX_ADVMSS;
+pub const RTAX_REORDERING: _bindgen_ty_63 = _bindgen_ty_63::RTAX_REORDERING;
+pub const RTAX_HOPLIMIT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_HOPLIMIT;
+pub const RTAX_INITCWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITCWND;
+pub const RTAX_FEATURES: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FEATURES;
+pub const RTAX_RTO_MIN: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTO_MIN;
+pub const RTAX_INITRWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITRWND;
+pub const RTAX_QUICKACK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_QUICKACK;
+pub const RTAX_CC_ALGO: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CC_ALGO;
+pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FASTOPEN_NO_COOKIE;
+pub const __RTAX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__RTAX_MAX;
+pub const PREFIX_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_UNSPEC;
+pub const PREFIX_ADDRESS: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_ADDRESS;
+pub const PREFIX_CACHEINFO: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_CACHEINFO;
+pub const __PREFIX_MAX: _bindgen_ty_64 = _bindgen_ty_64::__PREFIX_MAX;
+pub const TCA_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::TCA_UNSPEC;
+pub const TCA_KIND: _bindgen_ty_65 = _bindgen_ty_65::TCA_KIND;
+pub const TCA_OPTIONS: _bindgen_ty_65 = _bindgen_ty_65::TCA_OPTIONS;
+pub const TCA_STATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS;
+pub const TCA_XSTATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_XSTATS;
+pub const TCA_RATE: _bindgen_ty_65 = _bindgen_ty_65::TCA_RATE;
+pub const TCA_FCNT: _bindgen_ty_65 = _bindgen_ty_65::TCA_FCNT;
+pub const TCA_STATS2: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS2;
+pub const TCA_STAB: _bindgen_ty_65 = _bindgen_ty_65::TCA_STAB;
+pub const TCA_PAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_PAD;
+pub const TCA_DUMP_INVISIBLE: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_INVISIBLE;
+pub const TCA_CHAIN: _bindgen_ty_65 = _bindgen_ty_65::TCA_CHAIN;
+pub const TCA_HW_OFFLOAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_HW_OFFLOAD;
+pub const TCA_INGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_INGRESS_BLOCK;
+pub const TCA_EGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_EGRESS_BLOCK;
+pub const TCA_DUMP_FLAGS: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_FLAGS;
+pub const TCA_EXT_WARN_MSG: _bindgen_ty_65 = _bindgen_ty_65::TCA_EXT_WARN_MSG;
+pub const __TCA_MAX: _bindgen_ty_65 = _bindgen_ty_65::__TCA_MAX;
+pub const NDUSEROPT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_UNSPEC;
+pub const NDUSEROPT_SRCADDR: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_SRCADDR;
+pub const __NDUSEROPT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__NDUSEROPT_MAX;
+pub const TCA_ROOT_UNSPEC: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_UNSPEC;
+pub const TCA_ROOT_TAB: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TAB;
+pub const TCA_ROOT_FLAGS: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_FLAGS;
+pub const TCA_ROOT_COUNT: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_COUNT;
+pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TIME_DELTA;
+pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_EXT_WARN_MSG;
+pub const __TCA_ROOT_MAX: _bindgen_ty_67 = _bindgen_ty_67::__TCA_ROOT_MAX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1548,6 +1562,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1637,7 +1653,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1733,7 +1750,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1790,7 +1809,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1943,10 +1963,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_18 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_19 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -1962,7 +2010,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_19 {
+pub enum _bindgen_ty_20 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -1974,7 +2022,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_20 {
+pub enum _bindgen_ty_21 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -1982,7 +2030,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2015,7 +2063,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2029,7 +2078,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_23 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2059,7 +2116,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2070,7 +2127,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum _bindgen_ty_25 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2085,7 +2142,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2098,7 +2155,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2136,7 +2193,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2148,7 +2205,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2164,7 +2221,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2172,7 +2229,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2192,7 +2249,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2200,7 +2257,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2209,7 +2266,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2224,7 +2281,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2232,7 +2289,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2246,7 +2303,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2255,7 +2312,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2273,7 +2330,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2283,14 +2340,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2298,7 +2355,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2312,7 +2369,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2324,7 +2381,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2333,7 +2390,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2342,7 +2399,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2352,7 +2409,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2361,7 +2418,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2371,7 +2428,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2386,7 +2443,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2398,7 +2455,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2414,7 +2471,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2423,7 +2480,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2431,15 +2488,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFA_UNSPEC = 0,
 IFA_ADDRESS = 1,
 IFA_LOCAL = 2,
@@ -2457,7 +2514,7 @@ __IFA_MAX = 12,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 NDA_UNSPEC = 0,
 NDA_DST = 1,
 NDA_LLADDR = 2,
@@ -2481,7 +2538,7 @@ __NDA_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 NDTPA_UNSPEC = 0,
 NDTPA_IFINDEX = 1,
 NDTPA_REFCNT = 2,
@@ -2507,7 +2564,7 @@ __NDTPA_MAX = 20,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_57 {
+pub enum _bindgen_ty_58 {
 NDTA_UNSPEC = 0,
 NDTA_NAME = 1,
 NDTA_THRESH1 = 2,
@@ -2523,14 +2580,14 @@ __NDTA_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_58 {
+pub enum _bindgen_ty_59 {
 FDB_NOTIFY_BIT = 1,
 FDB_NOTIFY_INACTIVE_BIT = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_59 {
+pub enum _bindgen_ty_60 {
 NFEA_UNSPEC = 0,
 NFEA_ACTIVITY_NOTIFY = 1,
 NFEA_DONT_REFRESH = 2,
@@ -2539,7 +2596,7 @@ __NFEA_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_60 {
+pub enum _bindgen_ty_61 {
 RTM_BASE = 16,
 RTM_DELLINK = 17,
 RTM_GETLINK = 18,
@@ -2616,7 +2673,7 @@ __RTM_MAX = 123,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_61 {
+pub enum _bindgen_ty_62 {
 RTN_UNSPEC = 0,
 RTN_UNICAST = 1,
 RTN_LOCAL = 2,
@@ -2692,7 +2749,7 @@ __RTA_MAX = 31,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_62 {
+pub enum _bindgen_ty_63 {
 RTAX_UNSPEC = 0,
 RTAX_LOCK = 1,
 RTAX_MTU = 2,
@@ -2716,7 +2773,7 @@ __RTAX_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_63 {
+pub enum _bindgen_ty_64 {
 PREFIX_UNSPEC = 0,
 PREFIX_ADDRESS = 1,
 PREFIX_CACHEINFO = 2,
@@ -2725,7 +2782,7 @@ __PREFIX_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_64 {
+pub enum _bindgen_ty_65 {
 TCA_UNSPEC = 0,
 TCA_KIND = 1,
 TCA_OPTIONS = 2,
@@ -2748,7 +2805,7 @@ __TCA_MAX = 17,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_65 {
+pub enum _bindgen_ty_66 {
 NDUSEROPT_UNSPEC = 0,
 NDUSEROPT_SRCADDR = 1,
 __NDUSEROPT_MAX = 2,
@@ -2799,7 +2856,7 @@ __RTNLGRP_MAX = 37,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_66 {
+pub enum _bindgen_ty_67 {
 TCA_ROOT_UNSPEC = 0,
 TCA_ROOT_TAB = 1,
 TCA_ROOT_FLAGS = 2,
@@ -2862,6 +2919,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/sparc64/prctl.rs
+++ b/src/sparc64/prctl.rs
@@ -224,6 +224,7 @@ pub const PR_SME_VL_LEN_MASK: u32 = 65535;
 pub const PR_SME_VL_INHERIT: u32 = 131072;
 pub const PR_SET_MDWE: u32 = 65;
 pub const PR_MDWE_REFUSE_EXEC_GAIN: u32 = 1;
+pub const PR_MDWE_NO_INHERIT: u32 = 2;
 pub const PR_GET_MDWE: u32 = 66;
 pub const PR_SET_VMA: u32 = 1398164801;
 pub const PR_SET_VMA_ANON_NAME: u32 = 0;

--- a/src/sparc64/xdp.rs
+++ b/src/sparc64/xdp.rs
@@ -89,6 +89,7 @@ pub len: __u64,
 pub chunk_size: __u32,
 pub headroom: __u32,
 pub flags: __u32,
+pub tx_metadata_len: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -104,6 +105,23 @@ pub tx_ring_empty_descs: __u64,
 #[derive(Debug, Copy, Clone)]
 pub struct xdp_options {
 pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct xsk_tx_metadata {
+pub flags: __u64,
+pub __bindgen_anon_1: xsk_tx_metadata__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1 {
+pub csum_start: __u16,
+pub csum_offset: __u16,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2 {
+pub tx_timestamp: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -146,7 +164,9 @@ pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
 pub const XDP_USE_NEED_WAKEUP: u32 = 8;
+pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
+pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;
@@ -163,5 +183,13 @@ pub const XDP_UMEM_PGOFF_FILL_RING: u64 = 4294967296;
 pub const XDP_UMEM_PGOFF_COMPLETION_RING: u64 = 6442450944;
 pub const XSK_UNALIGNED_BUF_OFFSET_SHIFT: u32 = 48;
 pub const XSK_UNALIGNED_BUF_ADDR_MASK: u64 = 281474976710655;
-pub const XDP_USE_SG: u32 = 16;
+pub const XDP_TXMD_FLAGS_TIMESTAMP: u32 = 1;
+pub const XDP_TXMD_FLAGS_CHECKSUM: u32 = 2;
 pub const XDP_PKT_CONTD: u32 = 1;
+pub const XDP_TX_METADATA: u32 = 2;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union xsk_tx_metadata__bindgen_ty_1 {
+pub request: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1,
+pub completion: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2,
+}

--- a/src/x32/general.rs
+++ b/src/x32/general.rs
@@ -184,7 +184,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -239,6 +240,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -297,6 +331,29 @@ pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
 pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -391,36 +448,6 @@ pub it_value: __kernel_old_timeval,
 pub struct __kernel_sock_timeval {
 pub tv_sec: __s64,
 pub tv_usec: __s64,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timespec {
-pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: crate::ctypes::c_long,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timeval {
-pub tv_sec: __kernel_old_time_t,
-pub tv_usec: __kernel_suseconds_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerspec {
-pub it_interval: timespec,
-pub it_value: timespec,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerval {
-pub it_interval: timeval,
-pub it_value: timeval,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timezone {
-pub tz_minuteswest: crate::ctypes::c_int,
-pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -670,6 +697,36 @@ pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct timespec {
+pub tv_sec: __kernel_old_time_t,
+pub tv_nsec: crate::ctypes::c_long,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timeval {
+pub tv_sec: __kernel_old_time_t,
+pub tv_usec: __kernel_suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerspec {
+pub it_interval: timespec,
+pub it_value: timespec,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerval {
+pub it_interval: timeval,
+pub it_value: timeval,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timezone {
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct iovec {
 pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
@@ -763,6 +820,22 @@ pub struct uffdio_continue {
 pub range: uffdio_range,
 pub mode: __u64,
 pub mapped: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_poison {
+pub range: uffdio_range,
+pub mode: __u64,
+pub updated: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_move {
+pub dst: __u64,
+pub src: __u64,
+pub len: __u64,
+pub mode: __u64,
+pub move_: __s64,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -881,9 +954,9 @@ pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 394496;
+pub const LINUX_VERSION_CODE: u32 = 395264;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 5;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_VECTOR_SIZE_ARCH: u32 = 3;
@@ -1255,6 +1328,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1326,6 +1407,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const FUTEX_WAIT: u32 = 0;
 pub const FUTEX_WAKE: u32 = 1;
 pub const FUTEX_FD: u32 = 2;
@@ -1356,6 +1447,13 @@ pub const FUTEX_WAIT_BITSET_PRIVATE: u32 = 137;
 pub const FUTEX_WAKE_BITSET_PRIVATE: u32 = 138;
 pub const FUTEX_WAIT_REQUEUE_PI_PRIVATE: u32 = 139;
 pub const FUTEX_CMP_REQUEUE_PI_PRIVATE: u32 = 140;
+pub const FUTEX2_SIZE_U8: u32 = 0;
+pub const FUTEX2_SIZE_U16: u32 = 1;
+pub const FUTEX2_SIZE_U32: u32 = 2;
+pub const FUTEX2_SIZE_U64: u32 = 3;
+pub const FUTEX2_NUMA: u32 = 4;
+pub const FUTEX2_PRIVATE: u32 = 128;
+pub const FUTEX2_SIZE_MASK: u32 = 3;
 pub const FUTEX_32: u32 = 2;
 pub const FUTEX_WAITV_MAX: u32 = 128;
 pub const FUTEX_WAITERS: u32 = 2147483648;
@@ -1487,6 +1585,8 @@ pub const DMA_BUF_MAGIC: u32 = 1145913666;
 pub const DEVMEM_MAGIC: u32 = 1162691661;
 pub const SECRETMEM_MAGIC: u32 = 1397048141;
 pub const MAP_32BIT: u32 = 64;
+pub const MAP_ABOVE4G: u32 = 128;
+pub const SHADOW_STACK_SET_TOKEN: u32 = 1;
 pub const PROT_READ: u32 = 1;
 pub const PROT_WRITE: u32 = 2;
 pub const PROT_EXEC: u32 = 4;
@@ -1613,25 +1713,6 @@ pub const LINUX_REBOOT_CMD_POWER_OFF: u32 = 1126301404;
 pub const LINUX_REBOOT_CMD_RESTART2: u32 = 2712847316;
 pub const LINUX_REBOOT_CMD_SW_SUSPEND: u32 = 3489725666;
 pub const LINUX_REBOOT_CMD_KEXEC: u32 = 1163412803;
-pub const ITIMER_REAL: u32 = 0;
-pub const ITIMER_VIRTUAL: u32 = 1;
-pub const ITIMER_PROF: u32 = 2;
-pub const CLOCK_REALTIME: u32 = 0;
-pub const CLOCK_MONOTONIC: u32 = 1;
-pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
-pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
-pub const CLOCK_MONOTONIC_RAW: u32 = 4;
-pub const CLOCK_REALTIME_COARSE: u32 = 5;
-pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
-pub const CLOCK_BOOTTIME: u32 = 7;
-pub const CLOCK_REALTIME_ALARM: u32 = 8;
-pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
-pub const CLOCK_SGI_CYCLE: u32 = 10;
-pub const CLOCK_TAI: u32 = 11;
-pub const MAX_CLOCKS: u32 = 16;
-pub const CLOCKS_MASK: u32 = 1;
-pub const CLOCKS_MONO: u32 = 1;
-pub const TIMER_ABSTIME: u32 = 1;
 pub const RUSAGE_SELF: u32 = 0;
 pub const RUSAGE_CHILDREN: i32 = -1;
 pub const RUSAGE_BOTH: i32 = -2;
@@ -1811,7 +1892,8 @@ pub const SEGV_ADIDERR: u32 = 6;
 pub const SEGV_ADIPERR: u32 = 7;
 pub const SEGV_MTEAERR: u32 = 8;
 pub const SEGV_MTESERR: u32 = 9;
-pub const NSIGSEGV: u32 = 9;
+pub const SEGV_CPERR: u32 = 10;
+pub const NSIGSEGV: u32 = 10;
 pub const BUS_ADRALN: u32 = 1;
 pub const BUS_ADRERR: u32 = 2;
 pub const BUS_OBJERR: u32 = 3;
@@ -1892,6 +1974,7 @@ pub const STATX_BASIC_STATS: u32 = 2047;
 pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
+pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2069,6 +2152,25 @@ pub const TIOCM_RI: u32 = 128;
 pub const TIOCM_OUT1: u32 = 8192;
 pub const TIOCM_OUT2: u32 = 16384;
 pub const TIOCM_LOOP: u32 = 32768;
+pub const ITIMER_REAL: u32 = 0;
+pub const ITIMER_VIRTUAL: u32 = 1;
+pub const ITIMER_PROF: u32 = 2;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_SGI_CYCLE: u32 = 10;
+pub const CLOCK_TAI: u32 = 11;
+pub const MAX_CLOCKS: u32 = 16;
+pub const CLOCKS_MASK: u32 = 1;
+pub const CLOCKS_MONO: u32 = 1;
+pub const TIMER_ABSTIME: u32 = 1;
 pub const UIO_FASTIOV: u32 = 8;
 pub const UIO_MAXIOV: u32 = 1024;
 pub const __X32_SYSCALL_BIT: u32 = 1073741824;
@@ -2388,6 +2490,15 @@ pub const __NR_process_mrelease: u32 = 1073742272;
 pub const __NR_futex_waitv: u32 = 1073742273;
 pub const __NR_set_mempolicy_home_node: u32 = 1073742274;
 pub const __NR_cachestat: u32 = 1073742275;
+pub const __NR_fchmodat2: u32 = 1073742276;
+pub const __NR_futex_wake: u32 = 1073742278;
+pub const __NR_futex_wait: u32 = 1073742279;
+pub const __NR_futex_requeue: u32 = 1073742280;
+pub const __NR_statmount: u32 = 1073742281;
+pub const __NR_listmount: u32 = 1073742282;
+pub const __NR_lsm_get_self_attr: u32 = 1073742283;
+pub const __NR_lsm_set_self_attr: u32 = 1073742284;
+pub const __NR_lsm_list_modules: u32 = 1073742285;
 pub const __NR_rt_sigaction: u32 = 1073742336;
 pub const __NR_rt_sigreturn: u32 = 1073742337;
 pub const __NR_ioctl: u32 = 1073742338;
@@ -2502,8 +2613,10 @@ pub const _UFFDIO_UNREGISTER: u32 = 1;
 pub const _UFFDIO_WAKE: u32 = 2;
 pub const _UFFDIO_COPY: u32 = 3;
 pub const _UFFDIO_ZEROPAGE: u32 = 4;
+pub const _UFFDIO_MOVE: u32 = 5;
 pub const _UFFDIO_WRITEPROTECT: u32 = 6;
 pub const _UFFDIO_CONTINUE: u32 = 7;
+pub const _UFFDIO_POISON: u32 = 8;
 pub const _UFFDIO_API: u32 = 63;
 pub const UFFDIO: u32 = 170;
 pub const UFFD_EVENT_PAGEFAULT: u32 = 18;
@@ -2528,6 +2641,9 @@ pub const UFFD_FEATURE_MINOR_SHMEM: u32 = 1024;
 pub const UFFD_FEATURE_EXACT_ADDRESS: u32 = 2048;
 pub const UFFD_FEATURE_WP_HUGETLBFS_SHMEM: u32 = 4096;
 pub const UFFD_FEATURE_WP_UNPOPULATED: u32 = 8192;
+pub const UFFD_FEATURE_POISON: u32 = 16384;
+pub const UFFD_FEATURE_WP_ASYNC: u32 = 32768;
+pub const UFFD_FEATURE_MOVE: u32 = 65536;
 pub const UFFD_USER_MODE_ONLY: u32 = 1;
 pub const DT_UNKNOWN: u32 = 0;
 pub const DT_FIFO: u32 = 1;
@@ -2604,6 +2720,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/x32/if_arp.rs
+++ b/src/x32/if_arp.rs
@@ -52,11 +52,6 @@ pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
@@ -175,6 +170,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -182,23 +178,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -1126,6 +1107,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_4 = _bindgen_ty_4::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_4 = _bindgen_ty_4::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_MASK;
@@ -1194,6 +1176,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_HAIRPIN;
@@ -1241,6 +1225,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_10 = _bindgen_ty_10::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_KIND;
@@ -1302,301 +1287,310 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_19 = _bindgen_ty_19::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_40 = _bindgen_ty_40::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_46 = _bindgen_ty_46::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_DSA_MAX;
-pub const IF_PORT_UNKNOWN: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_UNKNOWN;
-pub const IF_PORT_10BASE2: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASE2;
-pub const IF_PORT_10BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASET;
-pub const IF_PORT_AUI: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_AUI;
-pub const IF_PORT_100BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASET;
-pub const IF_PORT_100BASETX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASETX;
-pub const IF_PORT_100BASEFX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASEFX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_20 = _bindgen_ty_20::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_23 = _bindgen_ty_23::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_47 = _bindgen_ty_47::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__IFLA_DSA_MAX;
+pub const IF_PORT_UNKNOWN: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_UNKNOWN;
+pub const IF_PORT_10BASE2: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASE2;
+pub const IF_PORT_10BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASET;
+pub const IF_PORT_AUI: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_AUI;
+pub const IF_PORT_100BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASET;
+pub const IF_PORT_100BASETX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASETX;
+pub const IF_PORT_100BASEFX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASEFX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1699,6 +1693,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1788,7 +1784,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1884,7 +1881,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1941,7 +1940,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2094,10 +2094,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_20 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_21 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -2113,7 +2141,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -2125,7 +2153,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum _bindgen_ty_23 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -2133,7 +2161,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2166,7 +2194,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2180,7 +2209,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_25 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2210,7 +2247,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2221,7 +2258,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2236,7 +2273,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2249,7 +2286,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2287,7 +2324,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2299,7 +2336,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2315,7 +2352,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2323,7 +2360,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2343,7 +2380,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2351,7 +2388,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2360,7 +2397,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2375,7 +2412,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2383,7 +2420,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2397,7 +2434,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2406,7 +2443,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2424,7 +2461,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2434,14 +2471,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2449,7 +2486,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2463,7 +2500,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2475,7 +2512,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2484,7 +2521,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2493,7 +2530,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2503,7 +2540,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2512,7 +2549,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2522,7 +2559,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2537,7 +2574,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2549,7 +2586,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2565,7 +2602,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2574,7 +2611,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2582,15 +2619,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 IF_PORT_UNKNOWN = 0,
 IF_PORT_10BASE2 = 1,
 IF_PORT_10BASET = 2,
@@ -2673,74 +2710,6 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 impl nlmsgerr_attrs {
 pub const NLMSGERR_ATTR_MAX: nlmsgerr_attrs = nlmsgerr_attrs::NLMSGERR_ATTR_MISS_NEST;
 }
@@ -2755,6 +2724,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/x32/if_packet.rs
+++ b/src/x32/if_packet.rs
@@ -51,11 +51,6 @@ pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_pkt {
 pub spkt_family: crate::ctypes::c_ushort,
@@ -63,6 +58,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -70,23 +66,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -327,71 +308,3 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}

--- a/src/x32/io_uring.rs
+++ b/src/x32/io_uring.rs
@@ -79,7 +79,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -134,6 +135,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -195,6 +229,29 @@ pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
 pub tv_nsec: crate::ctypes::c_longlong,
@@ -253,6 +310,12 @@ pub __pad1: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_sqe__bindgen_ty_2__bindgen_ty_1 {
+pub level: __u32,
+pub optname: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_sqe__bindgen_ty_5__bindgen_ty_1 {
 pub addr_len: __u16,
 pub __pad3: [__u16; 1usize],
@@ -260,6 +323,7 @@ pub __pad3: [__u16; 1usize],
 #[repr(C)]
 pub struct io_uring_sqe__bindgen_ty_6 {
 pub __bindgen_anon_1: __BindgenUnionField<io_uring_sqe__bindgen_ty_6__bindgen_ty_1>,
+pub optval: __BindgenUnionField<__u64>,
 pub cmd: __BindgenUnionField<[__u8; 0usize]>,
 pub bindgen_union_field: [u64; 2usize],
 }
@@ -421,6 +485,13 @@ pub resv: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_buf_status {
+pub buf_group: __u32,
+pub head: __u32,
+pub resv: [__u32; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -434,7 +505,9 @@ pub addr: __u64,
 pub fd: __s32,
 pub flags: __u32,
 pub timeout: __kernel_timespec,
-pub pad: [__u64; 4usize],
+pub opcode: __u8,
+pub pad: [__u8; 7usize],
+pub pad2: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -597,6 +670,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -668,6 +749,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const IORING_FILE_INDEX_ALLOC: i32 = -1;
 pub const IORING_SETUP_IOPOLL: u32 = 1;
 pub const IORING_SETUP_SQPOLL: u32 = 2;
@@ -685,8 +776,9 @@ pub const IORING_SETUP_SINGLE_ISSUER: u32 = 4096;
 pub const IORING_SETUP_DEFER_TASKRUN: u32 = 8192;
 pub const IORING_SETUP_NO_MMAP: u32 = 16384;
 pub const IORING_SETUP_REGISTERED_FD_ONLY: u32 = 32768;
+pub const IORING_SETUP_NO_SQARRAY: u32 = 65536;
 pub const IORING_URING_CMD_FIXED: u32 = 1;
-pub const IORING_URING_CMD_POLLED: u32 = 2147483648;
+pub const IORING_URING_CMD_MASK: u32 = 1;
 pub const IORING_FSYNC_DATASYNC: u32 = 1;
 pub const IORING_TIMEOUT_ABS: u32 = 1;
 pub const IORING_TIMEOUT_UPDATE: u32 = 2;
@@ -706,6 +798,8 @@ pub const IORING_ASYNC_CANCEL_ALL: u32 = 1;
 pub const IORING_ASYNC_CANCEL_FD: u32 = 2;
 pub const IORING_ASYNC_CANCEL_ANY: u32 = 4;
 pub const IORING_ASYNC_CANCEL_FD_FIXED: u32 = 8;
+pub const IORING_ASYNC_CANCEL_USERDATA: u32 = 16;
+pub const IORING_ASYNC_CANCEL_OP: u32 = 32;
 pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
@@ -714,6 +808,7 @@ pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
+pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
@@ -786,6 +881,7 @@ pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGIS
 pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
 pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
 pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
+pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
 pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
 pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
 pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
@@ -796,6 +892,10 @@ pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTR
 pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
 pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
 pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
+pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
+pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
+pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
+pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -808,6 +908,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -874,7 +975,13 @@ IORING_OP_SOCKET = 45,
 IORING_OP_URING_CMD = 46,
 IORING_OP_SEND_ZC = 47,
 IORING_OP_SENDMSG_ZC = 48,
-IORING_OP_LAST = 49,
+IORING_OP_READ_MULTISHOT = 49,
+IORING_OP_WAITID = 50,
+IORING_OP_FUTEX_WAIT = 51,
+IORING_OP_FUTEX_WAKE = 52,
+IORING_OP_FUTEX_WAITV = 53,
+IORING_OP_FIXED_FD_INSTALL = 54,
+IORING_OP_LAST = 55,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -919,7 +1026,8 @@ IORING_REGISTER_PBUF_RING = 22,
 IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
-IORING_REGISTER_LAST = 26,
+IORING_REGISTER_PBUF_STATUS = 26,
+IORING_REGISTER_LAST = 27,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
@@ -944,6 +1052,15 @@ IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
 IORING_RESTRICTION_SQE_FLAGS_REQUIRED = 3,
 IORING_RESTRICTION_LAST = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_8 {
+SOCKET_URING_OP_SIOCINQ = 0,
+SOCKET_URING_OP_SIOCOUTQ = 1,
+SOCKET_URING_OP_GETSOCKOPT = 2,
+SOCKET_URING_OP_SETSOCKOPT = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -971,6 +1088,7 @@ pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_1__bindgen_ty_1,
 pub union io_uring_sqe__bindgen_ty_2 {
 pub addr: __u64,
 pub splice_off_in: __u64,
+pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_2__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -994,6 +1112,9 @@ pub hardlink_flags: __u32,
 pub xattr_flags: __u32,
 pub msg_ring_flags: __u32,
 pub uring_cmd_flags: __u32,
+pub waitid_flags: __u32,
+pub futex_flags: __u32,
+pub install_fd_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]
@@ -1006,6 +1127,7 @@ pub buf_group: __u16,
 pub union io_uring_sqe__bindgen_ty_5 {
 pub splice_fd_in: __s32,
 pub file_index: __u32,
+pub optlen: __u32,
 pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]

--- a/src/x32/net.rs
+++ b/src/x32/net.rs
@@ -429,6 +429,9 @@ pub tcpi_rcv_ooopack: __u32,
 pub tcpi_snd_wnd: __u32,
 pub tcpi_rcv_wnd: __u32,
 pub tcpi_rehash: __u32,
+pub tcpi_total_rto: __u16,
+pub tcpi_total_rto_recoveries: __u16,
+pub tcpi_total_rto_time: __u32,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -448,6 +451,82 @@ pub tcpm_prefixlen: __u8,
 pub tcpm_keylen: __u16,
 pub tcpm_addr: [__be32; 4usize],
 pub tcpm_key: [__u8; 80usize],
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_add {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub key: [__u8; 80usize],
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_del {
+pub addr: __kernel_sockaddr_storage,
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub current_key: __u8,
+pub rnext: __u8,
+pub keyflags: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_info_opt {
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub current_key: __u8,
+pub rnext: __u8,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+pub pkt_key_not_found: __u64,
+pub pkt_ao_required: __u64,
+pub pkt_dropped_icmp: __u64,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_getsockopt {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub key: [__u8; 80usize],
+pub nkeys: __u32,
+pub _bitfield_align_1: [u16; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub prefix: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub ifindex: __s32,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_repair {
+pub snt_isn: __be32,
+pub rcv_isn: __be32,
+pub snd_sne: __u32,
+pub rcv_sne: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1185,6 +1264,11 @@ pub const TCP_ZEROCOPY_RECEIVE: u32 = 35;
 pub const TCP_INQ: u32 = 36;
 pub const TCP_CM_INQ: u32 = 36;
 pub const TCP_TX_DELAY: u32 = 37;
+pub const TCP_AO_ADD_KEY: u32 = 38;
+pub const TCP_AO_DEL_KEY: u32 = 39;
+pub const TCP_AO_INFO: u32 = 40;
+pub const TCP_AO_GET_KEYS: u32 = 41;
+pub const TCP_AO_REPAIR: u32 = 42;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1194,9 +1278,13 @@ pub const TCPI_OPT_WSCALE: u32 = 4;
 pub const TCPI_OPT_ECN: u32 = 8;
 pub const TCPI_OPT_ECN_SEEN: u32 = 16;
 pub const TCPI_OPT_SYN_DATA: u32 = 32;
+pub const TCPI_OPT_USEC_TS: u32 = 64;
 pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
+pub const TCP_AO_MAXKEYLEN: u32 = 80;
+pub const TCP_AO_KEYF_IFINDEX: u32 = 1;
+pub const TCP_AO_KEYF_EXCLUDE_OPT: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
@@ -1561,6 +1649,7 @@ pub const DEVCONF_IOAM6_ID: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID;
 pub const DEVCONF_IOAM6_ID_WIDE: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID_WIDE;
 pub const DEVCONF_NDISC_EVICT_NOCARRIER: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_NDISC_EVICT_NOCARRIER;
 pub const DEVCONF_ACCEPT_UNTRACKED_NA: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_UNTRACKED_NA;
+pub const DEVCONF_ACCEPT_RA_MIN_LFT: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_RA_MIN_LFT;
 pub const DEVCONF_MAX: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_MAX;
 pub const TCP_FLAG_CWR: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_CWR;
 pub const TCP_FLAG_ECE: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_ECE;
@@ -1758,7 +1847,8 @@ DEVCONF_IOAM6_ID = 54,
 DEVCONF_IOAM6_ID_WIDE = 55,
 DEVCONF_NDISC_EVICT_NOCARRIER = 56,
 DEVCONF_ACCEPT_UNTRACKED_NA = 57,
-DEVCONF_MAX = 58,
+DEVCONF_ACCEPT_RA_MIN_LFT = 58,
+DEVCONF_MAX = 59,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2476,6 +2566,289 @@ tcpi_delivery_rate_app_limited as u64
 __bindgen_bitfield_unit.set(9usize, 2u8, {
 let tcpi_fastopen_client_fail: u8 = unsafe { ::core::mem::transmute(tcpi_fastopen_client_fail) };
 tcpi_fastopen_client_fail as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_add {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 30u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 30u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_del {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn del_async(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_del_async(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 29u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 29u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, del_async: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let del_async: u32 = unsafe { ::core::mem::transmute(del_async) };
+del_async as u64
+});
+__bindgen_bitfield_unit.set(3usize, 29u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_info_opt {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn ao_required(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_ao_required(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_counters(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_counters(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn accept_icmps(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_accept_icmps(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(4usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(5usize, 27u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(5usize, 27u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, ao_required: __u32, set_counters: __u32, accept_icmps: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let ao_required: u32 = unsafe { ::core::mem::transmute(ao_required) };
+ao_required as u64
+});
+__bindgen_bitfield_unit.set(3usize, 1u8, {
+let set_counters: u32 = unsafe { ::core::mem::transmute(set_counters) };
+set_counters as u64
+});
+__bindgen_bitfield_unit.set(4usize, 1u8, {
+let accept_icmps: u32 = unsafe { ::core::mem::transmute(accept_icmps) };
+accept_icmps as u64
+});
+__bindgen_bitfield_unit.set(5usize, 27u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_getsockopt {
+#[inline]
+pub fn is_current(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_current(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn is_rnext(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_rnext(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn get_all(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_get_all(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 13u8) as u16) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 13u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(is_current: __u16, is_rnext: __u16, get_all: __u16, reserved: __u16) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let is_current: u16 = unsafe { ::core::mem::transmute(is_current) };
+is_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let is_rnext: u16 = unsafe { ::core::mem::transmute(is_rnext) };
+is_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let get_all: u16 = unsafe { ::core::mem::transmute(get_all) };
+get_all as u64
+});
+__bindgen_bitfield_unit.set(3usize, 13u8, {
+let reserved: u16 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
 });
 __bindgen_bitfield_unit
 }

--- a/src/x32/netlink.rs
+++ b/src/x32/netlink.rs
@@ -724,7 +724,8 @@ pub const RTAX_FEATURE_ECN: u32 = 1;
 pub const RTAX_FEATURE_SACK: u32 = 2;
 pub const RTAX_FEATURE_TIMESTAMP: u32 = 4;
 pub const RTAX_FEATURE_ALLFRAG: u32 = 8;
-pub const RTAX_FEATURE_MASK: u32 = 15;
+pub const RTAX_FEATURE_TCP_USEC_TS: u32 = 16;
+pub const RTAX_FEATURE_MASK: u32 = 31;
 pub const TCM_IFINDEX_MAGIC_BLOCK: u32 = 4294967295;
 pub const TCA_DUMP_FLAGS_TERSE: u32 = 1;
 pub const RTMGRP_LINK: u32 = 1;
@@ -821,6 +822,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_2 = _bindgen_ty_2::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_2 = _bindgen_ty_2::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_MASK;
@@ -889,6 +891,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_6 = _bindgen_ty_6::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_HAIRPIN;
@@ -936,6 +940,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_KIND;
@@ -997,501 +1002,510 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_17 = _bindgen_ty_17::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_18 = _bindgen_ty_18::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_21 = _bindgen_ty_21::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_44 = _bindgen_ty_44::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_DSA_MAX;
-pub const IFA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFA_UNSPEC;
-pub const IFA_ADDRESS: _bindgen_ty_54 = _bindgen_ty_54::IFA_ADDRESS;
-pub const IFA_LOCAL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LOCAL;
-pub const IFA_LABEL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LABEL;
-pub const IFA_BROADCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_BROADCAST;
-pub const IFA_ANYCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_ANYCAST;
-pub const IFA_CACHEINFO: _bindgen_ty_54 = _bindgen_ty_54::IFA_CACHEINFO;
-pub const IFA_MULTICAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_MULTICAST;
-pub const IFA_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFA_FLAGS;
-pub const IFA_RT_PRIORITY: _bindgen_ty_54 = _bindgen_ty_54::IFA_RT_PRIORITY;
-pub const IFA_TARGET_NETNSID: _bindgen_ty_54 = _bindgen_ty_54::IFA_TARGET_NETNSID;
-pub const IFA_PROTO: _bindgen_ty_54 = _bindgen_ty_54::IFA_PROTO;
-pub const __IFA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFA_MAX;
-pub const NDA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::NDA_UNSPEC;
-pub const NDA_DST: _bindgen_ty_55 = _bindgen_ty_55::NDA_DST;
-pub const NDA_LLADDR: _bindgen_ty_55 = _bindgen_ty_55::NDA_LLADDR;
-pub const NDA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::NDA_CACHEINFO;
-pub const NDA_PROBES: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROBES;
-pub const NDA_VLAN: _bindgen_ty_55 = _bindgen_ty_55::NDA_VLAN;
-pub const NDA_PORT: _bindgen_ty_55 = _bindgen_ty_55::NDA_PORT;
-pub const NDA_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_VNI;
-pub const NDA_IFINDEX: _bindgen_ty_55 = _bindgen_ty_55::NDA_IFINDEX;
-pub const NDA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::NDA_MASTER;
-pub const NDA_LINK_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::NDA_LINK_NETNSID;
-pub const NDA_SRC_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_SRC_VNI;
-pub const NDA_PROTOCOL: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROTOCOL;
-pub const NDA_NH_ID: _bindgen_ty_55 = _bindgen_ty_55::NDA_NH_ID;
-pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_55 = _bindgen_ty_55::NDA_FDB_EXT_ATTRS;
-pub const NDA_FLAGS_EXT: _bindgen_ty_55 = _bindgen_ty_55::NDA_FLAGS_EXT;
-pub const NDA_NDM_STATE_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_STATE_MASK;
-pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_FLAGS_MASK;
-pub const __NDA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__NDA_MAX;
-pub const NDTPA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UNSPEC;
-pub const NDTPA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_IFINDEX;
-pub const NDTPA_REFCNT: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REFCNT;
-pub const NDTPA_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REACHABLE_TIME;
-pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_BASE_REACHABLE_TIME;
-pub const NDTPA_RETRANS_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_RETRANS_TIME;
-pub const NDTPA_GC_STALETIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_GC_STALETIME;
-pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_DELAY_PROBE_TIME;
-pub const NDTPA_QUEUE_LEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LEN;
-pub const NDTPA_APP_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_APP_PROBES;
-pub const NDTPA_UCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UCAST_PROBES;
-pub const NDTPA_MCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_PROBES;
-pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_ANYCAST_DELAY;
-pub const NDTPA_PROXY_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_DELAY;
-pub const NDTPA_PROXY_QLEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_QLEN;
-pub const NDTPA_LOCKTIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_LOCKTIME;
-pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LENBYTES;
-pub const NDTPA_MCAST_REPROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_REPROBES;
-pub const NDTPA_PAD: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PAD;
-pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_INTERVAL_PROBE_TIME_MS;
-pub const __NDTPA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDTPA_MAX;
-pub const NDTA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTA_UNSPEC;
-pub const NDTA_NAME: _bindgen_ty_57 = _bindgen_ty_57::NDTA_NAME;
-pub const NDTA_THRESH1: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH1;
-pub const NDTA_THRESH2: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH2;
-pub const NDTA_THRESH3: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH3;
-pub const NDTA_CONFIG: _bindgen_ty_57 = _bindgen_ty_57::NDTA_CONFIG;
-pub const NDTA_PARMS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PARMS;
-pub const NDTA_STATS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_STATS;
-pub const NDTA_GC_INTERVAL: _bindgen_ty_57 = _bindgen_ty_57::NDTA_GC_INTERVAL;
-pub const NDTA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PAD;
-pub const __NDTA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTA_MAX;
-pub const FDB_NOTIFY_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_BIT;
-pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_INACTIVE_BIT;
-pub const NFEA_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::NFEA_UNSPEC;
-pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_59 = _bindgen_ty_59::NFEA_ACTIVITY_NOTIFY;
-pub const NFEA_DONT_REFRESH: _bindgen_ty_59 = _bindgen_ty_59::NFEA_DONT_REFRESH;
-pub const __NFEA_MAX: _bindgen_ty_59 = _bindgen_ty_59::__NFEA_MAX;
-pub const RTM_BASE: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_NEWLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_DELLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINK;
-pub const RTM_GETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINK;
-pub const RTM_SETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETLINK;
-pub const RTM_NEWADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDR;
-pub const RTM_DELADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDR;
-pub const RTM_GETADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDR;
-pub const RTM_NEWROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWROUTE;
-pub const RTM_DELROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELROUTE;
-pub const RTM_GETROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETROUTE;
-pub const RTM_NEWNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGH;
-pub const RTM_DELNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEIGH;
-pub const RTM_GETNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGH;
-pub const RTM_NEWRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWRULE;
-pub const RTM_DELRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELRULE;
-pub const RTM_GETRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETRULE;
-pub const RTM_NEWQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWQDISC;
-pub const RTM_DELQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELQDISC;
-pub const RTM_GETQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETQDISC;
-pub const RTM_NEWTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTCLASS;
-pub const RTM_DELTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTCLASS;
-pub const RTM_GETTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTCLASS;
-pub const RTM_NEWTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTFILTER;
-pub const RTM_DELTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTFILTER;
-pub const RTM_GETTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTFILTER;
-pub const RTM_NEWACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWACTION;
-pub const RTM_DELACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELACTION;
-pub const RTM_GETACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETACTION;
-pub const RTM_NEWPREFIX: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWPREFIX;
-pub const RTM_GETMULTICAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMULTICAST;
-pub const RTM_GETANYCAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETANYCAST;
-pub const RTM_NEWNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGHTBL;
-pub const RTM_GETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGHTBL;
-pub const RTM_SETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETNEIGHTBL;
-pub const RTM_NEWNDUSEROPT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNDUSEROPT;
-pub const RTM_NEWADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDRLABEL;
-pub const RTM_DELADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDRLABEL;
-pub const RTM_GETADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDRLABEL;
-pub const RTM_GETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETDCB;
-pub const RTM_SETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETDCB;
-pub const RTM_NEWNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNETCONF;
-pub const RTM_DELNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNETCONF;
-pub const RTM_GETNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNETCONF;
-pub const RTM_NEWMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWMDB;
-pub const RTM_DELMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELMDB;
-pub const RTM_GETMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMDB;
-pub const RTM_NEWNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNSID;
-pub const RTM_DELNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNSID;
-pub const RTM_GETNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNSID;
-pub const RTM_NEWSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWSTATS;
-pub const RTM_GETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETSTATS;
-pub const RTM_SETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETSTATS;
-pub const RTM_NEWCACHEREPORT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCACHEREPORT;
-pub const RTM_NEWCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCHAIN;
-pub const RTM_DELCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELCHAIN;
-pub const RTM_GETCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETCHAIN;
-pub const RTM_NEWNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOP;
-pub const RTM_DELNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOP;
-pub const RTM_GETNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOP;
-pub const RTM_NEWLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWLINKPROP;
-pub const RTM_DELLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINKPROP;
-pub const RTM_GETLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINKPROP;
-pub const RTM_NEWVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWVLAN;
-pub const RTM_DELVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELVLAN;
-pub const RTM_GETVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETVLAN;
-pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOPBUCKET;
-pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOPBUCKET;
-pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOPBUCKET;
-pub const RTM_NEWTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTUNNEL;
-pub const RTM_DELTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTUNNEL;
-pub const RTM_GETTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTUNNEL;
-pub const __RTM_MAX: _bindgen_ty_60 = _bindgen_ty_60::__RTM_MAX;
-pub const RTN_UNSPEC: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNSPEC;
-pub const RTN_UNICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNICAST;
-pub const RTN_LOCAL: _bindgen_ty_61 = _bindgen_ty_61::RTN_LOCAL;
-pub const RTN_BROADCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_BROADCAST;
-pub const RTN_ANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_ANYCAST;
-pub const RTN_MULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_MULTICAST;
-pub const RTN_BLACKHOLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_BLACKHOLE;
-pub const RTN_UNREACHABLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNREACHABLE;
-pub const RTN_PROHIBIT: _bindgen_ty_61 = _bindgen_ty_61::RTN_PROHIBIT;
-pub const RTN_THROW: _bindgen_ty_61 = _bindgen_ty_61::RTN_THROW;
-pub const RTN_NAT: _bindgen_ty_61 = _bindgen_ty_61::RTN_NAT;
-pub const RTN_XRESOLVE: _bindgen_ty_61 = _bindgen_ty_61::RTN_XRESOLVE;
-pub const __RTN_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTN_MAX;
-pub const RTAX_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTAX_UNSPEC;
-pub const RTAX_LOCK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_LOCK;
-pub const RTAX_MTU: _bindgen_ty_62 = _bindgen_ty_62::RTAX_MTU;
-pub const RTAX_WINDOW: _bindgen_ty_62 = _bindgen_ty_62::RTAX_WINDOW;
-pub const RTAX_RTT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTT;
-pub const RTAX_RTTVAR: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTTVAR;
-pub const RTAX_SSTHRESH: _bindgen_ty_62 = _bindgen_ty_62::RTAX_SSTHRESH;
-pub const RTAX_CWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CWND;
-pub const RTAX_ADVMSS: _bindgen_ty_62 = _bindgen_ty_62::RTAX_ADVMSS;
-pub const RTAX_REORDERING: _bindgen_ty_62 = _bindgen_ty_62::RTAX_REORDERING;
-pub const RTAX_HOPLIMIT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_HOPLIMIT;
-pub const RTAX_INITCWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITCWND;
-pub const RTAX_FEATURES: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FEATURES;
-pub const RTAX_RTO_MIN: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTO_MIN;
-pub const RTAX_INITRWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITRWND;
-pub const RTAX_QUICKACK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_QUICKACK;
-pub const RTAX_CC_ALGO: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CC_ALGO;
-pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FASTOPEN_NO_COOKIE;
-pub const __RTAX_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTAX_MAX;
-pub const PREFIX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_UNSPEC;
-pub const PREFIX_ADDRESS: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_ADDRESS;
-pub const PREFIX_CACHEINFO: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_CACHEINFO;
-pub const __PREFIX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__PREFIX_MAX;
-pub const TCA_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::TCA_UNSPEC;
-pub const TCA_KIND: _bindgen_ty_64 = _bindgen_ty_64::TCA_KIND;
-pub const TCA_OPTIONS: _bindgen_ty_64 = _bindgen_ty_64::TCA_OPTIONS;
-pub const TCA_STATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS;
-pub const TCA_XSTATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_XSTATS;
-pub const TCA_RATE: _bindgen_ty_64 = _bindgen_ty_64::TCA_RATE;
-pub const TCA_FCNT: _bindgen_ty_64 = _bindgen_ty_64::TCA_FCNT;
-pub const TCA_STATS2: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS2;
-pub const TCA_STAB: _bindgen_ty_64 = _bindgen_ty_64::TCA_STAB;
-pub const TCA_PAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_PAD;
-pub const TCA_DUMP_INVISIBLE: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_INVISIBLE;
-pub const TCA_CHAIN: _bindgen_ty_64 = _bindgen_ty_64::TCA_CHAIN;
-pub const TCA_HW_OFFLOAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_HW_OFFLOAD;
-pub const TCA_INGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_INGRESS_BLOCK;
-pub const TCA_EGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_EGRESS_BLOCK;
-pub const TCA_DUMP_FLAGS: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_FLAGS;
-pub const TCA_EXT_WARN_MSG: _bindgen_ty_64 = _bindgen_ty_64::TCA_EXT_WARN_MSG;
-pub const __TCA_MAX: _bindgen_ty_64 = _bindgen_ty_64::__TCA_MAX;
-pub const NDUSEROPT_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_UNSPEC;
-pub const NDUSEROPT_SRCADDR: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_SRCADDR;
-pub const __NDUSEROPT_MAX: _bindgen_ty_65 = _bindgen_ty_65::__NDUSEROPT_MAX;
-pub const TCA_ROOT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_UNSPEC;
-pub const TCA_ROOT_TAB: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TAB;
-pub const TCA_ROOT_FLAGS: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_FLAGS;
-pub const TCA_ROOT_COUNT: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_COUNT;
-pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TIME_DELTA;
-pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_EXT_WARN_MSG;
-pub const __TCA_ROOT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__TCA_ROOT_MAX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_18 = _bindgen_ty_18::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_39 = _bindgen_ty_39::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_45 = _bindgen_ty_45::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_DSA_MAX;
+pub const IFA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFA_UNSPEC;
+pub const IFA_ADDRESS: _bindgen_ty_55 = _bindgen_ty_55::IFA_ADDRESS;
+pub const IFA_LOCAL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LOCAL;
+pub const IFA_LABEL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LABEL;
+pub const IFA_BROADCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_BROADCAST;
+pub const IFA_ANYCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_ANYCAST;
+pub const IFA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::IFA_CACHEINFO;
+pub const IFA_MULTICAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_MULTICAST;
+pub const IFA_FLAGS: _bindgen_ty_55 = _bindgen_ty_55::IFA_FLAGS;
+pub const IFA_RT_PRIORITY: _bindgen_ty_55 = _bindgen_ty_55::IFA_RT_PRIORITY;
+pub const IFA_TARGET_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::IFA_TARGET_NETNSID;
+pub const IFA_PROTO: _bindgen_ty_55 = _bindgen_ty_55::IFA_PROTO;
+pub const __IFA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFA_MAX;
+pub const NDA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDA_UNSPEC;
+pub const NDA_DST: _bindgen_ty_56 = _bindgen_ty_56::NDA_DST;
+pub const NDA_LLADDR: _bindgen_ty_56 = _bindgen_ty_56::NDA_LLADDR;
+pub const NDA_CACHEINFO: _bindgen_ty_56 = _bindgen_ty_56::NDA_CACHEINFO;
+pub const NDA_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROBES;
+pub const NDA_VLAN: _bindgen_ty_56 = _bindgen_ty_56::NDA_VLAN;
+pub const NDA_PORT: _bindgen_ty_56 = _bindgen_ty_56::NDA_PORT;
+pub const NDA_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_VNI;
+pub const NDA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDA_IFINDEX;
+pub const NDA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::NDA_MASTER;
+pub const NDA_LINK_NETNSID: _bindgen_ty_56 = _bindgen_ty_56::NDA_LINK_NETNSID;
+pub const NDA_SRC_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_SRC_VNI;
+pub const NDA_PROTOCOL: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROTOCOL;
+pub const NDA_NH_ID: _bindgen_ty_56 = _bindgen_ty_56::NDA_NH_ID;
+pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_56 = _bindgen_ty_56::NDA_FDB_EXT_ATTRS;
+pub const NDA_FLAGS_EXT: _bindgen_ty_56 = _bindgen_ty_56::NDA_FLAGS_EXT;
+pub const NDA_NDM_STATE_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_STATE_MASK;
+pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_FLAGS_MASK;
+pub const __NDA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDA_MAX;
+pub const NDTPA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UNSPEC;
+pub const NDTPA_IFINDEX: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_IFINDEX;
+pub const NDTPA_REFCNT: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REFCNT;
+pub const NDTPA_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REACHABLE_TIME;
+pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_BASE_REACHABLE_TIME;
+pub const NDTPA_RETRANS_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_RETRANS_TIME;
+pub const NDTPA_GC_STALETIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_GC_STALETIME;
+pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_DELAY_PROBE_TIME;
+pub const NDTPA_QUEUE_LEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LEN;
+pub const NDTPA_APP_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_APP_PROBES;
+pub const NDTPA_UCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UCAST_PROBES;
+pub const NDTPA_MCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_PROBES;
+pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_ANYCAST_DELAY;
+pub const NDTPA_PROXY_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_DELAY;
+pub const NDTPA_PROXY_QLEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_QLEN;
+pub const NDTPA_LOCKTIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_LOCKTIME;
+pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LENBYTES;
+pub const NDTPA_MCAST_REPROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_REPROBES;
+pub const NDTPA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PAD;
+pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_INTERVAL_PROBE_TIME_MS;
+pub const __NDTPA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTPA_MAX;
+pub const NDTA_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDTA_UNSPEC;
+pub const NDTA_NAME: _bindgen_ty_58 = _bindgen_ty_58::NDTA_NAME;
+pub const NDTA_THRESH1: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH1;
+pub const NDTA_THRESH2: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH2;
+pub const NDTA_THRESH3: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH3;
+pub const NDTA_CONFIG: _bindgen_ty_58 = _bindgen_ty_58::NDTA_CONFIG;
+pub const NDTA_PARMS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PARMS;
+pub const NDTA_STATS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_STATS;
+pub const NDTA_GC_INTERVAL: _bindgen_ty_58 = _bindgen_ty_58::NDTA_GC_INTERVAL;
+pub const NDTA_PAD: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PAD;
+pub const __NDTA_MAX: _bindgen_ty_58 = _bindgen_ty_58::__NDTA_MAX;
+pub const FDB_NOTIFY_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_BIT;
+pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_INACTIVE_BIT;
+pub const NFEA_UNSPEC: _bindgen_ty_60 = _bindgen_ty_60::NFEA_UNSPEC;
+pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_60 = _bindgen_ty_60::NFEA_ACTIVITY_NOTIFY;
+pub const NFEA_DONT_REFRESH: _bindgen_ty_60 = _bindgen_ty_60::NFEA_DONT_REFRESH;
+pub const __NFEA_MAX: _bindgen_ty_60 = _bindgen_ty_60::__NFEA_MAX;
+pub const RTM_BASE: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_NEWLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_DELLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINK;
+pub const RTM_GETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINK;
+pub const RTM_SETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETLINK;
+pub const RTM_NEWADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDR;
+pub const RTM_DELADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDR;
+pub const RTM_GETADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDR;
+pub const RTM_NEWROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWROUTE;
+pub const RTM_DELROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELROUTE;
+pub const RTM_GETROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETROUTE;
+pub const RTM_NEWNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGH;
+pub const RTM_DELNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEIGH;
+pub const RTM_GETNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGH;
+pub const RTM_NEWRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWRULE;
+pub const RTM_DELRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELRULE;
+pub const RTM_GETRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETRULE;
+pub const RTM_NEWQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWQDISC;
+pub const RTM_DELQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELQDISC;
+pub const RTM_GETQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETQDISC;
+pub const RTM_NEWTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTCLASS;
+pub const RTM_DELTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTCLASS;
+pub const RTM_GETTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTCLASS;
+pub const RTM_NEWTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTFILTER;
+pub const RTM_DELTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTFILTER;
+pub const RTM_GETTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTFILTER;
+pub const RTM_NEWACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWACTION;
+pub const RTM_DELACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELACTION;
+pub const RTM_GETACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETACTION;
+pub const RTM_NEWPREFIX: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWPREFIX;
+pub const RTM_GETMULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMULTICAST;
+pub const RTM_GETANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETANYCAST;
+pub const RTM_NEWNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGHTBL;
+pub const RTM_GETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGHTBL;
+pub const RTM_SETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETNEIGHTBL;
+pub const RTM_NEWNDUSEROPT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNDUSEROPT;
+pub const RTM_NEWADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDRLABEL;
+pub const RTM_DELADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDRLABEL;
+pub const RTM_GETADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDRLABEL;
+pub const RTM_GETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETDCB;
+pub const RTM_SETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETDCB;
+pub const RTM_NEWNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNETCONF;
+pub const RTM_DELNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNETCONF;
+pub const RTM_GETNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNETCONF;
+pub const RTM_NEWMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWMDB;
+pub const RTM_DELMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELMDB;
+pub const RTM_GETMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMDB;
+pub const RTM_NEWNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNSID;
+pub const RTM_DELNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNSID;
+pub const RTM_GETNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNSID;
+pub const RTM_NEWSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWSTATS;
+pub const RTM_GETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETSTATS;
+pub const RTM_SETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETSTATS;
+pub const RTM_NEWCACHEREPORT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCACHEREPORT;
+pub const RTM_NEWCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCHAIN;
+pub const RTM_DELCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELCHAIN;
+pub const RTM_GETCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETCHAIN;
+pub const RTM_NEWNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOP;
+pub const RTM_DELNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOP;
+pub const RTM_GETNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOP;
+pub const RTM_NEWLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWLINKPROP;
+pub const RTM_DELLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINKPROP;
+pub const RTM_GETLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINKPROP;
+pub const RTM_NEWVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWVLAN;
+pub const RTM_DELVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELVLAN;
+pub const RTM_GETVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETVLAN;
+pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOPBUCKET;
+pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOPBUCKET;
+pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOPBUCKET;
+pub const RTM_NEWTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTUNNEL;
+pub const RTM_DELTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTUNNEL;
+pub const RTM_GETTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTUNNEL;
+pub const __RTM_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTM_MAX;
+pub const RTN_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNSPEC;
+pub const RTN_UNICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNICAST;
+pub const RTN_LOCAL: _bindgen_ty_62 = _bindgen_ty_62::RTN_LOCAL;
+pub const RTN_BROADCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_BROADCAST;
+pub const RTN_ANYCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_ANYCAST;
+pub const RTN_MULTICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_MULTICAST;
+pub const RTN_BLACKHOLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_BLACKHOLE;
+pub const RTN_UNREACHABLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNREACHABLE;
+pub const RTN_PROHIBIT: _bindgen_ty_62 = _bindgen_ty_62::RTN_PROHIBIT;
+pub const RTN_THROW: _bindgen_ty_62 = _bindgen_ty_62::RTN_THROW;
+pub const RTN_NAT: _bindgen_ty_62 = _bindgen_ty_62::RTN_NAT;
+pub const RTN_XRESOLVE: _bindgen_ty_62 = _bindgen_ty_62::RTN_XRESOLVE;
+pub const __RTN_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTN_MAX;
+pub const RTAX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::RTAX_UNSPEC;
+pub const RTAX_LOCK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_LOCK;
+pub const RTAX_MTU: _bindgen_ty_63 = _bindgen_ty_63::RTAX_MTU;
+pub const RTAX_WINDOW: _bindgen_ty_63 = _bindgen_ty_63::RTAX_WINDOW;
+pub const RTAX_RTT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTT;
+pub const RTAX_RTTVAR: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTTVAR;
+pub const RTAX_SSTHRESH: _bindgen_ty_63 = _bindgen_ty_63::RTAX_SSTHRESH;
+pub const RTAX_CWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CWND;
+pub const RTAX_ADVMSS: _bindgen_ty_63 = _bindgen_ty_63::RTAX_ADVMSS;
+pub const RTAX_REORDERING: _bindgen_ty_63 = _bindgen_ty_63::RTAX_REORDERING;
+pub const RTAX_HOPLIMIT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_HOPLIMIT;
+pub const RTAX_INITCWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITCWND;
+pub const RTAX_FEATURES: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FEATURES;
+pub const RTAX_RTO_MIN: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTO_MIN;
+pub const RTAX_INITRWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITRWND;
+pub const RTAX_QUICKACK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_QUICKACK;
+pub const RTAX_CC_ALGO: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CC_ALGO;
+pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FASTOPEN_NO_COOKIE;
+pub const __RTAX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__RTAX_MAX;
+pub const PREFIX_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_UNSPEC;
+pub const PREFIX_ADDRESS: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_ADDRESS;
+pub const PREFIX_CACHEINFO: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_CACHEINFO;
+pub const __PREFIX_MAX: _bindgen_ty_64 = _bindgen_ty_64::__PREFIX_MAX;
+pub const TCA_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::TCA_UNSPEC;
+pub const TCA_KIND: _bindgen_ty_65 = _bindgen_ty_65::TCA_KIND;
+pub const TCA_OPTIONS: _bindgen_ty_65 = _bindgen_ty_65::TCA_OPTIONS;
+pub const TCA_STATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS;
+pub const TCA_XSTATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_XSTATS;
+pub const TCA_RATE: _bindgen_ty_65 = _bindgen_ty_65::TCA_RATE;
+pub const TCA_FCNT: _bindgen_ty_65 = _bindgen_ty_65::TCA_FCNT;
+pub const TCA_STATS2: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS2;
+pub const TCA_STAB: _bindgen_ty_65 = _bindgen_ty_65::TCA_STAB;
+pub const TCA_PAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_PAD;
+pub const TCA_DUMP_INVISIBLE: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_INVISIBLE;
+pub const TCA_CHAIN: _bindgen_ty_65 = _bindgen_ty_65::TCA_CHAIN;
+pub const TCA_HW_OFFLOAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_HW_OFFLOAD;
+pub const TCA_INGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_INGRESS_BLOCK;
+pub const TCA_EGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_EGRESS_BLOCK;
+pub const TCA_DUMP_FLAGS: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_FLAGS;
+pub const TCA_EXT_WARN_MSG: _bindgen_ty_65 = _bindgen_ty_65::TCA_EXT_WARN_MSG;
+pub const __TCA_MAX: _bindgen_ty_65 = _bindgen_ty_65::__TCA_MAX;
+pub const NDUSEROPT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_UNSPEC;
+pub const NDUSEROPT_SRCADDR: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_SRCADDR;
+pub const __NDUSEROPT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__NDUSEROPT_MAX;
+pub const TCA_ROOT_UNSPEC: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_UNSPEC;
+pub const TCA_ROOT_TAB: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TAB;
+pub const TCA_ROOT_FLAGS: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_FLAGS;
+pub const TCA_ROOT_COUNT: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_COUNT;
+pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TIME_DELTA;
+pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_EXT_WARN_MSG;
+pub const __TCA_ROOT_MAX: _bindgen_ty_67 = _bindgen_ty_67::__TCA_ROOT_MAX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1542,6 +1556,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1631,7 +1647,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1727,7 +1744,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1784,7 +1803,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1937,10 +1957,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_18 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_19 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -1956,7 +2004,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_19 {
+pub enum _bindgen_ty_20 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -1968,7 +2016,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_20 {
+pub enum _bindgen_ty_21 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -1976,7 +2024,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2009,7 +2057,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2023,7 +2072,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_23 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2053,7 +2110,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2064,7 +2121,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum _bindgen_ty_25 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2079,7 +2136,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2092,7 +2149,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2130,7 +2187,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2142,7 +2199,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2158,7 +2215,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2166,7 +2223,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2186,7 +2243,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2194,7 +2251,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2203,7 +2260,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2218,7 +2275,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2226,7 +2283,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2240,7 +2297,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2249,7 +2306,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2267,7 +2324,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2277,14 +2334,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2292,7 +2349,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2306,7 +2363,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2318,7 +2375,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2327,7 +2384,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2336,7 +2393,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2346,7 +2403,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2355,7 +2412,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2365,7 +2422,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2380,7 +2437,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2392,7 +2449,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2408,7 +2465,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2417,7 +2474,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2425,15 +2482,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFA_UNSPEC = 0,
 IFA_ADDRESS = 1,
 IFA_LOCAL = 2,
@@ -2451,7 +2508,7 @@ __IFA_MAX = 12,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 NDA_UNSPEC = 0,
 NDA_DST = 1,
 NDA_LLADDR = 2,
@@ -2475,7 +2532,7 @@ __NDA_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 NDTPA_UNSPEC = 0,
 NDTPA_IFINDEX = 1,
 NDTPA_REFCNT = 2,
@@ -2501,7 +2558,7 @@ __NDTPA_MAX = 20,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_57 {
+pub enum _bindgen_ty_58 {
 NDTA_UNSPEC = 0,
 NDTA_NAME = 1,
 NDTA_THRESH1 = 2,
@@ -2517,14 +2574,14 @@ __NDTA_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_58 {
+pub enum _bindgen_ty_59 {
 FDB_NOTIFY_BIT = 1,
 FDB_NOTIFY_INACTIVE_BIT = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_59 {
+pub enum _bindgen_ty_60 {
 NFEA_UNSPEC = 0,
 NFEA_ACTIVITY_NOTIFY = 1,
 NFEA_DONT_REFRESH = 2,
@@ -2533,7 +2590,7 @@ __NFEA_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_60 {
+pub enum _bindgen_ty_61 {
 RTM_BASE = 16,
 RTM_DELLINK = 17,
 RTM_GETLINK = 18,
@@ -2610,7 +2667,7 @@ __RTM_MAX = 123,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_61 {
+pub enum _bindgen_ty_62 {
 RTN_UNSPEC = 0,
 RTN_UNICAST = 1,
 RTN_LOCAL = 2,
@@ -2686,7 +2743,7 @@ __RTA_MAX = 31,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_62 {
+pub enum _bindgen_ty_63 {
 RTAX_UNSPEC = 0,
 RTAX_LOCK = 1,
 RTAX_MTU = 2,
@@ -2710,7 +2767,7 @@ __RTAX_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_63 {
+pub enum _bindgen_ty_64 {
 PREFIX_UNSPEC = 0,
 PREFIX_ADDRESS = 1,
 PREFIX_CACHEINFO = 2,
@@ -2719,7 +2776,7 @@ __PREFIX_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_64 {
+pub enum _bindgen_ty_65 {
 TCA_UNSPEC = 0,
 TCA_KIND = 1,
 TCA_OPTIONS = 2,
@@ -2742,7 +2799,7 @@ __TCA_MAX = 17,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_65 {
+pub enum _bindgen_ty_66 {
 NDUSEROPT_UNSPEC = 0,
 NDUSEROPT_SRCADDR = 1,
 __NDUSEROPT_MAX = 2,
@@ -2793,7 +2850,7 @@ __RTNLGRP_MAX = 37,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_66 {
+pub enum _bindgen_ty_67 {
 TCA_ROOT_UNSPEC = 0,
 TCA_ROOT_TAB = 1,
 TCA_ROOT_FLAGS = 2,
@@ -2856,6 +2913,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/x32/prctl.rs
+++ b/src/x32/prctl.rs
@@ -218,6 +218,7 @@ pub const PR_SME_VL_LEN_MASK: u32 = 65535;
 pub const PR_SME_VL_INHERIT: u32 = 131072;
 pub const PR_SET_MDWE: u32 = 65;
 pub const PR_MDWE_REFUSE_EXEC_GAIN: u32 = 1;
+pub const PR_MDWE_NO_INHERIT: u32 = 2;
 pub const PR_GET_MDWE: u32 = 66;
 pub const PR_SET_VMA: u32 = 1398164801;
 pub const PR_SET_VMA_ANON_NAME: u32 = 0;

--- a/src/x32/xdp.rs
+++ b/src/x32/xdp.rs
@@ -83,6 +83,7 @@ pub len: __u64,
 pub chunk_size: __u32,
 pub headroom: __u32,
 pub flags: __u32,
+pub tx_metadata_len: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -98,6 +99,23 @@ pub tx_ring_empty_descs: __u64,
 #[derive(Debug, Copy, Clone)]
 pub struct xdp_options {
 pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct xsk_tx_metadata {
+pub flags: __u64,
+pub __bindgen_anon_1: xsk_tx_metadata__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1 {
+pub csum_start: __u16,
+pub csum_offset: __u16,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2 {
+pub tx_timestamp: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -140,7 +158,9 @@ pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
 pub const XDP_USE_NEED_WAKEUP: u32 = 8;
+pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
+pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;
@@ -157,5 +177,13 @@ pub const XDP_UMEM_PGOFF_FILL_RING: u64 = 4294967296;
 pub const XDP_UMEM_PGOFF_COMPLETION_RING: u64 = 6442450944;
 pub const XSK_UNALIGNED_BUF_OFFSET_SHIFT: u32 = 48;
 pub const XSK_UNALIGNED_BUF_ADDR_MASK: u64 = 281474976710655;
-pub const XDP_USE_SG: u32 = 16;
+pub const XDP_TXMD_FLAGS_TIMESTAMP: u32 = 1;
+pub const XDP_TXMD_FLAGS_CHECKSUM: u32 = 2;
 pub const XDP_PKT_CONTD: u32 = 1;
+pub const XDP_TX_METADATA: u32 = 2;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union xsk_tx_metadata__bindgen_ty_1 {
+pub request: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1,
+pub completion: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2,
+}

--- a/src/x86/general.rs
+++ b/src/x86/general.rs
@@ -181,7 +181,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -236,6 +237,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -294,6 +328,29 @@ pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
 pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -388,36 +445,6 @@ pub it_value: __kernel_old_timeval,
 pub struct __kernel_sock_timeval {
 pub tv_sec: __s64,
 pub tv_usec: __s64,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timespec {
-pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: crate::ctypes::c_long,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timeval {
-pub tv_sec: __kernel_old_time_t,
-pub tv_usec: __kernel_suseconds_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerspec {
-pub it_interval: timespec,
-pub it_value: timespec,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerval {
-pub it_interval: timeval,
-pub it_value: timeval,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timezone {
-pub tz_minuteswest: crate::ctypes::c_int,
-pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -667,6 +694,36 @@ pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct timespec {
+pub tv_sec: __kernel_old_time_t,
+pub tv_nsec: crate::ctypes::c_long,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timeval {
+pub tv_sec: __kernel_old_time_t,
+pub tv_usec: __kernel_suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerspec {
+pub it_interval: timespec,
+pub it_value: timespec,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerval {
+pub it_interval: timeval,
+pub it_value: timeval,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timezone {
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct iovec {
 pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
@@ -760,6 +817,22 @@ pub struct uffdio_continue {
 pub range: uffdio_range,
 pub mode: __u64,
 pub mapped: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_poison {
+pub range: uffdio_range,
+pub mode: __u64,
+pub updated: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_move {
+pub dst: __u64,
+pub src: __u64,
+pub len: __u64,
+pub mode: __u64,
+pub move_: __s64,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -901,9 +974,9 @@ pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 394496;
+pub const LINUX_VERSION_CODE: u32 = 395264;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 5;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO: u32 = 32;
 pub const AT_SYSINFO_EHDR: u32 = 33;
@@ -1276,6 +1349,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1347,6 +1428,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const FUTEX_WAIT: u32 = 0;
 pub const FUTEX_WAKE: u32 = 1;
 pub const FUTEX_FD: u32 = 2;
@@ -1377,6 +1468,13 @@ pub const FUTEX_WAIT_BITSET_PRIVATE: u32 = 137;
 pub const FUTEX_WAKE_BITSET_PRIVATE: u32 = 138;
 pub const FUTEX_WAIT_REQUEUE_PI_PRIVATE: u32 = 139;
 pub const FUTEX_CMP_REQUEUE_PI_PRIVATE: u32 = 140;
+pub const FUTEX2_SIZE_U8: u32 = 0;
+pub const FUTEX2_SIZE_U16: u32 = 1;
+pub const FUTEX2_SIZE_U32: u32 = 2;
+pub const FUTEX2_SIZE_U64: u32 = 3;
+pub const FUTEX2_NUMA: u32 = 4;
+pub const FUTEX2_PRIVATE: u32 = 128;
+pub const FUTEX2_SIZE_MASK: u32 = 3;
 pub const FUTEX_32: u32 = 2;
 pub const FUTEX_WAITV_MAX: u32 = 128;
 pub const FUTEX_WAITERS: u32 = 2147483648;
@@ -1508,6 +1606,8 @@ pub const DMA_BUF_MAGIC: u32 = 1145913666;
 pub const DEVMEM_MAGIC: u32 = 1162691661;
 pub const SECRETMEM_MAGIC: u32 = 1397048141;
 pub const MAP_32BIT: u32 = 64;
+pub const MAP_ABOVE4G: u32 = 128;
+pub const SHADOW_STACK_SET_TOKEN: u32 = 1;
 pub const PROT_READ: u32 = 1;
 pub const PROT_WRITE: u32 = 2;
 pub const PROT_EXEC: u32 = 4;
@@ -1634,25 +1734,6 @@ pub const LINUX_REBOOT_CMD_POWER_OFF: u32 = 1126301404;
 pub const LINUX_REBOOT_CMD_RESTART2: u32 = 2712847316;
 pub const LINUX_REBOOT_CMD_SW_SUSPEND: u32 = 3489725666;
 pub const LINUX_REBOOT_CMD_KEXEC: u32 = 1163412803;
-pub const ITIMER_REAL: u32 = 0;
-pub const ITIMER_VIRTUAL: u32 = 1;
-pub const ITIMER_PROF: u32 = 2;
-pub const CLOCK_REALTIME: u32 = 0;
-pub const CLOCK_MONOTONIC: u32 = 1;
-pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
-pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
-pub const CLOCK_MONOTONIC_RAW: u32 = 4;
-pub const CLOCK_REALTIME_COARSE: u32 = 5;
-pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
-pub const CLOCK_BOOTTIME: u32 = 7;
-pub const CLOCK_REALTIME_ALARM: u32 = 8;
-pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
-pub const CLOCK_SGI_CYCLE: u32 = 10;
-pub const CLOCK_TAI: u32 = 11;
-pub const MAX_CLOCKS: u32 = 16;
-pub const CLOCKS_MASK: u32 = 1;
-pub const CLOCKS_MONO: u32 = 1;
-pub const TIMER_ABSTIME: u32 = 1;
 pub const RUSAGE_SELF: u32 = 0;
 pub const RUSAGE_CHILDREN: i32 = -1;
 pub const RUSAGE_BOTH: i32 = -2;
@@ -1832,7 +1913,8 @@ pub const SEGV_ADIDERR: u32 = 6;
 pub const SEGV_ADIPERR: u32 = 7;
 pub const SEGV_MTEAERR: u32 = 8;
 pub const SEGV_MTESERR: u32 = 9;
-pub const NSIGSEGV: u32 = 9;
+pub const SEGV_CPERR: u32 = 10;
+pub const NSIGSEGV: u32 = 10;
 pub const BUS_ADRALN: u32 = 1;
 pub const BUS_ADRERR: u32 = 2;
 pub const BUS_OBJERR: u32 = 3;
@@ -1913,6 +1995,7 @@ pub const STATX_BASIC_STATS: u32 = 2047;
 pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
+pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2090,6 +2173,25 @@ pub const TIOCM_RI: u32 = 128;
 pub const TIOCM_OUT1: u32 = 8192;
 pub const TIOCM_OUT2: u32 = 16384;
 pub const TIOCM_LOOP: u32 = 32768;
+pub const ITIMER_REAL: u32 = 0;
+pub const ITIMER_VIRTUAL: u32 = 1;
+pub const ITIMER_PROF: u32 = 2;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_SGI_CYCLE: u32 = 10;
+pub const CLOCK_TAI: u32 = 11;
+pub const MAX_CLOCKS: u32 = 16;
+pub const CLOCKS_MASK: u32 = 1;
+pub const CLOCKS_MONO: u32 = 1;
+pub const TIMER_ABSTIME: u32 = 1;
 pub const UIO_FASTIOV: u32 = 8;
 pub const UIO_MAXIOV: u32 = 1024;
 pub const __X32_SYSCALL_BIT: u32 = 1073741824;
@@ -2534,6 +2636,16 @@ pub const __NR_process_mrelease: u32 = 448;
 pub const __NR_futex_waitv: u32 = 449;
 pub const __NR_set_mempolicy_home_node: u32 = 450;
 pub const __NR_cachestat: u32 = 451;
+pub const __NR_fchmodat2: u32 = 452;
+pub const __NR_map_shadow_stack: u32 = 453;
+pub const __NR_futex_wake: u32 = 454;
+pub const __NR_futex_wait: u32 = 455;
+pub const __NR_futex_requeue: u32 = 456;
+pub const __NR_statmount: u32 = 457;
+pub const __NR_listmount: u32 = 458;
+pub const __NR_lsm_get_self_attr: u32 = 459;
+pub const __NR_lsm_set_self_attr: u32 = 460;
+pub const __NR_lsm_list_modules: u32 = 461;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
 pub const WSTOPPED: u32 = 2;
@@ -2612,8 +2724,10 @@ pub const _UFFDIO_UNREGISTER: u32 = 1;
 pub const _UFFDIO_WAKE: u32 = 2;
 pub const _UFFDIO_COPY: u32 = 3;
 pub const _UFFDIO_ZEROPAGE: u32 = 4;
+pub const _UFFDIO_MOVE: u32 = 5;
 pub const _UFFDIO_WRITEPROTECT: u32 = 6;
 pub const _UFFDIO_CONTINUE: u32 = 7;
+pub const _UFFDIO_POISON: u32 = 8;
 pub const _UFFDIO_API: u32 = 63;
 pub const UFFDIO: u32 = 170;
 pub const UFFD_EVENT_PAGEFAULT: u32 = 18;
@@ -2638,6 +2752,9 @@ pub const UFFD_FEATURE_MINOR_SHMEM: u32 = 1024;
 pub const UFFD_FEATURE_EXACT_ADDRESS: u32 = 2048;
 pub const UFFD_FEATURE_WP_HUGETLBFS_SHMEM: u32 = 4096;
 pub const UFFD_FEATURE_WP_UNPOPULATED: u32 = 8192;
+pub const UFFD_FEATURE_POISON: u32 = 16384;
+pub const UFFD_FEATURE_WP_ASYNC: u32 = 32768;
+pub const UFFD_FEATURE_MOVE: u32 = 65536;
 pub const UFFD_USER_MODE_ONLY: u32 = 1;
 pub const DT_UNKNOWN: u32 = 0;
 pub const DT_FIFO: u32 = 1;
@@ -2715,6 +2832,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/x86/if_arp.rs
+++ b/src/x86/if_arp.rs
@@ -50,11 +50,6 @@ pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
@@ -173,6 +168,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -180,23 +176,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -1126,6 +1107,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_4 = _bindgen_ty_4::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_4 = _bindgen_ty_4::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_MASK;
@@ -1194,6 +1176,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_HAIRPIN;
@@ -1241,6 +1225,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_10 = _bindgen_ty_10::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_KIND;
@@ -1302,301 +1287,310 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_19 = _bindgen_ty_19::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_40 = _bindgen_ty_40::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_46 = _bindgen_ty_46::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_DSA_MAX;
-pub const IF_PORT_UNKNOWN: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_UNKNOWN;
-pub const IF_PORT_10BASE2: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASE2;
-pub const IF_PORT_10BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASET;
-pub const IF_PORT_AUI: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_AUI;
-pub const IF_PORT_100BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASET;
-pub const IF_PORT_100BASETX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASETX;
-pub const IF_PORT_100BASEFX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASEFX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_20 = _bindgen_ty_20::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_23 = _bindgen_ty_23::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_47 = _bindgen_ty_47::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__IFLA_DSA_MAX;
+pub const IF_PORT_UNKNOWN: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_UNKNOWN;
+pub const IF_PORT_10BASE2: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASE2;
+pub const IF_PORT_10BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASET;
+pub const IF_PORT_AUI: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_AUI;
+pub const IF_PORT_100BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASET;
+pub const IF_PORT_100BASETX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASETX;
+pub const IF_PORT_100BASEFX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASEFX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1699,6 +1693,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1788,7 +1784,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1884,7 +1881,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1941,7 +1940,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2094,10 +2094,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_20 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_21 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -2113,7 +2141,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -2125,7 +2153,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum _bindgen_ty_23 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -2133,7 +2161,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2166,7 +2194,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2180,7 +2209,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_25 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2210,7 +2247,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2221,7 +2258,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2236,7 +2273,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2249,7 +2286,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2287,7 +2324,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2299,7 +2336,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2315,7 +2352,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2323,7 +2360,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2343,7 +2380,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2351,7 +2388,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2360,7 +2397,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2375,7 +2412,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2383,7 +2420,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2397,7 +2434,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2406,7 +2443,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2424,7 +2461,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2434,14 +2471,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2449,7 +2486,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2463,7 +2500,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2475,7 +2512,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2484,7 +2521,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2493,7 +2530,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2503,7 +2540,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2512,7 +2549,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2522,7 +2559,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2537,7 +2574,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2549,7 +2586,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2565,7 +2602,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2574,7 +2611,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2582,15 +2619,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 IF_PORT_UNKNOWN = 0,
 IF_PORT_10BASE2 = 1,
 IF_PORT_10BASET = 2,
@@ -2673,74 +2710,6 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 impl nlmsgerr_attrs {
 pub const NLMSGERR_ATTR_MAX: nlmsgerr_attrs = nlmsgerr_attrs::NLMSGERR_ATTR_MISS_NEST;
 }
@@ -2755,6 +2724,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/x86/if_packet.rs
+++ b/src/x86/if_packet.rs
@@ -49,11 +49,6 @@ pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_pkt {
 pub spkt_family: crate::ctypes::c_ushort,
@@ -61,6 +56,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -68,23 +64,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -327,71 +308,3 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}

--- a/src/x86/io_uring.rs
+++ b/src/x86/io_uring.rs
@@ -77,7 +77,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -132,6 +133,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -193,6 +227,29 @@ pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
 pub tv_nsec: crate::ctypes::c_longlong,
@@ -251,6 +308,12 @@ pub __pad1: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_sqe__bindgen_ty_2__bindgen_ty_1 {
+pub level: __u32,
+pub optname: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_sqe__bindgen_ty_5__bindgen_ty_1 {
 pub addr_len: __u16,
 pub __pad3: [__u16; 1usize],
@@ -258,6 +321,7 @@ pub __pad3: [__u16; 1usize],
 #[repr(C)]
 pub struct io_uring_sqe__bindgen_ty_6 {
 pub __bindgen_anon_1: __BindgenUnionField<io_uring_sqe__bindgen_ty_6__bindgen_ty_1>,
+pub optval: __BindgenUnionField<__u64>,
 pub cmd: __BindgenUnionField<[__u8; 0usize]>,
 pub bindgen_union_field: [u32; 4usize],
 }
@@ -423,6 +487,13 @@ pub resv: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_buf_status {
+pub buf_group: __u32,
+pub head: __u32,
+pub resv: [__u32; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -436,7 +507,9 @@ pub addr: __u64,
 pub fd: __s32,
 pub flags: __u32,
 pub timeout: __kernel_timespec,
-pub pad: [__u64; 4usize],
+pub opcode: __u8,
+pub pad: [__u8; 7usize],
+pub pad2: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -599,6 +672,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -670,6 +751,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const IORING_FILE_INDEX_ALLOC: i32 = -1;
 pub const IORING_SETUP_IOPOLL: u32 = 1;
 pub const IORING_SETUP_SQPOLL: u32 = 2;
@@ -687,8 +778,9 @@ pub const IORING_SETUP_SINGLE_ISSUER: u32 = 4096;
 pub const IORING_SETUP_DEFER_TASKRUN: u32 = 8192;
 pub const IORING_SETUP_NO_MMAP: u32 = 16384;
 pub const IORING_SETUP_REGISTERED_FD_ONLY: u32 = 32768;
+pub const IORING_SETUP_NO_SQARRAY: u32 = 65536;
 pub const IORING_URING_CMD_FIXED: u32 = 1;
-pub const IORING_URING_CMD_POLLED: u32 = 2147483648;
+pub const IORING_URING_CMD_MASK: u32 = 1;
 pub const IORING_FSYNC_DATASYNC: u32 = 1;
 pub const IORING_TIMEOUT_ABS: u32 = 1;
 pub const IORING_TIMEOUT_UPDATE: u32 = 2;
@@ -708,6 +800,8 @@ pub const IORING_ASYNC_CANCEL_ALL: u32 = 1;
 pub const IORING_ASYNC_CANCEL_FD: u32 = 2;
 pub const IORING_ASYNC_CANCEL_ANY: u32 = 4;
 pub const IORING_ASYNC_CANCEL_FD_FIXED: u32 = 8;
+pub const IORING_ASYNC_CANCEL_USERDATA: u32 = 16;
+pub const IORING_ASYNC_CANCEL_OP: u32 = 32;
 pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
@@ -716,6 +810,7 @@ pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
+pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
@@ -788,6 +883,7 @@ pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGIS
 pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
 pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
 pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
+pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
 pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
 pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
 pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
@@ -798,6 +894,10 @@ pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTR
 pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
 pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
 pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
+pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
+pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
+pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
+pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -810,6 +910,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -876,7 +977,13 @@ IORING_OP_SOCKET = 45,
 IORING_OP_URING_CMD = 46,
 IORING_OP_SEND_ZC = 47,
 IORING_OP_SENDMSG_ZC = 48,
-IORING_OP_LAST = 49,
+IORING_OP_READ_MULTISHOT = 49,
+IORING_OP_WAITID = 50,
+IORING_OP_FUTEX_WAIT = 51,
+IORING_OP_FUTEX_WAKE = 52,
+IORING_OP_FUTEX_WAITV = 53,
+IORING_OP_FIXED_FD_INSTALL = 54,
+IORING_OP_LAST = 55,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -921,7 +1028,8 @@ IORING_REGISTER_PBUF_RING = 22,
 IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
-IORING_REGISTER_LAST = 26,
+IORING_REGISTER_PBUF_STATUS = 26,
+IORING_REGISTER_LAST = 27,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
@@ -946,6 +1054,15 @@ IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
 IORING_RESTRICTION_SQE_FLAGS_REQUIRED = 3,
 IORING_RESTRICTION_LAST = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_8 {
+SOCKET_URING_OP_SIOCINQ = 0,
+SOCKET_URING_OP_SIOCOUTQ = 1,
+SOCKET_URING_OP_GETSOCKOPT = 2,
+SOCKET_URING_OP_SETSOCKOPT = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -973,6 +1090,7 @@ pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_1__bindgen_ty_1,
 pub union io_uring_sqe__bindgen_ty_2 {
 pub addr: __u64,
 pub splice_off_in: __u64,
+pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_2__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -996,6 +1114,9 @@ pub hardlink_flags: __u32,
 pub xattr_flags: __u32,
 pub msg_ring_flags: __u32,
 pub uring_cmd_flags: __u32,
+pub waitid_flags: __u32,
+pub futex_flags: __u32,
+pub install_fd_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]
@@ -1008,6 +1129,7 @@ pub buf_group: __u16,
 pub union io_uring_sqe__bindgen_ty_5 {
 pub splice_fd_in: __s32,
 pub file_index: __u32,
+pub optlen: __u32,
 pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]

--- a/src/x86/net.rs
+++ b/src/x86/net.rs
@@ -427,6 +427,9 @@ pub tcpi_rcv_ooopack: __u32,
 pub tcpi_snd_wnd: __u32,
 pub tcpi_rcv_wnd: __u32,
 pub tcpi_rehash: __u32,
+pub tcpi_total_rto: __u16,
+pub tcpi_total_rto_recoveries: __u16,
+pub tcpi_total_rto_time: __u32,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -446,6 +449,84 @@ pub tcpm_prefixlen: __u8,
 pub tcpm_keylen: __u16,
 pub tcpm_addr: [__be32; 4usize],
 pub tcpm_key: [__u8; 80usize],
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_add {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub key: [__u8; 80usize],
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_del {
+pub addr: __kernel_sockaddr_storage,
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub current_key: __u8,
+pub rnext: __u8,
+pub keyflags: __u8,
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_info_opt {
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub current_key: __u8,
+pub rnext: __u8,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+pub pkt_key_not_found: __u64,
+pub pkt_ao_required: __u64,
+pub pkt_dropped_icmp: __u64,
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_getsockopt {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub key: [__u8; 80usize],
+pub nkeys: __u32,
+pub _bitfield_align_1: [u16; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub prefix: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub ifindex: __s32,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_repair {
+pub snt_isn: __be32,
+pub rcv_isn: __be32,
+pub snd_sne: __u32,
+pub rcv_sne: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1175,6 +1256,11 @@ pub const TCP_ZEROCOPY_RECEIVE: u32 = 35;
 pub const TCP_INQ: u32 = 36;
 pub const TCP_CM_INQ: u32 = 36;
 pub const TCP_TX_DELAY: u32 = 37;
+pub const TCP_AO_ADD_KEY: u32 = 38;
+pub const TCP_AO_DEL_KEY: u32 = 39;
+pub const TCP_AO_INFO: u32 = 40;
+pub const TCP_AO_GET_KEYS: u32 = 41;
+pub const TCP_AO_REPAIR: u32 = 42;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1184,9 +1270,13 @@ pub const TCPI_OPT_WSCALE: u32 = 4;
 pub const TCPI_OPT_ECN: u32 = 8;
 pub const TCPI_OPT_ECN_SEEN: u32 = 16;
 pub const TCPI_OPT_SYN_DATA: u32 = 32;
+pub const TCPI_OPT_USEC_TS: u32 = 64;
 pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
+pub const TCP_AO_MAXKEYLEN: u32 = 80;
+pub const TCP_AO_KEYF_IFINDEX: u32 = 1;
+pub const TCP_AO_KEYF_EXCLUDE_OPT: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
@@ -1551,6 +1641,7 @@ pub const DEVCONF_IOAM6_ID: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID;
 pub const DEVCONF_IOAM6_ID_WIDE: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID_WIDE;
 pub const DEVCONF_NDISC_EVICT_NOCARRIER: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_NDISC_EVICT_NOCARRIER;
 pub const DEVCONF_ACCEPT_UNTRACKED_NA: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_UNTRACKED_NA;
+pub const DEVCONF_ACCEPT_RA_MIN_LFT: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_RA_MIN_LFT;
 pub const DEVCONF_MAX: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_MAX;
 pub const TCP_FLAG_CWR: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_CWR;
 pub const TCP_FLAG_ECE: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_ECE;
@@ -1748,7 +1839,8 @@ DEVCONF_IOAM6_ID = 54,
 DEVCONF_IOAM6_ID_WIDE = 55,
 DEVCONF_NDISC_EVICT_NOCARRIER = 56,
 DEVCONF_ACCEPT_UNTRACKED_NA = 57,
-DEVCONF_MAX = 58,
+DEVCONF_ACCEPT_RA_MIN_LFT = 58,
+DEVCONF_MAX = 59,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2466,6 +2558,289 @@ tcpi_delivery_rate_app_limited as u64
 __bindgen_bitfield_unit.set(9usize, 2u8, {
 let tcpi_fastopen_client_fail: u8 = unsafe { ::core::mem::transmute(tcpi_fastopen_client_fail) };
 tcpi_fastopen_client_fail as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_add {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 30u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 30u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_del {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn del_async(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_del_async(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 29u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 29u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, del_async: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let del_async: u32 = unsafe { ::core::mem::transmute(del_async) };
+del_async as u64
+});
+__bindgen_bitfield_unit.set(3usize, 29u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_info_opt {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn ao_required(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_ao_required(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_counters(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_counters(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn accept_icmps(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_accept_icmps(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(4usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(5usize, 27u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(5usize, 27u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, ao_required: __u32, set_counters: __u32, accept_icmps: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let ao_required: u32 = unsafe { ::core::mem::transmute(ao_required) };
+ao_required as u64
+});
+__bindgen_bitfield_unit.set(3usize, 1u8, {
+let set_counters: u32 = unsafe { ::core::mem::transmute(set_counters) };
+set_counters as u64
+});
+__bindgen_bitfield_unit.set(4usize, 1u8, {
+let accept_icmps: u32 = unsafe { ::core::mem::transmute(accept_icmps) };
+accept_icmps as u64
+});
+__bindgen_bitfield_unit.set(5usize, 27u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_getsockopt {
+#[inline]
+pub fn is_current(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_current(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn is_rnext(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_rnext(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn get_all(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_get_all(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 13u8) as u16) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 13u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(is_current: __u16, is_rnext: __u16, get_all: __u16, reserved: __u16) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let is_current: u16 = unsafe { ::core::mem::transmute(is_current) };
+is_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let is_rnext: u16 = unsafe { ::core::mem::transmute(is_rnext) };
+is_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let get_all: u16 = unsafe { ::core::mem::transmute(get_all) };
+get_all as u64
+});
+__bindgen_bitfield_unit.set(3usize, 13u8, {
+let reserved: u16 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
 });
 __bindgen_bitfield_unit
 }

--- a/src/x86/netlink.rs
+++ b/src/x86/netlink.rs
@@ -722,7 +722,8 @@ pub const RTAX_FEATURE_ECN: u32 = 1;
 pub const RTAX_FEATURE_SACK: u32 = 2;
 pub const RTAX_FEATURE_TIMESTAMP: u32 = 4;
 pub const RTAX_FEATURE_ALLFRAG: u32 = 8;
-pub const RTAX_FEATURE_MASK: u32 = 15;
+pub const RTAX_FEATURE_TCP_USEC_TS: u32 = 16;
+pub const RTAX_FEATURE_MASK: u32 = 31;
 pub const TCM_IFINDEX_MAGIC_BLOCK: u32 = 4294967295;
 pub const TCA_DUMP_FLAGS_TERSE: u32 = 1;
 pub const RTMGRP_LINK: u32 = 1;
@@ -819,6 +820,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_2 = _bindgen_ty_2::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_2 = _bindgen_ty_2::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_MASK;
@@ -887,6 +889,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_6 = _bindgen_ty_6::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_HAIRPIN;
@@ -934,6 +938,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_KIND;
@@ -995,501 +1000,510 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_17 = _bindgen_ty_17::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_18 = _bindgen_ty_18::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_21 = _bindgen_ty_21::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_44 = _bindgen_ty_44::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_DSA_MAX;
-pub const IFA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFA_UNSPEC;
-pub const IFA_ADDRESS: _bindgen_ty_54 = _bindgen_ty_54::IFA_ADDRESS;
-pub const IFA_LOCAL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LOCAL;
-pub const IFA_LABEL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LABEL;
-pub const IFA_BROADCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_BROADCAST;
-pub const IFA_ANYCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_ANYCAST;
-pub const IFA_CACHEINFO: _bindgen_ty_54 = _bindgen_ty_54::IFA_CACHEINFO;
-pub const IFA_MULTICAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_MULTICAST;
-pub const IFA_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFA_FLAGS;
-pub const IFA_RT_PRIORITY: _bindgen_ty_54 = _bindgen_ty_54::IFA_RT_PRIORITY;
-pub const IFA_TARGET_NETNSID: _bindgen_ty_54 = _bindgen_ty_54::IFA_TARGET_NETNSID;
-pub const IFA_PROTO: _bindgen_ty_54 = _bindgen_ty_54::IFA_PROTO;
-pub const __IFA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFA_MAX;
-pub const NDA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::NDA_UNSPEC;
-pub const NDA_DST: _bindgen_ty_55 = _bindgen_ty_55::NDA_DST;
-pub const NDA_LLADDR: _bindgen_ty_55 = _bindgen_ty_55::NDA_LLADDR;
-pub const NDA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::NDA_CACHEINFO;
-pub const NDA_PROBES: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROBES;
-pub const NDA_VLAN: _bindgen_ty_55 = _bindgen_ty_55::NDA_VLAN;
-pub const NDA_PORT: _bindgen_ty_55 = _bindgen_ty_55::NDA_PORT;
-pub const NDA_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_VNI;
-pub const NDA_IFINDEX: _bindgen_ty_55 = _bindgen_ty_55::NDA_IFINDEX;
-pub const NDA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::NDA_MASTER;
-pub const NDA_LINK_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::NDA_LINK_NETNSID;
-pub const NDA_SRC_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_SRC_VNI;
-pub const NDA_PROTOCOL: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROTOCOL;
-pub const NDA_NH_ID: _bindgen_ty_55 = _bindgen_ty_55::NDA_NH_ID;
-pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_55 = _bindgen_ty_55::NDA_FDB_EXT_ATTRS;
-pub const NDA_FLAGS_EXT: _bindgen_ty_55 = _bindgen_ty_55::NDA_FLAGS_EXT;
-pub const NDA_NDM_STATE_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_STATE_MASK;
-pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_FLAGS_MASK;
-pub const __NDA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__NDA_MAX;
-pub const NDTPA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UNSPEC;
-pub const NDTPA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_IFINDEX;
-pub const NDTPA_REFCNT: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REFCNT;
-pub const NDTPA_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REACHABLE_TIME;
-pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_BASE_REACHABLE_TIME;
-pub const NDTPA_RETRANS_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_RETRANS_TIME;
-pub const NDTPA_GC_STALETIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_GC_STALETIME;
-pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_DELAY_PROBE_TIME;
-pub const NDTPA_QUEUE_LEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LEN;
-pub const NDTPA_APP_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_APP_PROBES;
-pub const NDTPA_UCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UCAST_PROBES;
-pub const NDTPA_MCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_PROBES;
-pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_ANYCAST_DELAY;
-pub const NDTPA_PROXY_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_DELAY;
-pub const NDTPA_PROXY_QLEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_QLEN;
-pub const NDTPA_LOCKTIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_LOCKTIME;
-pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LENBYTES;
-pub const NDTPA_MCAST_REPROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_REPROBES;
-pub const NDTPA_PAD: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PAD;
-pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_INTERVAL_PROBE_TIME_MS;
-pub const __NDTPA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDTPA_MAX;
-pub const NDTA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTA_UNSPEC;
-pub const NDTA_NAME: _bindgen_ty_57 = _bindgen_ty_57::NDTA_NAME;
-pub const NDTA_THRESH1: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH1;
-pub const NDTA_THRESH2: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH2;
-pub const NDTA_THRESH3: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH3;
-pub const NDTA_CONFIG: _bindgen_ty_57 = _bindgen_ty_57::NDTA_CONFIG;
-pub const NDTA_PARMS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PARMS;
-pub const NDTA_STATS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_STATS;
-pub const NDTA_GC_INTERVAL: _bindgen_ty_57 = _bindgen_ty_57::NDTA_GC_INTERVAL;
-pub const NDTA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PAD;
-pub const __NDTA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTA_MAX;
-pub const FDB_NOTIFY_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_BIT;
-pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_INACTIVE_BIT;
-pub const NFEA_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::NFEA_UNSPEC;
-pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_59 = _bindgen_ty_59::NFEA_ACTIVITY_NOTIFY;
-pub const NFEA_DONT_REFRESH: _bindgen_ty_59 = _bindgen_ty_59::NFEA_DONT_REFRESH;
-pub const __NFEA_MAX: _bindgen_ty_59 = _bindgen_ty_59::__NFEA_MAX;
-pub const RTM_BASE: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_NEWLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_DELLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINK;
-pub const RTM_GETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINK;
-pub const RTM_SETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETLINK;
-pub const RTM_NEWADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDR;
-pub const RTM_DELADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDR;
-pub const RTM_GETADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDR;
-pub const RTM_NEWROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWROUTE;
-pub const RTM_DELROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELROUTE;
-pub const RTM_GETROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETROUTE;
-pub const RTM_NEWNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGH;
-pub const RTM_DELNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEIGH;
-pub const RTM_GETNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGH;
-pub const RTM_NEWRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWRULE;
-pub const RTM_DELRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELRULE;
-pub const RTM_GETRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETRULE;
-pub const RTM_NEWQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWQDISC;
-pub const RTM_DELQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELQDISC;
-pub const RTM_GETQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETQDISC;
-pub const RTM_NEWTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTCLASS;
-pub const RTM_DELTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTCLASS;
-pub const RTM_GETTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTCLASS;
-pub const RTM_NEWTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTFILTER;
-pub const RTM_DELTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTFILTER;
-pub const RTM_GETTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTFILTER;
-pub const RTM_NEWACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWACTION;
-pub const RTM_DELACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELACTION;
-pub const RTM_GETACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETACTION;
-pub const RTM_NEWPREFIX: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWPREFIX;
-pub const RTM_GETMULTICAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMULTICAST;
-pub const RTM_GETANYCAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETANYCAST;
-pub const RTM_NEWNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGHTBL;
-pub const RTM_GETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGHTBL;
-pub const RTM_SETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETNEIGHTBL;
-pub const RTM_NEWNDUSEROPT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNDUSEROPT;
-pub const RTM_NEWADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDRLABEL;
-pub const RTM_DELADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDRLABEL;
-pub const RTM_GETADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDRLABEL;
-pub const RTM_GETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETDCB;
-pub const RTM_SETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETDCB;
-pub const RTM_NEWNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNETCONF;
-pub const RTM_DELNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNETCONF;
-pub const RTM_GETNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNETCONF;
-pub const RTM_NEWMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWMDB;
-pub const RTM_DELMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELMDB;
-pub const RTM_GETMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMDB;
-pub const RTM_NEWNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNSID;
-pub const RTM_DELNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNSID;
-pub const RTM_GETNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNSID;
-pub const RTM_NEWSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWSTATS;
-pub const RTM_GETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETSTATS;
-pub const RTM_SETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETSTATS;
-pub const RTM_NEWCACHEREPORT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCACHEREPORT;
-pub const RTM_NEWCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCHAIN;
-pub const RTM_DELCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELCHAIN;
-pub const RTM_GETCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETCHAIN;
-pub const RTM_NEWNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOP;
-pub const RTM_DELNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOP;
-pub const RTM_GETNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOP;
-pub const RTM_NEWLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWLINKPROP;
-pub const RTM_DELLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINKPROP;
-pub const RTM_GETLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINKPROP;
-pub const RTM_NEWVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWVLAN;
-pub const RTM_DELVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELVLAN;
-pub const RTM_GETVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETVLAN;
-pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOPBUCKET;
-pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOPBUCKET;
-pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOPBUCKET;
-pub const RTM_NEWTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTUNNEL;
-pub const RTM_DELTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTUNNEL;
-pub const RTM_GETTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTUNNEL;
-pub const __RTM_MAX: _bindgen_ty_60 = _bindgen_ty_60::__RTM_MAX;
-pub const RTN_UNSPEC: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNSPEC;
-pub const RTN_UNICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNICAST;
-pub const RTN_LOCAL: _bindgen_ty_61 = _bindgen_ty_61::RTN_LOCAL;
-pub const RTN_BROADCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_BROADCAST;
-pub const RTN_ANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_ANYCAST;
-pub const RTN_MULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_MULTICAST;
-pub const RTN_BLACKHOLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_BLACKHOLE;
-pub const RTN_UNREACHABLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNREACHABLE;
-pub const RTN_PROHIBIT: _bindgen_ty_61 = _bindgen_ty_61::RTN_PROHIBIT;
-pub const RTN_THROW: _bindgen_ty_61 = _bindgen_ty_61::RTN_THROW;
-pub const RTN_NAT: _bindgen_ty_61 = _bindgen_ty_61::RTN_NAT;
-pub const RTN_XRESOLVE: _bindgen_ty_61 = _bindgen_ty_61::RTN_XRESOLVE;
-pub const __RTN_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTN_MAX;
-pub const RTAX_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTAX_UNSPEC;
-pub const RTAX_LOCK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_LOCK;
-pub const RTAX_MTU: _bindgen_ty_62 = _bindgen_ty_62::RTAX_MTU;
-pub const RTAX_WINDOW: _bindgen_ty_62 = _bindgen_ty_62::RTAX_WINDOW;
-pub const RTAX_RTT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTT;
-pub const RTAX_RTTVAR: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTTVAR;
-pub const RTAX_SSTHRESH: _bindgen_ty_62 = _bindgen_ty_62::RTAX_SSTHRESH;
-pub const RTAX_CWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CWND;
-pub const RTAX_ADVMSS: _bindgen_ty_62 = _bindgen_ty_62::RTAX_ADVMSS;
-pub const RTAX_REORDERING: _bindgen_ty_62 = _bindgen_ty_62::RTAX_REORDERING;
-pub const RTAX_HOPLIMIT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_HOPLIMIT;
-pub const RTAX_INITCWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITCWND;
-pub const RTAX_FEATURES: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FEATURES;
-pub const RTAX_RTO_MIN: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTO_MIN;
-pub const RTAX_INITRWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITRWND;
-pub const RTAX_QUICKACK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_QUICKACK;
-pub const RTAX_CC_ALGO: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CC_ALGO;
-pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FASTOPEN_NO_COOKIE;
-pub const __RTAX_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTAX_MAX;
-pub const PREFIX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_UNSPEC;
-pub const PREFIX_ADDRESS: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_ADDRESS;
-pub const PREFIX_CACHEINFO: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_CACHEINFO;
-pub const __PREFIX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__PREFIX_MAX;
-pub const TCA_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::TCA_UNSPEC;
-pub const TCA_KIND: _bindgen_ty_64 = _bindgen_ty_64::TCA_KIND;
-pub const TCA_OPTIONS: _bindgen_ty_64 = _bindgen_ty_64::TCA_OPTIONS;
-pub const TCA_STATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS;
-pub const TCA_XSTATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_XSTATS;
-pub const TCA_RATE: _bindgen_ty_64 = _bindgen_ty_64::TCA_RATE;
-pub const TCA_FCNT: _bindgen_ty_64 = _bindgen_ty_64::TCA_FCNT;
-pub const TCA_STATS2: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS2;
-pub const TCA_STAB: _bindgen_ty_64 = _bindgen_ty_64::TCA_STAB;
-pub const TCA_PAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_PAD;
-pub const TCA_DUMP_INVISIBLE: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_INVISIBLE;
-pub const TCA_CHAIN: _bindgen_ty_64 = _bindgen_ty_64::TCA_CHAIN;
-pub const TCA_HW_OFFLOAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_HW_OFFLOAD;
-pub const TCA_INGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_INGRESS_BLOCK;
-pub const TCA_EGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_EGRESS_BLOCK;
-pub const TCA_DUMP_FLAGS: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_FLAGS;
-pub const TCA_EXT_WARN_MSG: _bindgen_ty_64 = _bindgen_ty_64::TCA_EXT_WARN_MSG;
-pub const __TCA_MAX: _bindgen_ty_64 = _bindgen_ty_64::__TCA_MAX;
-pub const NDUSEROPT_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_UNSPEC;
-pub const NDUSEROPT_SRCADDR: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_SRCADDR;
-pub const __NDUSEROPT_MAX: _bindgen_ty_65 = _bindgen_ty_65::__NDUSEROPT_MAX;
-pub const TCA_ROOT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_UNSPEC;
-pub const TCA_ROOT_TAB: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TAB;
-pub const TCA_ROOT_FLAGS: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_FLAGS;
-pub const TCA_ROOT_COUNT: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_COUNT;
-pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TIME_DELTA;
-pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_EXT_WARN_MSG;
-pub const __TCA_ROOT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__TCA_ROOT_MAX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_18 = _bindgen_ty_18::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_39 = _bindgen_ty_39::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_45 = _bindgen_ty_45::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_DSA_MAX;
+pub const IFA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFA_UNSPEC;
+pub const IFA_ADDRESS: _bindgen_ty_55 = _bindgen_ty_55::IFA_ADDRESS;
+pub const IFA_LOCAL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LOCAL;
+pub const IFA_LABEL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LABEL;
+pub const IFA_BROADCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_BROADCAST;
+pub const IFA_ANYCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_ANYCAST;
+pub const IFA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::IFA_CACHEINFO;
+pub const IFA_MULTICAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_MULTICAST;
+pub const IFA_FLAGS: _bindgen_ty_55 = _bindgen_ty_55::IFA_FLAGS;
+pub const IFA_RT_PRIORITY: _bindgen_ty_55 = _bindgen_ty_55::IFA_RT_PRIORITY;
+pub const IFA_TARGET_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::IFA_TARGET_NETNSID;
+pub const IFA_PROTO: _bindgen_ty_55 = _bindgen_ty_55::IFA_PROTO;
+pub const __IFA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFA_MAX;
+pub const NDA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDA_UNSPEC;
+pub const NDA_DST: _bindgen_ty_56 = _bindgen_ty_56::NDA_DST;
+pub const NDA_LLADDR: _bindgen_ty_56 = _bindgen_ty_56::NDA_LLADDR;
+pub const NDA_CACHEINFO: _bindgen_ty_56 = _bindgen_ty_56::NDA_CACHEINFO;
+pub const NDA_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROBES;
+pub const NDA_VLAN: _bindgen_ty_56 = _bindgen_ty_56::NDA_VLAN;
+pub const NDA_PORT: _bindgen_ty_56 = _bindgen_ty_56::NDA_PORT;
+pub const NDA_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_VNI;
+pub const NDA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDA_IFINDEX;
+pub const NDA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::NDA_MASTER;
+pub const NDA_LINK_NETNSID: _bindgen_ty_56 = _bindgen_ty_56::NDA_LINK_NETNSID;
+pub const NDA_SRC_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_SRC_VNI;
+pub const NDA_PROTOCOL: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROTOCOL;
+pub const NDA_NH_ID: _bindgen_ty_56 = _bindgen_ty_56::NDA_NH_ID;
+pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_56 = _bindgen_ty_56::NDA_FDB_EXT_ATTRS;
+pub const NDA_FLAGS_EXT: _bindgen_ty_56 = _bindgen_ty_56::NDA_FLAGS_EXT;
+pub const NDA_NDM_STATE_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_STATE_MASK;
+pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_FLAGS_MASK;
+pub const __NDA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDA_MAX;
+pub const NDTPA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UNSPEC;
+pub const NDTPA_IFINDEX: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_IFINDEX;
+pub const NDTPA_REFCNT: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REFCNT;
+pub const NDTPA_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REACHABLE_TIME;
+pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_BASE_REACHABLE_TIME;
+pub const NDTPA_RETRANS_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_RETRANS_TIME;
+pub const NDTPA_GC_STALETIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_GC_STALETIME;
+pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_DELAY_PROBE_TIME;
+pub const NDTPA_QUEUE_LEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LEN;
+pub const NDTPA_APP_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_APP_PROBES;
+pub const NDTPA_UCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UCAST_PROBES;
+pub const NDTPA_MCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_PROBES;
+pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_ANYCAST_DELAY;
+pub const NDTPA_PROXY_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_DELAY;
+pub const NDTPA_PROXY_QLEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_QLEN;
+pub const NDTPA_LOCKTIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_LOCKTIME;
+pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LENBYTES;
+pub const NDTPA_MCAST_REPROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_REPROBES;
+pub const NDTPA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PAD;
+pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_INTERVAL_PROBE_TIME_MS;
+pub const __NDTPA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTPA_MAX;
+pub const NDTA_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDTA_UNSPEC;
+pub const NDTA_NAME: _bindgen_ty_58 = _bindgen_ty_58::NDTA_NAME;
+pub const NDTA_THRESH1: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH1;
+pub const NDTA_THRESH2: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH2;
+pub const NDTA_THRESH3: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH3;
+pub const NDTA_CONFIG: _bindgen_ty_58 = _bindgen_ty_58::NDTA_CONFIG;
+pub const NDTA_PARMS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PARMS;
+pub const NDTA_STATS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_STATS;
+pub const NDTA_GC_INTERVAL: _bindgen_ty_58 = _bindgen_ty_58::NDTA_GC_INTERVAL;
+pub const NDTA_PAD: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PAD;
+pub const __NDTA_MAX: _bindgen_ty_58 = _bindgen_ty_58::__NDTA_MAX;
+pub const FDB_NOTIFY_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_BIT;
+pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_INACTIVE_BIT;
+pub const NFEA_UNSPEC: _bindgen_ty_60 = _bindgen_ty_60::NFEA_UNSPEC;
+pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_60 = _bindgen_ty_60::NFEA_ACTIVITY_NOTIFY;
+pub const NFEA_DONT_REFRESH: _bindgen_ty_60 = _bindgen_ty_60::NFEA_DONT_REFRESH;
+pub const __NFEA_MAX: _bindgen_ty_60 = _bindgen_ty_60::__NFEA_MAX;
+pub const RTM_BASE: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_NEWLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_DELLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINK;
+pub const RTM_GETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINK;
+pub const RTM_SETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETLINK;
+pub const RTM_NEWADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDR;
+pub const RTM_DELADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDR;
+pub const RTM_GETADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDR;
+pub const RTM_NEWROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWROUTE;
+pub const RTM_DELROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELROUTE;
+pub const RTM_GETROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETROUTE;
+pub const RTM_NEWNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGH;
+pub const RTM_DELNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEIGH;
+pub const RTM_GETNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGH;
+pub const RTM_NEWRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWRULE;
+pub const RTM_DELRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELRULE;
+pub const RTM_GETRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETRULE;
+pub const RTM_NEWQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWQDISC;
+pub const RTM_DELQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELQDISC;
+pub const RTM_GETQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETQDISC;
+pub const RTM_NEWTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTCLASS;
+pub const RTM_DELTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTCLASS;
+pub const RTM_GETTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTCLASS;
+pub const RTM_NEWTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTFILTER;
+pub const RTM_DELTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTFILTER;
+pub const RTM_GETTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTFILTER;
+pub const RTM_NEWACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWACTION;
+pub const RTM_DELACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELACTION;
+pub const RTM_GETACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETACTION;
+pub const RTM_NEWPREFIX: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWPREFIX;
+pub const RTM_GETMULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMULTICAST;
+pub const RTM_GETANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETANYCAST;
+pub const RTM_NEWNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGHTBL;
+pub const RTM_GETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGHTBL;
+pub const RTM_SETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETNEIGHTBL;
+pub const RTM_NEWNDUSEROPT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNDUSEROPT;
+pub const RTM_NEWADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDRLABEL;
+pub const RTM_DELADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDRLABEL;
+pub const RTM_GETADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDRLABEL;
+pub const RTM_GETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETDCB;
+pub const RTM_SETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETDCB;
+pub const RTM_NEWNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNETCONF;
+pub const RTM_DELNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNETCONF;
+pub const RTM_GETNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNETCONF;
+pub const RTM_NEWMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWMDB;
+pub const RTM_DELMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELMDB;
+pub const RTM_GETMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMDB;
+pub const RTM_NEWNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNSID;
+pub const RTM_DELNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNSID;
+pub const RTM_GETNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNSID;
+pub const RTM_NEWSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWSTATS;
+pub const RTM_GETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETSTATS;
+pub const RTM_SETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETSTATS;
+pub const RTM_NEWCACHEREPORT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCACHEREPORT;
+pub const RTM_NEWCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCHAIN;
+pub const RTM_DELCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELCHAIN;
+pub const RTM_GETCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETCHAIN;
+pub const RTM_NEWNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOP;
+pub const RTM_DELNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOP;
+pub const RTM_GETNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOP;
+pub const RTM_NEWLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWLINKPROP;
+pub const RTM_DELLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINKPROP;
+pub const RTM_GETLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINKPROP;
+pub const RTM_NEWVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWVLAN;
+pub const RTM_DELVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELVLAN;
+pub const RTM_GETVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETVLAN;
+pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOPBUCKET;
+pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOPBUCKET;
+pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOPBUCKET;
+pub const RTM_NEWTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTUNNEL;
+pub const RTM_DELTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTUNNEL;
+pub const RTM_GETTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTUNNEL;
+pub const __RTM_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTM_MAX;
+pub const RTN_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNSPEC;
+pub const RTN_UNICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNICAST;
+pub const RTN_LOCAL: _bindgen_ty_62 = _bindgen_ty_62::RTN_LOCAL;
+pub const RTN_BROADCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_BROADCAST;
+pub const RTN_ANYCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_ANYCAST;
+pub const RTN_MULTICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_MULTICAST;
+pub const RTN_BLACKHOLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_BLACKHOLE;
+pub const RTN_UNREACHABLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNREACHABLE;
+pub const RTN_PROHIBIT: _bindgen_ty_62 = _bindgen_ty_62::RTN_PROHIBIT;
+pub const RTN_THROW: _bindgen_ty_62 = _bindgen_ty_62::RTN_THROW;
+pub const RTN_NAT: _bindgen_ty_62 = _bindgen_ty_62::RTN_NAT;
+pub const RTN_XRESOLVE: _bindgen_ty_62 = _bindgen_ty_62::RTN_XRESOLVE;
+pub const __RTN_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTN_MAX;
+pub const RTAX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::RTAX_UNSPEC;
+pub const RTAX_LOCK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_LOCK;
+pub const RTAX_MTU: _bindgen_ty_63 = _bindgen_ty_63::RTAX_MTU;
+pub const RTAX_WINDOW: _bindgen_ty_63 = _bindgen_ty_63::RTAX_WINDOW;
+pub const RTAX_RTT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTT;
+pub const RTAX_RTTVAR: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTTVAR;
+pub const RTAX_SSTHRESH: _bindgen_ty_63 = _bindgen_ty_63::RTAX_SSTHRESH;
+pub const RTAX_CWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CWND;
+pub const RTAX_ADVMSS: _bindgen_ty_63 = _bindgen_ty_63::RTAX_ADVMSS;
+pub const RTAX_REORDERING: _bindgen_ty_63 = _bindgen_ty_63::RTAX_REORDERING;
+pub const RTAX_HOPLIMIT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_HOPLIMIT;
+pub const RTAX_INITCWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITCWND;
+pub const RTAX_FEATURES: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FEATURES;
+pub const RTAX_RTO_MIN: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTO_MIN;
+pub const RTAX_INITRWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITRWND;
+pub const RTAX_QUICKACK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_QUICKACK;
+pub const RTAX_CC_ALGO: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CC_ALGO;
+pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FASTOPEN_NO_COOKIE;
+pub const __RTAX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__RTAX_MAX;
+pub const PREFIX_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_UNSPEC;
+pub const PREFIX_ADDRESS: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_ADDRESS;
+pub const PREFIX_CACHEINFO: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_CACHEINFO;
+pub const __PREFIX_MAX: _bindgen_ty_64 = _bindgen_ty_64::__PREFIX_MAX;
+pub const TCA_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::TCA_UNSPEC;
+pub const TCA_KIND: _bindgen_ty_65 = _bindgen_ty_65::TCA_KIND;
+pub const TCA_OPTIONS: _bindgen_ty_65 = _bindgen_ty_65::TCA_OPTIONS;
+pub const TCA_STATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS;
+pub const TCA_XSTATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_XSTATS;
+pub const TCA_RATE: _bindgen_ty_65 = _bindgen_ty_65::TCA_RATE;
+pub const TCA_FCNT: _bindgen_ty_65 = _bindgen_ty_65::TCA_FCNT;
+pub const TCA_STATS2: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS2;
+pub const TCA_STAB: _bindgen_ty_65 = _bindgen_ty_65::TCA_STAB;
+pub const TCA_PAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_PAD;
+pub const TCA_DUMP_INVISIBLE: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_INVISIBLE;
+pub const TCA_CHAIN: _bindgen_ty_65 = _bindgen_ty_65::TCA_CHAIN;
+pub const TCA_HW_OFFLOAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_HW_OFFLOAD;
+pub const TCA_INGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_INGRESS_BLOCK;
+pub const TCA_EGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_EGRESS_BLOCK;
+pub const TCA_DUMP_FLAGS: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_FLAGS;
+pub const TCA_EXT_WARN_MSG: _bindgen_ty_65 = _bindgen_ty_65::TCA_EXT_WARN_MSG;
+pub const __TCA_MAX: _bindgen_ty_65 = _bindgen_ty_65::__TCA_MAX;
+pub const NDUSEROPT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_UNSPEC;
+pub const NDUSEROPT_SRCADDR: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_SRCADDR;
+pub const __NDUSEROPT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__NDUSEROPT_MAX;
+pub const TCA_ROOT_UNSPEC: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_UNSPEC;
+pub const TCA_ROOT_TAB: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TAB;
+pub const TCA_ROOT_FLAGS: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_FLAGS;
+pub const TCA_ROOT_COUNT: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_COUNT;
+pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TIME_DELTA;
+pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_EXT_WARN_MSG;
+pub const __TCA_ROOT_MAX: _bindgen_ty_67 = _bindgen_ty_67::__TCA_ROOT_MAX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1540,6 +1554,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1629,7 +1645,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1725,7 +1742,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1782,7 +1801,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1935,10 +1955,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_18 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_19 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -1954,7 +2002,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_19 {
+pub enum _bindgen_ty_20 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -1966,7 +2014,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_20 {
+pub enum _bindgen_ty_21 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -1974,7 +2022,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2007,7 +2055,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2021,7 +2070,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_23 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2051,7 +2108,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2062,7 +2119,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum _bindgen_ty_25 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2077,7 +2134,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2090,7 +2147,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2128,7 +2185,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2140,7 +2197,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2156,7 +2213,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2164,7 +2221,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2184,7 +2241,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2192,7 +2249,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2201,7 +2258,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2216,7 +2273,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2224,7 +2281,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2238,7 +2295,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2247,7 +2304,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2265,7 +2322,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2275,14 +2332,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2290,7 +2347,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2304,7 +2361,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2316,7 +2373,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2325,7 +2382,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2334,7 +2391,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2344,7 +2401,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2353,7 +2410,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2363,7 +2420,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2378,7 +2435,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2390,7 +2447,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2406,7 +2463,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2415,7 +2472,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2423,15 +2480,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFA_UNSPEC = 0,
 IFA_ADDRESS = 1,
 IFA_LOCAL = 2,
@@ -2449,7 +2506,7 @@ __IFA_MAX = 12,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 NDA_UNSPEC = 0,
 NDA_DST = 1,
 NDA_LLADDR = 2,
@@ -2473,7 +2530,7 @@ __NDA_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 NDTPA_UNSPEC = 0,
 NDTPA_IFINDEX = 1,
 NDTPA_REFCNT = 2,
@@ -2499,7 +2556,7 @@ __NDTPA_MAX = 20,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_57 {
+pub enum _bindgen_ty_58 {
 NDTA_UNSPEC = 0,
 NDTA_NAME = 1,
 NDTA_THRESH1 = 2,
@@ -2515,14 +2572,14 @@ __NDTA_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_58 {
+pub enum _bindgen_ty_59 {
 FDB_NOTIFY_BIT = 1,
 FDB_NOTIFY_INACTIVE_BIT = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_59 {
+pub enum _bindgen_ty_60 {
 NFEA_UNSPEC = 0,
 NFEA_ACTIVITY_NOTIFY = 1,
 NFEA_DONT_REFRESH = 2,
@@ -2531,7 +2588,7 @@ __NFEA_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_60 {
+pub enum _bindgen_ty_61 {
 RTM_BASE = 16,
 RTM_DELLINK = 17,
 RTM_GETLINK = 18,
@@ -2608,7 +2665,7 @@ __RTM_MAX = 123,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_61 {
+pub enum _bindgen_ty_62 {
 RTN_UNSPEC = 0,
 RTN_UNICAST = 1,
 RTN_LOCAL = 2,
@@ -2684,7 +2741,7 @@ __RTA_MAX = 31,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_62 {
+pub enum _bindgen_ty_63 {
 RTAX_UNSPEC = 0,
 RTAX_LOCK = 1,
 RTAX_MTU = 2,
@@ -2708,7 +2765,7 @@ __RTAX_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_63 {
+pub enum _bindgen_ty_64 {
 PREFIX_UNSPEC = 0,
 PREFIX_ADDRESS = 1,
 PREFIX_CACHEINFO = 2,
@@ -2717,7 +2774,7 @@ __PREFIX_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_64 {
+pub enum _bindgen_ty_65 {
 TCA_UNSPEC = 0,
 TCA_KIND = 1,
 TCA_OPTIONS = 2,
@@ -2740,7 +2797,7 @@ __TCA_MAX = 17,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_65 {
+pub enum _bindgen_ty_66 {
 NDUSEROPT_UNSPEC = 0,
 NDUSEROPT_SRCADDR = 1,
 __NDUSEROPT_MAX = 2,
@@ -2791,7 +2848,7 @@ __RTNLGRP_MAX = 37,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_66 {
+pub enum _bindgen_ty_67 {
 TCA_ROOT_UNSPEC = 0,
 TCA_ROOT_TAB = 1,
 TCA_ROOT_FLAGS = 2,
@@ -2854,6 +2911,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/x86/prctl.rs
+++ b/src/x86/prctl.rs
@@ -216,6 +216,7 @@ pub const PR_SME_VL_LEN_MASK: u32 = 65535;
 pub const PR_SME_VL_INHERIT: u32 = 131072;
 pub const PR_SET_MDWE: u32 = 65;
 pub const PR_MDWE_REFUSE_EXEC_GAIN: u32 = 1;
+pub const PR_MDWE_NO_INHERIT: u32 = 2;
 pub const PR_GET_MDWE: u32 = 66;
 pub const PR_SET_VMA: u32 = 1398164801;
 pub const PR_SET_VMA_ANON_NAME: u32 = 0;

--- a/src/x86/xdp.rs
+++ b/src/x86/xdp.rs
@@ -81,6 +81,7 @@ pub len: __u64,
 pub chunk_size: __u32,
 pub headroom: __u32,
 pub flags: __u32,
+pub tx_metadata_len: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -96,6 +97,23 @@ pub tx_ring_empty_descs: __u64,
 #[derive(Debug, Copy, Clone)]
 pub struct xdp_options {
 pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct xsk_tx_metadata {
+pub flags: __u64,
+pub __bindgen_anon_1: xsk_tx_metadata__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1 {
+pub csum_start: __u16,
+pub csum_offset: __u16,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2 {
+pub tx_timestamp: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -138,7 +156,9 @@ pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
 pub const XDP_USE_NEED_WAKEUP: u32 = 8;
+pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
+pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;
@@ -155,5 +175,13 @@ pub const XDP_UMEM_PGOFF_FILL_RING: u64 = 4294967296;
 pub const XDP_UMEM_PGOFF_COMPLETION_RING: u64 = 6442450944;
 pub const XSK_UNALIGNED_BUF_OFFSET_SHIFT: u32 = 48;
 pub const XSK_UNALIGNED_BUF_ADDR_MASK: u64 = 281474976710655;
-pub const XDP_USE_SG: u32 = 16;
+pub const XDP_TXMD_FLAGS_TIMESTAMP: u32 = 1;
+pub const XDP_TXMD_FLAGS_CHECKSUM: u32 = 2;
 pub const XDP_PKT_CONTD: u32 = 1;
+pub const XDP_TX_METADATA: u32 = 2;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union xsk_tx_metadata__bindgen_ty_1 {
+pub request: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1,
+pub completion: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2,
+}

--- a/src/x86_64/general.rs
+++ b/src/x86_64/general.rs
@@ -183,7 +183,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -238,6 +239,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -296,6 +330,29 @@ pub fsx_nextents: __u32,
 pub fsx_projid: __u32,
 pub fsx_cowextsize: __u32,
 pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -390,36 +447,6 @@ pub it_value: __kernel_old_timeval,
 pub struct __kernel_sock_timeval {
 pub tv_sec: __s64,
 pub tv_usec: __s64,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timespec {
-pub tv_sec: __kernel_old_time_t,
-pub tv_nsec: crate::ctypes::c_long,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timeval {
-pub tv_sec: __kernel_old_time_t,
-pub tv_usec: __kernel_suseconds_t,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerspec {
-pub it_interval: timespec,
-pub it_value: timespec,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct itimerval {
-pub it_interval: timeval,
-pub it_value: timeval,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timezone {
-pub tz_minuteswest: crate::ctypes::c_int,
-pub tz_dsttime: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -668,6 +695,36 @@ pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct timespec {
+pub tv_sec: __kernel_old_time_t,
+pub tv_nsec: crate::ctypes::c_long,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timeval {
+pub tv_sec: __kernel_old_time_t,
+pub tv_usec: __kernel_suseconds_t,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerspec {
+pub it_interval: timespec,
+pub it_value: timespec,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct itimerval {
+pub it_interval: timeval,
+pub it_value: timeval,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timezone {
+pub tz_minuteswest: crate::ctypes::c_int,
+pub tz_dsttime: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct iovec {
 pub iov_base: *mut crate::ctypes::c_void,
 pub iov_len: __kernel_size_t,
@@ -761,6 +818,22 @@ pub struct uffdio_continue {
 pub range: uffdio_range,
 pub mode: __u64,
 pub mapped: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_poison {
+pub range: uffdio_range,
+pub mode: __u64,
+pub updated: __s64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct uffdio_move {
+pub dst: __u64,
+pub src: __u64,
+pub len: __u64,
+pub mode: __u64,
+pub move_: __s64,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -879,9 +952,9 @@ pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 394496;
+pub const LINUX_VERSION_CODE: u32 = 395264;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 5;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_VECTOR_SIZE_ARCH: u32 = 3;
@@ -1250,6 +1323,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1321,6 +1402,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const FUTEX_WAIT: u32 = 0;
 pub const FUTEX_WAKE: u32 = 1;
 pub const FUTEX_FD: u32 = 2;
@@ -1351,6 +1442,13 @@ pub const FUTEX_WAIT_BITSET_PRIVATE: u32 = 137;
 pub const FUTEX_WAKE_BITSET_PRIVATE: u32 = 138;
 pub const FUTEX_WAIT_REQUEUE_PI_PRIVATE: u32 = 139;
 pub const FUTEX_CMP_REQUEUE_PI_PRIVATE: u32 = 140;
+pub const FUTEX2_SIZE_U8: u32 = 0;
+pub const FUTEX2_SIZE_U16: u32 = 1;
+pub const FUTEX2_SIZE_U32: u32 = 2;
+pub const FUTEX2_SIZE_U64: u32 = 3;
+pub const FUTEX2_NUMA: u32 = 4;
+pub const FUTEX2_PRIVATE: u32 = 128;
+pub const FUTEX2_SIZE_MASK: u32 = 3;
 pub const FUTEX_32: u32 = 2;
 pub const FUTEX_WAITV_MAX: u32 = 128;
 pub const FUTEX_WAITERS: u32 = 2147483648;
@@ -1482,6 +1580,8 @@ pub const DMA_BUF_MAGIC: u32 = 1145913666;
 pub const DEVMEM_MAGIC: u32 = 1162691661;
 pub const SECRETMEM_MAGIC: u32 = 1397048141;
 pub const MAP_32BIT: u32 = 64;
+pub const MAP_ABOVE4G: u32 = 128;
+pub const SHADOW_STACK_SET_TOKEN: u32 = 1;
 pub const PROT_READ: u32 = 1;
 pub const PROT_WRITE: u32 = 2;
 pub const PROT_EXEC: u32 = 4;
@@ -1608,25 +1708,6 @@ pub const LINUX_REBOOT_CMD_POWER_OFF: u32 = 1126301404;
 pub const LINUX_REBOOT_CMD_RESTART2: u32 = 2712847316;
 pub const LINUX_REBOOT_CMD_SW_SUSPEND: u32 = 3489725666;
 pub const LINUX_REBOOT_CMD_KEXEC: u32 = 1163412803;
-pub const ITIMER_REAL: u32 = 0;
-pub const ITIMER_VIRTUAL: u32 = 1;
-pub const ITIMER_PROF: u32 = 2;
-pub const CLOCK_REALTIME: u32 = 0;
-pub const CLOCK_MONOTONIC: u32 = 1;
-pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
-pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
-pub const CLOCK_MONOTONIC_RAW: u32 = 4;
-pub const CLOCK_REALTIME_COARSE: u32 = 5;
-pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
-pub const CLOCK_BOOTTIME: u32 = 7;
-pub const CLOCK_REALTIME_ALARM: u32 = 8;
-pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
-pub const CLOCK_SGI_CYCLE: u32 = 10;
-pub const CLOCK_TAI: u32 = 11;
-pub const MAX_CLOCKS: u32 = 16;
-pub const CLOCKS_MASK: u32 = 1;
-pub const CLOCKS_MONO: u32 = 1;
-pub const TIMER_ABSTIME: u32 = 1;
 pub const RUSAGE_SELF: u32 = 0;
 pub const RUSAGE_CHILDREN: i32 = -1;
 pub const RUSAGE_BOTH: i32 = -2;
@@ -1806,7 +1887,8 @@ pub const SEGV_ADIDERR: u32 = 6;
 pub const SEGV_ADIPERR: u32 = 7;
 pub const SEGV_MTEAERR: u32 = 8;
 pub const SEGV_MTESERR: u32 = 9;
-pub const NSIGSEGV: u32 = 9;
+pub const SEGV_CPERR: u32 = 10;
+pub const NSIGSEGV: u32 = 10;
 pub const BUS_ADRALN: u32 = 1;
 pub const BUS_ADRERR: u32 = 2;
 pub const BUS_OBJERR: u32 = 3;
@@ -1887,6 +1969,7 @@ pub const STATX_BASIC_STATS: u32 = 2047;
 pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
+pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2064,6 +2147,25 @@ pub const TIOCM_RI: u32 = 128;
 pub const TIOCM_OUT1: u32 = 8192;
 pub const TIOCM_OUT2: u32 = 16384;
 pub const TIOCM_LOOP: u32 = 32768;
+pub const ITIMER_REAL: u32 = 0;
+pub const ITIMER_VIRTUAL: u32 = 1;
+pub const ITIMER_PROF: u32 = 2;
+pub const CLOCK_REALTIME: u32 = 0;
+pub const CLOCK_MONOTONIC: u32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: u32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: u32 = 3;
+pub const CLOCK_MONOTONIC_RAW: u32 = 4;
+pub const CLOCK_REALTIME_COARSE: u32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: u32 = 6;
+pub const CLOCK_BOOTTIME: u32 = 7;
+pub const CLOCK_REALTIME_ALARM: u32 = 8;
+pub const CLOCK_BOOTTIME_ALARM: u32 = 9;
+pub const CLOCK_SGI_CYCLE: u32 = 10;
+pub const CLOCK_TAI: u32 = 11;
+pub const MAX_CLOCKS: u32 = 16;
+pub const CLOCKS_MASK: u32 = 1;
+pub const CLOCKS_MONO: u32 = 1;
+pub const TIMER_ABSTIME: u32 = 1;
 pub const UIO_FASTIOV: u32 = 8;
 pub const UIO_MAXIOV: u32 = 1024;
 pub const __X32_SYSCALL_BIT: u32 = 1073741824;
@@ -2430,6 +2532,16 @@ pub const __NR_process_mrelease: u32 = 448;
 pub const __NR_futex_waitv: u32 = 449;
 pub const __NR_set_mempolicy_home_node: u32 = 450;
 pub const __NR_cachestat: u32 = 451;
+pub const __NR_fchmodat2: u32 = 452;
+pub const __NR_map_shadow_stack: u32 = 453;
+pub const __NR_futex_wake: u32 = 454;
+pub const __NR_futex_wait: u32 = 455;
+pub const __NR_futex_requeue: u32 = 456;
+pub const __NR_statmount: u32 = 457;
+pub const __NR_listmount: u32 = 458;
+pub const __NR_lsm_get_self_attr: u32 = 459;
+pub const __NR_lsm_set_self_attr: u32 = 460;
+pub const __NR_lsm_list_modules: u32 = 461;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
 pub const WSTOPPED: u32 = 2;
@@ -2508,8 +2620,10 @@ pub const _UFFDIO_UNREGISTER: u32 = 1;
 pub const _UFFDIO_WAKE: u32 = 2;
 pub const _UFFDIO_COPY: u32 = 3;
 pub const _UFFDIO_ZEROPAGE: u32 = 4;
+pub const _UFFDIO_MOVE: u32 = 5;
 pub const _UFFDIO_WRITEPROTECT: u32 = 6;
 pub const _UFFDIO_CONTINUE: u32 = 7;
+pub const _UFFDIO_POISON: u32 = 8;
 pub const _UFFDIO_API: u32 = 63;
 pub const UFFDIO: u32 = 170;
 pub const UFFD_EVENT_PAGEFAULT: u32 = 18;
@@ -2534,6 +2648,9 @@ pub const UFFD_FEATURE_MINOR_SHMEM: u32 = 1024;
 pub const UFFD_FEATURE_EXACT_ADDRESS: u32 = 2048;
 pub const UFFD_FEATURE_WP_HUGETLBFS_SHMEM: u32 = 4096;
 pub const UFFD_FEATURE_WP_UNPOPULATED: u32 = 8192;
+pub const UFFD_FEATURE_POISON: u32 = 16384;
+pub const UFFD_FEATURE_WP_ASYNC: u32 = 32768;
+pub const UFFD_FEATURE_MOVE: u32 = 65536;
 pub const UFFD_USER_MODE_ONLY: u32 = 1;
 pub const DT_UNKNOWN: u32 = 0;
 pub const DT_FIFO: u32 = 1;
@@ -2610,6 +2727,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/x86_64/if_arp.rs
+++ b/src/x86_64/if_arp.rs
@@ -52,11 +52,6 @@ pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 pub type __kernel_sa_family_t = crate::ctypes::c_ushort;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Copy, Clone)]
 pub struct __kernel_sockaddr_storage {
 pub __bindgen_anon_1: __kernel_sockaddr_storage__bindgen_ty_1,
@@ -175,6 +170,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -182,23 +178,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -1126,6 +1107,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_4 = _bindgen_ty_4::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_4 = _bindgen_ty_4::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_4 = _bindgen_ty_4::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_4 = _bindgen_ty_4::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_5 = _bindgen_ty_5::IFLA_PROTO_DOWN_REASON_MASK;
@@ -1194,6 +1176,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_9 = _bindgen_ty_9::BRIDGE_MODE_HAIRPIN;
@@ -1241,6 +1225,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_10 = _bindgen_ty_10::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_10 = _bindgen_ty_10::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_11 = _bindgen_ty_11::IFLA_INFO_KIND;
@@ -1302,301 +1287,310 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_19 = _bindgen_ty_19::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_19 = _bindgen_ty_19::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_20 = _bindgen_ty_20::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_26 = _bindgen_ty_26::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_37 = _bindgen_ty_37::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_39 = _bindgen_ty_39::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_39 = _bindgen_ty_39::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_40 = _bindgen_ty_40::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_40 = _bindgen_ty_40::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_41 = _bindgen_ty_41::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_42 = _bindgen_ty_42::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_43 = _bindgen_ty_43::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_46 = _bindgen_ty_46::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_46 = _bindgen_ty_46::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_49 = _bindgen_ty_49::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_50 = _bindgen_ty_50::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_53 = _bindgen_ty_53::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_54 = _bindgen_ty_54::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_DSA_MAX;
-pub const IF_PORT_UNKNOWN: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_UNKNOWN;
-pub const IF_PORT_10BASE2: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASE2;
-pub const IF_PORT_10BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_10BASET;
-pub const IF_PORT_AUI: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_AUI;
-pub const IF_PORT_100BASET: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASET;
-pub const IF_PORT_100BASETX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASETX;
-pub const IF_PORT_100BASEFX: _bindgen_ty_56 = _bindgen_ty_56::IF_PORT_100BASEFX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_20 = _bindgen_ty_20::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_20 = _bindgen_ty_20::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_21 = _bindgen_ty_21::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_22 = _bindgen_ty_22::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_22 = _bindgen_ty_22::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_23 = _bindgen_ty_23::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_23 = _bindgen_ty_23::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_24 = _bindgen_ty_24::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_27 = _bindgen_ty_27::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_36 = _bindgen_ty_36::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_37 = _bindgen_ty_37::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_37 = _bindgen_ty_37::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_39 = _bindgen_ty_39::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_40 = _bindgen_ty_40::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_40 = _bindgen_ty_40::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_41 = _bindgen_ty_41::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_42 = _bindgen_ty_42::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_43 = _bindgen_ty_43::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_47 = _bindgen_ty_47::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_47 = _bindgen_ty_47::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_50 = _bindgen_ty_50::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_51 = _bindgen_ty_51::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_53 = _bindgen_ty_53::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_55 = _bindgen_ty_55::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__IFLA_DSA_MAX;
+pub const IF_PORT_UNKNOWN: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_UNKNOWN;
+pub const IF_PORT_10BASE2: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASE2;
+pub const IF_PORT_10BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_10BASET;
+pub const IF_PORT_AUI: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_AUI;
+pub const IF_PORT_100BASET: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASET;
+pub const IF_PORT_100BASETX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASETX;
+pub const IF_PORT_100BASEFX: _bindgen_ty_57 = _bindgen_ty_57::IF_PORT_100BASEFX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1699,6 +1693,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1788,7 +1784,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1884,7 +1881,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1941,7 +1940,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2094,10 +2094,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_20 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_21 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -2113,7 +2141,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -2125,7 +2153,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum _bindgen_ty_23 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -2133,7 +2161,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2166,7 +2194,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2180,7 +2209,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_25 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2210,7 +2247,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2221,7 +2258,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2236,7 +2273,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2249,7 +2286,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2287,7 +2324,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2299,7 +2336,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2315,7 +2352,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2323,7 +2360,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2343,7 +2380,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2351,7 +2388,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2360,7 +2397,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2375,7 +2412,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2383,7 +2420,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2397,7 +2434,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2406,7 +2443,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2424,7 +2461,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2434,14 +2471,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2449,7 +2486,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2463,7 +2500,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2475,7 +2512,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2484,7 +2521,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2493,7 +2530,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2503,7 +2540,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2512,7 +2549,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2522,7 +2559,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2537,7 +2574,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2549,7 +2586,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2565,7 +2602,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2574,7 +2611,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2582,15 +2619,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 IF_PORT_UNKNOWN = 0,
 IF_PORT_10BASE2 = 1,
 IF_PORT_10BASET = 2,
@@ -2673,74 +2710,6 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 impl nlmsgerr_attrs {
 pub const NLMSGERR_ATTR_MAX: nlmsgerr_attrs = nlmsgerr_attrs::NLMSGERR_ATTR_MISS_NEST;
 }
@@ -2755,6 +2724,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/x86_64/if_packet.rs
+++ b/src/x86_64/if_packet.rs
@@ -51,11 +51,6 @@ pub type __sum16 = __u16;
 pub type __wsum = __u32;
 pub type __poll_t = crate::ctypes::c_uint;
 #[repr(C)]
-#[derive(Default)]
-pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
-#[repr(C)]
-pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
-#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_pkt {
 pub spkt_family: crate::ctypes::c_ushort,
@@ -63,6 +58,7 @@ pub spkt_device: [crate::ctypes::c_uchar; 14usize],
 pub spkt_protocol: __be16,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct sockaddr_ll {
 pub sll_family: crate::ctypes::c_ushort,
 pub sll_protocol: __be16,
@@ -70,23 +66,8 @@ pub sll_ifindex: crate::ctypes::c_int,
 pub sll_hatype: crate::ctypes::c_ushort,
 pub sll_pkttype: crate::ctypes::c_uchar,
 pub sll_halen: crate::ctypes::c_uchar,
-pub __bindgen_anon_1: sockaddr_ll__bindgen_ty_1,
+pub sll_addr: [crate::ctypes::c_uchar; 8usize],
 }
-#[repr(C)]
-pub struct sockaddr_ll__bindgen_ty_1 {
-pub sll_addr: __BindgenUnionField<[crate::ctypes::c_uchar; 8usize]>,
-pub __bindgen_anon_1: __BindgenUnionField<sockaddr_ll__bindgen_ty_1__bindgen_ty_1>,
-pub bindgen_union_field: [u8; 8usize],
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1 {
-pub __empty_sll_addr_flex: sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-pub sll_addr_flex: __IncompleteArrayField<crate::ctypes::c_uchar>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sockaddr_ll__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tpacket_stats {
@@ -327,71 +308,3 @@ pub union tpacket_req_u {
 pub req: tpacket_req,
 pub req3: tpacket_req3,
 }
-impl<T> __IncompleteArrayField<T> {
-#[inline]
-pub const fn new() -> Self {
-__IncompleteArrayField(::core::marker::PhantomData, [])
-}
-#[inline]
-pub fn as_ptr(&self) -> *const T {
-self as *const _ as *const T
-}
-#[inline]
-pub fn as_mut_ptr(&mut self) -> *mut T {
-self as *mut _ as *mut T
-}
-#[inline]
-pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-::core::slice::from_raw_parts(self.as_ptr(), len)
-}
-#[inline]
-pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-::core::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-}
-}
-impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__IncompleteArrayField")
-}
-}
-impl<T> __BindgenUnionField<T> {
-#[inline]
-pub const fn new() -> Self {
-__BindgenUnionField(::core::marker::PhantomData)
-}
-#[inline]
-pub unsafe fn as_ref(&self) -> &T {
-::core::mem::transmute(self)
-}
-#[inline]
-pub unsafe fn as_mut(&mut self) -> &mut T {
-::core::mem::transmute(self)
-}
-}
-impl<T> ::core::default::Default for __BindgenUnionField<T> {
-#[inline]
-fn default() -> Self {
-Self::new()
-}
-}
-impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
-#[inline]
-fn clone(&self) -> Self {
-Self::new()
-}
-}
-impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
-impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
-fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-fmt.write_str("__BindgenUnionField")
-}
-}
-impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
-fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
-}
-impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
-fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
-true
-}
-}
-impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}

--- a/src/x86_64/io_uring.rs
+++ b/src/x86_64/io_uring.rs
@@ -79,7 +79,8 @@ pub version: __u8,
 pub contents_encryption_mode: __u8,
 pub filenames_encryption_mode: __u8,
 pub flags: __u8,
-pub __reserved: [__u8; 4usize],
+pub log2_data_unit_size: __u8,
+pub __reserved: [__u8; 3usize],
 pub master_key_identifier: [__u8; 16usize],
 }
 #[repr(C)]
@@ -134,6 +135,39 @@ pub attr_set: __u64,
 pub attr_clr: __u64,
 pub propagation: __u64,
 pub userns_fd: __u64,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct statmount {
+pub size: __u32,
+pub __spare1: __u32,
+pub mask: __u64,
+pub sb_dev_major: __u32,
+pub sb_dev_minor: __u32,
+pub sb_magic: __u64,
+pub sb_flags: __u32,
+pub fs_type: __u32,
+pub mnt_id: __u64,
+pub mnt_parent_id: __u64,
+pub mnt_id_old: __u32,
+pub mnt_parent_id_old: __u32,
+pub mnt_attr: __u64,
+pub mnt_propagation: __u64,
+pub mnt_peer_group: __u64,
+pub mnt_master: __u64,
+pub propagate_from: __u64,
+pub mnt_root: __u32,
+pub mnt_point: __u32,
+pub __spare2: [__u64; 50usize],
+pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mnt_id_req {
+pub size: __u32,
+pub spare: __u32,
+pub mnt_id: __u64,
+pub param: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -195,6 +229,29 @@ pub fsx_pad: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct page_region {
+pub start: __u64,
+pub end: __u64,
+pub categories: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct pm_scan_arg {
+pub size: __u64,
+pub flags: __u64,
+pub start: __u64,
+pub end: __u64,
+pub walk_end: __u64,
+pub vec: __u64,
+pub vec_len: __u64,
+pub max_pages: __u64,
+pub category_inverted: __u64,
+pub category_mask: __u64,
+pub category_anyof_mask: __u64,
+pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct __kernel_timespec {
 pub tv_sec: __kernel_time64_t,
 pub tv_nsec: crate::ctypes::c_longlong,
@@ -253,6 +310,12 @@ pub __pad1: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_sqe__bindgen_ty_2__bindgen_ty_1 {
+pub level: __u32,
+pub optname: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_sqe__bindgen_ty_5__bindgen_ty_1 {
 pub addr_len: __u16,
 pub __pad3: [__u16; 1usize],
@@ -260,6 +323,7 @@ pub __pad3: [__u16; 1usize],
 #[repr(C)]
 pub struct io_uring_sqe__bindgen_ty_6 {
 pub __bindgen_anon_1: __BindgenUnionField<io_uring_sqe__bindgen_ty_6__bindgen_ty_1>,
+pub optval: __BindgenUnionField<__u64>,
 pub cmd: __BindgenUnionField<[__u8; 0usize]>,
 pub bindgen_union_field: [u64; 2usize],
 }
@@ -421,6 +485,13 @@ pub resv: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_buf_status {
+pub buf_group: __u32,
+pub head: __u32,
+pub resv: [__u32; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -434,7 +505,9 @@ pub addr: __u64,
 pub fd: __s32,
 pub flags: __u32,
 pub timeout: __kernel_timespec,
-pub pad: [__u64; 4usize],
+pub opcode: __u8,
+pub pad: [__u8; 7usize],
+pub pad2: [__u64; 3usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -597,6 +670,14 @@ pub const MOUNT_ATTR_NODIRATIME: u32 = 128;
 pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
+pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const STATMOUNT_SB_BASIC: u32 = 1;
+pub const STATMOUNT_MNT_BASIC: u32 = 2;
+pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
+pub const STATMOUNT_MNT_ROOT: u32 = 8;
+pub const STATMOUNT_MNT_POINT: u32 = 16;
+pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const LSMT_ROOT: i32 = -1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -668,6 +749,16 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PAGE_IS_WPALLOWED: u32 = 1;
+pub const PAGE_IS_WRITTEN: u32 = 2;
+pub const PAGE_IS_FILE: u32 = 4;
+pub const PAGE_IS_PRESENT: u32 = 8;
+pub const PAGE_IS_SWAPPED: u32 = 16;
+pub const PAGE_IS_PFNZERO: u32 = 32;
+pub const PAGE_IS_HUGE: u32 = 64;
+pub const PAGE_IS_SOFT_DIRTY: u32 = 128;
+pub const PM_SCAN_WP_MATCHING: u32 = 1;
+pub const PM_SCAN_CHECK_WPASYNC: u32 = 2;
 pub const IORING_FILE_INDEX_ALLOC: i32 = -1;
 pub const IORING_SETUP_IOPOLL: u32 = 1;
 pub const IORING_SETUP_SQPOLL: u32 = 2;
@@ -685,8 +776,9 @@ pub const IORING_SETUP_SINGLE_ISSUER: u32 = 4096;
 pub const IORING_SETUP_DEFER_TASKRUN: u32 = 8192;
 pub const IORING_SETUP_NO_MMAP: u32 = 16384;
 pub const IORING_SETUP_REGISTERED_FD_ONLY: u32 = 32768;
+pub const IORING_SETUP_NO_SQARRAY: u32 = 65536;
 pub const IORING_URING_CMD_FIXED: u32 = 1;
-pub const IORING_URING_CMD_POLLED: u32 = 2147483648;
+pub const IORING_URING_CMD_MASK: u32 = 1;
 pub const IORING_FSYNC_DATASYNC: u32 = 1;
 pub const IORING_TIMEOUT_ABS: u32 = 1;
 pub const IORING_TIMEOUT_UPDATE: u32 = 2;
@@ -706,6 +798,8 @@ pub const IORING_ASYNC_CANCEL_ALL: u32 = 1;
 pub const IORING_ASYNC_CANCEL_FD: u32 = 2;
 pub const IORING_ASYNC_CANCEL_ANY: u32 = 4;
 pub const IORING_ASYNC_CANCEL_FD_FIXED: u32 = 8;
+pub const IORING_ASYNC_CANCEL_USERDATA: u32 = 16;
+pub const IORING_ASYNC_CANCEL_OP: u32 = 32;
 pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
@@ -714,6 +808,7 @@ pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
+pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
@@ -786,6 +881,7 @@ pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGIS
 pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
 pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
 pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
+pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
 pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
 pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
 pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
@@ -796,6 +892,10 @@ pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTR
 pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
 pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
 pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
+pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
+pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
+pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
+pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -808,6 +908,7 @@ FSCONFIG_SET_PATH_EMPTY = 4,
 FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
+FSCONFIG_CMD_CREATE_EXCL = 8,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -874,7 +975,13 @@ IORING_OP_SOCKET = 45,
 IORING_OP_URING_CMD = 46,
 IORING_OP_SEND_ZC = 47,
 IORING_OP_SENDMSG_ZC = 48,
-IORING_OP_LAST = 49,
+IORING_OP_READ_MULTISHOT = 49,
+IORING_OP_WAITID = 50,
+IORING_OP_FUTEX_WAIT = 51,
+IORING_OP_FUTEX_WAKE = 52,
+IORING_OP_FUTEX_WAITV = 53,
+IORING_OP_FIXED_FD_INSTALL = 54,
+IORING_OP_LAST = 55,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -919,7 +1026,8 @@ IORING_REGISTER_PBUF_RING = 22,
 IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
-IORING_REGISTER_LAST = 26,
+IORING_REGISTER_PBUF_STATUS = 26,
+IORING_REGISTER_LAST = 27,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
@@ -944,6 +1052,15 @@ IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
 IORING_RESTRICTION_SQE_FLAGS_REQUIRED = 3,
 IORING_RESTRICTION_LAST = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_8 {
+SOCKET_URING_OP_SIOCINQ = 0,
+SOCKET_URING_OP_SIOCOUTQ = 1,
+SOCKET_URING_OP_GETSOCKOPT = 2,
+SOCKET_URING_OP_SETSOCKOPT = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -971,6 +1088,7 @@ pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_1__bindgen_ty_1,
 pub union io_uring_sqe__bindgen_ty_2 {
 pub addr: __u64,
 pub splice_off_in: __u64,
+pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_2__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -994,6 +1112,9 @@ pub hardlink_flags: __u32,
 pub xattr_flags: __u32,
 pub msg_ring_flags: __u32,
 pub uring_cmd_flags: __u32,
+pub waitid_flags: __u32,
+pub futex_flags: __u32,
+pub install_fd_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]
@@ -1006,6 +1127,7 @@ pub buf_group: __u16,
 pub union io_uring_sqe__bindgen_ty_5 {
 pub splice_fd_in: __s32,
 pub file_index: __u32,
+pub optlen: __u32,
 pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]

--- a/src/x86_64/net.rs
+++ b/src/x86_64/net.rs
@@ -429,6 +429,9 @@ pub tcpi_rcv_ooopack: __u32,
 pub tcpi_snd_wnd: __u32,
 pub tcpi_rcv_wnd: __u32,
 pub tcpi_rehash: __u32,
+pub tcpi_total_rto: __u16,
+pub tcpi_total_rto_recoveries: __u16,
+pub tcpi_total_rto_time: __u32,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -448,6 +451,80 @@ pub tcpm_prefixlen: __u8,
 pub tcpm_keylen: __u16,
 pub tcpm_addr: [__be32; 4usize],
 pub tcpm_key: [__u8; 80usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_add {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub key: [__u8; 80usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_del {
+pub addr: __kernel_sockaddr_storage,
+pub ifindex: __s32,
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub prefix: __u8,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub current_key: __u8,
+pub rnext: __u8,
+pub keyflags: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_info_opt {
+pub _bitfield_align_1: [u32; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+pub reserved2: __u16,
+pub current_key: __u8,
+pub rnext: __u8,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+pub pkt_key_not_found: __u64,
+pub pkt_ao_required: __u64,
+pub pkt_dropped_icmp: __u64,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tcp_ao_getsockopt {
+pub addr: __kernel_sockaddr_storage,
+pub alg_name: [crate::ctypes::c_char; 64usize],
+pub key: [__u8; 80usize],
+pub nkeys: __u32,
+pub _bitfield_align_1: [u16; 0],
+pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+pub sndid: __u8,
+pub rcvid: __u8,
+pub prefix: __u8,
+pub maclen: __u8,
+pub keyflags: __u8,
+pub keylen: __u8,
+pub ifindex: __s32,
+pub pkt_good: __u64,
+pub pkt_bad: __u64,
+}
+#[repr(C)]
+#[repr(align(8))]
+#[derive(Debug, Copy, Clone)]
+pub struct tcp_ao_repair {
+pub snt_isn: __be32,
+pub rcv_isn: __be32,
+pub snd_sne: __u32,
+pub rcv_sne: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1185,6 +1262,11 @@ pub const TCP_ZEROCOPY_RECEIVE: u32 = 35;
 pub const TCP_INQ: u32 = 36;
 pub const TCP_CM_INQ: u32 = 36;
 pub const TCP_TX_DELAY: u32 = 37;
+pub const TCP_AO_ADD_KEY: u32 = 38;
+pub const TCP_AO_DEL_KEY: u32 = 39;
+pub const TCP_AO_INFO: u32 = 40;
+pub const TCP_AO_GET_KEYS: u32 = 41;
+pub const TCP_AO_REPAIR: u32 = 42;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1194,9 +1276,13 @@ pub const TCPI_OPT_WSCALE: u32 = 4;
 pub const TCPI_OPT_ECN: u32 = 8;
 pub const TCPI_OPT_ECN_SEEN: u32 = 16;
 pub const TCPI_OPT_SYN_DATA: u32 = 32;
+pub const TCPI_OPT_USEC_TS: u32 = 64;
 pub const TCP_MD5SIG_MAXKEYLEN: u32 = 80;
 pub const TCP_MD5SIG_FLAG_PREFIX: u32 = 1;
 pub const TCP_MD5SIG_FLAG_IFINDEX: u32 = 2;
+pub const TCP_AO_MAXKEYLEN: u32 = 80;
+pub const TCP_AO_KEYF_IFINDEX: u32 = 1;
+pub const TCP_AO_KEYF_EXCLUDE_OPT: u32 = 2;
 pub const TCP_RECEIVE_ZEROCOPY_FLAG_TLB_CLEAN_HINT: u32 = 1;
 pub const UNIX_PATH_MAX: u32 = 108;
 pub const IFNAMSIZ: u32 = 16;
@@ -1561,6 +1647,7 @@ pub const DEVCONF_IOAM6_ID: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID;
 pub const DEVCONF_IOAM6_ID_WIDE: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_IOAM6_ID_WIDE;
 pub const DEVCONF_NDISC_EVICT_NOCARRIER: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_NDISC_EVICT_NOCARRIER;
 pub const DEVCONF_ACCEPT_UNTRACKED_NA: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_UNTRACKED_NA;
+pub const DEVCONF_ACCEPT_RA_MIN_LFT: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_ACCEPT_RA_MIN_LFT;
 pub const DEVCONF_MAX: _bindgen_ty_3 = _bindgen_ty_3::DEVCONF_MAX;
 pub const TCP_FLAG_CWR: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_CWR;
 pub const TCP_FLAG_ECE: _bindgen_ty_4 = _bindgen_ty_4::TCP_FLAG_ECE;
@@ -1758,7 +1845,8 @@ DEVCONF_IOAM6_ID = 54,
 DEVCONF_IOAM6_ID_WIDE = 55,
 DEVCONF_NDISC_EVICT_NOCARRIER = 56,
 DEVCONF_ACCEPT_UNTRACKED_NA = 57,
-DEVCONF_MAX = 58,
+DEVCONF_ACCEPT_RA_MIN_LFT = 58,
+DEVCONF_MAX = 59,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2476,6 +2564,289 @@ tcpi_delivery_rate_app_limited as u64
 __bindgen_bitfield_unit.set(9usize, 2u8, {
 let tcpi_fastopen_client_fail: u8 = unsafe { ::core::mem::transmute(tcpi_fastopen_client_fail) };
 tcpi_fastopen_client_fail as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_add {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 30u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 30u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_del {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn del_async(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_del_async(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 29u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 29u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, del_async: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let del_async: u32 = unsafe { ::core::mem::transmute(del_async) };
+del_async as u64
+});
+__bindgen_bitfield_unit.set(3usize, 29u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_info_opt {
+#[inline]
+pub fn set_current(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_current(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_rnext(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_rnext(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn ao_required(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_ao_required(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn set_counters(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_set_counters(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn accept_icmps(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u32) }
+}
+#[inline]
+pub fn set_accept_icmps(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(4usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u32 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(5usize, 27u8) as u32) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u32) {
+unsafe {
+let val: u32 = ::core::mem::transmute(val);
+self._bitfield_1.set(5usize, 27u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(set_current: __u32, set_rnext: __u32, ao_required: __u32, set_counters: __u32, accept_icmps: __u32, reserved: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let set_current: u32 = unsafe { ::core::mem::transmute(set_current) };
+set_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let set_rnext: u32 = unsafe { ::core::mem::transmute(set_rnext) };
+set_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let ao_required: u32 = unsafe { ::core::mem::transmute(ao_required) };
+ao_required as u64
+});
+__bindgen_bitfield_unit.set(3usize, 1u8, {
+let set_counters: u32 = unsafe { ::core::mem::transmute(set_counters) };
+set_counters as u64
+});
+__bindgen_bitfield_unit.set(4usize, 1u8, {
+let accept_icmps: u32 = unsafe { ::core::mem::transmute(accept_icmps) };
+accept_icmps as u64
+});
+__bindgen_bitfield_unit.set(5usize, 27u8, {
+let reserved: u32 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
+});
+__bindgen_bitfield_unit
+}
+}
+impl tcp_ao_getsockopt {
+#[inline]
+pub fn is_current(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_current(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(0usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn is_rnext(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_is_rnext(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(1usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn get_all(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+}
+#[inline]
+pub fn set_get_all(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(2usize, 1u8, val as u64)
+}
+}
+#[inline]
+pub fn reserved(&self) -> __u16 {
+unsafe { ::core::mem::transmute(self._bitfield_1.get(3usize, 13u8) as u16) }
+}
+#[inline]
+pub fn set_reserved(&mut self, val: __u16) {
+unsafe {
+let val: u16 = ::core::mem::transmute(val);
+self._bitfield_1.set(3usize, 13u8, val as u64)
+}
+}
+#[inline]
+pub fn new_bitfield_1(is_current: __u16, is_rnext: __u16, get_all: __u16, reserved: __u16) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+__bindgen_bitfield_unit.set(0usize, 1u8, {
+let is_current: u16 = unsafe { ::core::mem::transmute(is_current) };
+is_current as u64
+});
+__bindgen_bitfield_unit.set(1usize, 1u8, {
+let is_rnext: u16 = unsafe { ::core::mem::transmute(is_rnext) };
+is_rnext as u64
+});
+__bindgen_bitfield_unit.set(2usize, 1u8, {
+let get_all: u16 = unsafe { ::core::mem::transmute(get_all) };
+get_all as u64
+});
+__bindgen_bitfield_unit.set(3usize, 13u8, {
+let reserved: u16 = unsafe { ::core::mem::transmute(reserved) };
+reserved as u64
 });
 __bindgen_bitfield_unit
 }

--- a/src/x86_64/netlink.rs
+++ b/src/x86_64/netlink.rs
@@ -724,7 +724,8 @@ pub const RTAX_FEATURE_ECN: u32 = 1;
 pub const RTAX_FEATURE_SACK: u32 = 2;
 pub const RTAX_FEATURE_TIMESTAMP: u32 = 4;
 pub const RTAX_FEATURE_ALLFRAG: u32 = 8;
-pub const RTAX_FEATURE_MASK: u32 = 15;
+pub const RTAX_FEATURE_TCP_USEC_TS: u32 = 16;
+pub const RTAX_FEATURE_MASK: u32 = 31;
 pub const TCM_IFINDEX_MAGIC_BLOCK: u32 = 4294967295;
 pub const TCA_DUMP_FLAGS_TERSE: u32 = 1;
 pub const RTMGRP_LINK: u32 = 1;
@@ -821,6 +822,7 @@ pub const IFLA_ALLMULTI: _bindgen_ty_2 = _bindgen_ty_2::IFLA_ALLMULTI;
 pub const IFLA_DEVLINK_PORT: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DEVLINK_PORT;
 pub const IFLA_GSO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GSO_IPV4_MAX_SIZE;
 pub const IFLA_GRO_IPV4_MAX_SIZE: _bindgen_ty_2 = _bindgen_ty_2::IFLA_GRO_IPV4_MAX_SIZE;
+pub const IFLA_DPLL_PIN: _bindgen_ty_2 = _bindgen_ty_2::IFLA_DPLL_PIN;
 pub const __IFLA_MAX: _bindgen_ty_2 = _bindgen_ty_2::__IFLA_MAX;
 pub const IFLA_PROTO_DOWN_REASON_UNSPEC: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_UNSPEC;
 pub const IFLA_PROTO_DOWN_REASON_MASK: _bindgen_ty_3 = _bindgen_ty_3::IFLA_PROTO_DOWN_REASON_MASK;
@@ -889,6 +891,8 @@ pub const IFLA_BR_MCAST_MLD_VERSION: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAS
 pub const IFLA_BR_VLAN_STATS_PER_PORT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_VLAN_STATS_PER_PORT;
 pub const IFLA_BR_MULTI_BOOLOPT: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MULTI_BOOLOPT;
 pub const IFLA_BR_MCAST_QUERIER_STATE: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_MCAST_QUERIER_STATE;
+pub const IFLA_BR_FDB_N_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_N_LEARNED;
+pub const IFLA_BR_FDB_MAX_LEARNED: _bindgen_ty_6 = _bindgen_ty_6::IFLA_BR_FDB_MAX_LEARNED;
 pub const __IFLA_BR_MAX: _bindgen_ty_6 = _bindgen_ty_6::__IFLA_BR_MAX;
 pub const BRIDGE_MODE_UNSPEC: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_UNSPEC;
 pub const BRIDGE_MODE_HAIRPIN: _bindgen_ty_7 = _bindgen_ty_7::BRIDGE_MODE_HAIRPIN;
@@ -936,6 +940,7 @@ pub const IFLA_BRPORT_MAB: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MAB;
 pub const IFLA_BRPORT_MCAST_N_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_N_GROUPS;
 pub const IFLA_BRPORT_MCAST_MAX_GROUPS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_MCAST_MAX_GROUPS;
 pub const IFLA_BRPORT_NEIGH_VLAN_SUPPRESS: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_NEIGH_VLAN_SUPPRESS;
+pub const IFLA_BRPORT_BACKUP_NHID: _bindgen_ty_8 = _bindgen_ty_8::IFLA_BRPORT_BACKUP_NHID;
 pub const __IFLA_BRPORT_MAX: _bindgen_ty_8 = _bindgen_ty_8::__IFLA_BRPORT_MAX;
 pub const IFLA_INFO_UNSPEC: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_UNSPEC;
 pub const IFLA_INFO_KIND: _bindgen_ty_9 = _bindgen_ty_9::IFLA_INFO_KIND;
@@ -997,501 +1002,510 @@ pub const IFLA_IPVLAN_UNSPEC: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_UNSPE
 pub const IFLA_IPVLAN_MODE: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_MODE;
 pub const IFLA_IPVLAN_FLAGS: _bindgen_ty_17 = _bindgen_ty_17::IFLA_IPVLAN_FLAGS;
 pub const __IFLA_IPVLAN_MAX: _bindgen_ty_17 = _bindgen_ty_17::__IFLA_IPVLAN_MAX;
-pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_UNSPEC;
-pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_RX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_BYTES;
-pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_PKTS;
-pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_DROPS;
-pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_TX_ERRORS;
-pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_18 = _bindgen_ty_18::VNIFILTER_ENTRY_STATS_PAD;
-pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_18 = _bindgen_ty_18::__VNIFILTER_ENTRY_STATS_MAX;
-pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_START;
-pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_END;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP;
-pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_GROUP6;
-pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_19 = _bindgen_ty_19::VXLAN_VNIFILTER_ENTRY_STATS;
-pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VXLAN_VNIFILTER_ENTRY_MAX;
-pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_UNSPEC;
-pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY;
-pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_MAX;
-pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UNSPEC;
-pub const IFLA_VXLAN_ID: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_ID;
-pub const IFLA_VXLAN_GROUP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP;
-pub const IFLA_VXLAN_LINK: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LINK;
-pub const IFLA_VXLAN_LOCAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL;
-pub const IFLA_VXLAN_TTL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL;
-pub const IFLA_VXLAN_TOS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TOS;
-pub const IFLA_VXLAN_LEARNING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LEARNING;
-pub const IFLA_VXLAN_AGEING: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_AGEING;
-pub const IFLA_VXLAN_LIMIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LIMIT;
-pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT_RANGE;
-pub const IFLA_VXLAN_PROXY: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PROXY;
-pub const IFLA_VXLAN_RSC: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_RSC;
-pub const IFLA_VXLAN_L2MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L2MISS;
-pub const IFLA_VXLAN_L3MISS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_L3MISS;
-pub const IFLA_VXLAN_PORT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_PORT;
-pub const IFLA_VXLAN_GROUP6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GROUP6;
-pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCAL6;
-pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_CSUM;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
-pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
-pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_TX;
-pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_RX;
-pub const IFLA_VXLAN_GBP: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GBP;
-pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_REMCSUM_NOPARTIAL;
-pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_COLLECT_METADATA;
-pub const IFLA_VXLAN_LABEL: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LABEL;
-pub const IFLA_VXLAN_GPE: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_GPE;
-pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_TTL_INHERIT;
-pub const IFLA_VXLAN_DF: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_DF;
-pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_VNIFILTER;
-pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_21 = _bindgen_ty_21::IFLA_VXLAN_LOCALBYPASS;
-pub const __IFLA_VXLAN_MAX: _bindgen_ty_21 = _bindgen_ty_21::__IFLA_VXLAN_MAX;
-pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UNSPEC;
-pub const IFLA_GENEVE_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_ID;
-pub const IFLA_GENEVE_REMOTE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE;
-pub const IFLA_GENEVE_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL;
-pub const IFLA_GENEVE_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TOS;
-pub const IFLA_GENEVE_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_PORT;
-pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_COLLECT_METADATA;
-pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_REMOTE6;
-pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_CSUM;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
-pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
-pub const IFLA_GENEVE_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_LABEL;
-pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_TTL_INHERIT;
-pub const IFLA_GENEVE_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_DF;
-pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_GENEVE_INNER_PROTO_INHERIT;
-pub const __IFLA_GENEVE_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_GENEVE_MAX;
-pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_UNSPEC;
-pub const IFLA_BAREUDP_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_PORT;
-pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_ETHERTYPE;
-pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_SRCPORT_MIN;
-pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_BAREUDP_MULTIPROTO_MODE;
-pub const __IFLA_BAREUDP_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_BAREUDP_MAX;
-pub const IFLA_PPP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_UNSPEC;
-pub const IFLA_PPP_DEV_FD: _bindgen_ty_24 = _bindgen_ty_24::IFLA_PPP_DEV_FD;
-pub const __IFLA_PPP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_PPP_MAX;
-pub const IFLA_GTP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_UNSPEC;
-pub const IFLA_GTP_FD0: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD0;
-pub const IFLA_GTP_FD1: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_FD1;
-pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_PDP_HASHSIZE;
-pub const IFLA_GTP_ROLE: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_ROLE;
-pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_CREATE_SOCKETS;
-pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_25 = _bindgen_ty_25::IFLA_GTP_RESTART_COUNT;
-pub const __IFLA_GTP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_GTP_MAX;
-pub const IFLA_BOND_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UNSPEC;
-pub const IFLA_BOND_MODE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MODE;
-pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ACTIVE_SLAVE;
-pub const IFLA_BOND_MIIMON: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIIMON;
-pub const IFLA_BOND_UPDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_UPDELAY;
-pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_DOWNDELAY;
-pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_USE_CARRIER;
-pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_INTERVAL;
-pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_IP_TARGET;
-pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_VALIDATE;
-pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ARP_ALL_TARGETS;
-pub const IFLA_BOND_PRIMARY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY;
-pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PRIMARY_RESELECT;
-pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_FAIL_OVER_MAC;
-pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_XMIT_HASH_POLICY;
-pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_RESEND_IGMP;
-pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NUM_PEER_NOTIF;
-pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_ALL_SLAVES_ACTIVE;
-pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MIN_LINKS;
-pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_LP_INTERVAL;
-pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PACKETS_PER_SLAVE;
-pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_RATE;
-pub const IFLA_BOND_AD_SELECT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_SELECT;
-pub const IFLA_BOND_AD_INFO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_INFO;
-pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYS_PRIO;
-pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_USER_PORT_KEY;
-pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_ACTOR_SYSTEM;
-pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_TLB_DYNAMIC_LB;
-pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_PEER_NOTIF_DELAY;
-pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_AD_LACP_ACTIVE;
-pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_MISSED_MAX;
-pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_26 = _bindgen_ty_26::IFLA_BOND_NS_IP6_TARGET;
-pub const __IFLA_BOND_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_BOND_MAX;
-pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_UNSPEC;
-pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_AGGREGATOR;
-pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_NUM_PORTS;
-pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_ACTOR_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_KEY;
-pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO_PARTNER_MAC;
-pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_AD_INFO_MAX;
-pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_UNSPEC;
-pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_STATE;
-pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_MII_STATUS;
-pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
-pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PERM_HWADDR;
-pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_QUEUE_ID;
-pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
-pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
-pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_SLAVE_PRIO;
-pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_SLAVE_MAX;
-pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO_UNSPEC;
-pub const IFLA_VF_INFO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_VF_INFO;
-pub const __IFLA_VF_INFO_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_VF_INFO_MAX;
-pub const IFLA_VF_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_UNSPEC;
-pub const IFLA_VF_MAC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_MAC;
-pub const IFLA_VF_VLAN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN;
-pub const IFLA_VF_TX_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TX_RATE;
-pub const IFLA_VF_SPOOFCHK: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_SPOOFCHK;
-pub const IFLA_VF_LINK_STATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_LINK_STATE;
-pub const IFLA_VF_RATE: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RATE;
-pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_RSS_QUERY_EN;
-pub const IFLA_VF_STATS: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_STATS;
-pub const IFLA_VF_TRUST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_TRUST;
-pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_NODE_GUID;
-pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_IB_PORT_GUID;
-pub const IFLA_VF_VLAN_LIST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_VLAN_LIST;
-pub const IFLA_VF_BROADCAST: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_BROADCAST;
-pub const __IFLA_VF_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_MAX;
-pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO_UNSPEC;
-pub const IFLA_VF_VLAN_INFO: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_INFO;
-pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_VLAN_INFO_MAX;
-pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_AUTO;
-pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_ENABLE;
-pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_LINK_STATE_DISABLE;
-pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_LINK_STATE_MAX;
-pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_PACKETS;
-pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_PACKETS;
-pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_BYTES;
-pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_BYTES;
-pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_BROADCAST;
-pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_MULTICAST;
-pub const IFLA_VF_STATS_PAD: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_PAD;
-pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_RX_DROPPED;
-pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_STATS_TX_DROPPED;
-pub const __IFLA_VF_STATS_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_STATS_MAX;
-pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT_UNSPEC;
-pub const IFLA_VF_PORT: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_PORT;
-pub const __IFLA_VF_PORT_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_PORT_MAX;
-pub const IFLA_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_UNSPEC;
-pub const IFLA_PORT_VF: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VF;
-pub const IFLA_PORT_PROFILE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_PROFILE;
-pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_VSI_TYPE;
-pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_INSTANCE_UUID;
-pub const IFLA_PORT_HOST_UUID: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_HOST_UUID;
-pub const IFLA_PORT_REQUEST: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_REQUEST;
-pub const IFLA_PORT_RESPONSE: _bindgen_ty_35 = _bindgen_ty_35::IFLA_PORT_RESPONSE;
-pub const __IFLA_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_PORT_MAX;
-pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE;
-pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_PREASSOCIATE_RR;
-pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_ASSOCIATE;
-pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_36 = _bindgen_ty_36::PORT_REQUEST_DISASSOCIATE;
-pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_SUCCESS;
-pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INVALID_FORMAT;
-pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_UNUSED_VTID;
-pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VIOLATION;
-pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
-pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_37 = _bindgen_ty_37::PORT_VDP_RESPONSE_OUT_OF_SYNC;
-pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_SUCCESS;
-pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INPROGRESS;
-pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INVALID;
-pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_BADSTATE;
-pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
-pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_37 = _bindgen_ty_37::PORT_PROFILE_RESPONSE_ERROR;
-pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UNSPEC;
-pub const IFLA_IPOIB_PKEY: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_PKEY;
-pub const IFLA_IPOIB_MODE: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_MODE;
-pub const IFLA_IPOIB_UMCAST: _bindgen_ty_38 = _bindgen_ty_38::IFLA_IPOIB_UMCAST;
-pub const __IFLA_IPOIB_MAX: _bindgen_ty_38 = _bindgen_ty_38::__IFLA_IPOIB_MAX;
-pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_DATAGRAM;
-pub const IPOIB_MODE_CONNECTED: _bindgen_ty_39 = _bindgen_ty_39::IPOIB_MODE_CONNECTED;
-pub const HSR_PROTOCOL_HSR: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_HSR;
-pub const HSR_PROTOCOL_PRP: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_PRP;
-pub const HSR_PROTOCOL_MAX: _bindgen_ty_40 = _bindgen_ty_40::HSR_PROTOCOL_MAX;
-pub const IFLA_HSR_UNSPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_UNSPEC;
-pub const IFLA_HSR_SLAVE1: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE1;
-pub const IFLA_HSR_SLAVE2: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SLAVE2;
-pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_MULTICAST_SPEC;
-pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SUPERVISION_ADDR;
-pub const IFLA_HSR_SEQ_NR: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_SEQ_NR;
-pub const IFLA_HSR_VERSION: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_VERSION;
-pub const IFLA_HSR_PROTOCOL: _bindgen_ty_41 = _bindgen_ty_41::IFLA_HSR_PROTOCOL;
-pub const __IFLA_HSR_MAX: _bindgen_ty_41 = _bindgen_ty_41::__IFLA_HSR_MAX;
-pub const IFLA_STATS_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_UNSPEC;
-pub const IFLA_STATS_LINK_64: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_64;
-pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS;
-pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_XSTATS_SLAVE;
-pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_LINK_OFFLOAD_XSTATS;
-pub const IFLA_STATS_AF_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_STATS_AF_SPEC;
-pub const __IFLA_STATS_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_STATS_MAX;
-pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GETSET_UNSPEC;
-pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_GET_FILTERS;
-pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_GETSET_MAX;
-pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_UNSPEC;
-pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BRIDGE;
-pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_44 = _bindgen_ty_44::LINK_XSTATS_TYPE_BOND;
-pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_44 = _bindgen_ty_44::__LINK_XSTATS_TYPE_MAX;
-pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_CPU_HIT;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
-pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_45 = _bindgen_ty_45::IFLA_OFFLOAD_XSTATS_L3_STATS;
-pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_45 = _bindgen_ty_45::__IFLA_OFFLOAD_XSTATS_MAX;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
-pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
-pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
-pub const XDP_ATTACHED_NONE: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_NONE;
-pub const XDP_ATTACHED_DRV: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_DRV;
-pub const XDP_ATTACHED_SKB: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_SKB;
-pub const XDP_ATTACHED_HW: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_HW;
-pub const XDP_ATTACHED_MULTI: _bindgen_ty_47 = _bindgen_ty_47::XDP_ATTACHED_MULTI;
-pub const IFLA_XDP_UNSPEC: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_UNSPEC;
-pub const IFLA_XDP_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FD;
-pub const IFLA_XDP_ATTACHED: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_ATTACHED;
-pub const IFLA_XDP_FLAGS: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_FLAGS;
-pub const IFLA_XDP_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_PROG_ID;
-pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_DRV_PROG_ID;
-pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_SKB_PROG_ID;
-pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_HW_PROG_ID;
-pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_48 = _bindgen_ty_48::IFLA_XDP_EXPECTED_FD;
-pub const __IFLA_XDP_MAX: _bindgen_ty_48 = _bindgen_ty_48::__IFLA_XDP_MAX;
-pub const IFLA_EVENT_NONE: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NONE;
-pub const IFLA_EVENT_REBOOT: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_REBOOT;
-pub const IFLA_EVENT_FEATURES: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_FEATURES;
-pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_FAILOVER;
-pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_NOTIFY_PEERS;
-pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_IGMP_RESEND;
-pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_EVENT_BONDING_OPTIONS;
-pub const IFLA_TUN_UNSPEC: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_UNSPEC;
-pub const IFLA_TUN_OWNER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_OWNER;
-pub const IFLA_TUN_GROUP: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_GROUP;
-pub const IFLA_TUN_TYPE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_TYPE;
-pub const IFLA_TUN_PI: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PI;
-pub const IFLA_TUN_VNET_HDR: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_VNET_HDR;
-pub const IFLA_TUN_PERSIST: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_PERSIST;
-pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_MULTI_QUEUE;
-pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_QUEUES;
-pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_TUN_NUM_DISABLED_QUEUES;
-pub const __IFLA_TUN_MAX: _bindgen_ty_50 = _bindgen_ty_50::__IFLA_TUN_MAX;
-pub const IFLA_RMNET_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_UNSPEC;
-pub const IFLA_RMNET_MUX_ID: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_MUX_ID;
-pub const IFLA_RMNET_FLAGS: _bindgen_ty_51 = _bindgen_ty_51::IFLA_RMNET_FLAGS;
-pub const __IFLA_RMNET_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_RMNET_MAX;
-pub const IFLA_MCTP_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_UNSPEC;
-pub const IFLA_MCTP_NET: _bindgen_ty_52 = _bindgen_ty_52::IFLA_MCTP_NET;
-pub const __IFLA_MCTP_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_MCTP_MAX;
-pub const IFLA_DSA_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_UNSPEC;
-pub const IFLA_DSA_MASTER: _bindgen_ty_53 = _bindgen_ty_53::IFLA_DSA_MASTER;
-pub const __IFLA_DSA_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_DSA_MAX;
-pub const IFA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFA_UNSPEC;
-pub const IFA_ADDRESS: _bindgen_ty_54 = _bindgen_ty_54::IFA_ADDRESS;
-pub const IFA_LOCAL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LOCAL;
-pub const IFA_LABEL: _bindgen_ty_54 = _bindgen_ty_54::IFA_LABEL;
-pub const IFA_BROADCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_BROADCAST;
-pub const IFA_ANYCAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_ANYCAST;
-pub const IFA_CACHEINFO: _bindgen_ty_54 = _bindgen_ty_54::IFA_CACHEINFO;
-pub const IFA_MULTICAST: _bindgen_ty_54 = _bindgen_ty_54::IFA_MULTICAST;
-pub const IFA_FLAGS: _bindgen_ty_54 = _bindgen_ty_54::IFA_FLAGS;
-pub const IFA_RT_PRIORITY: _bindgen_ty_54 = _bindgen_ty_54::IFA_RT_PRIORITY;
-pub const IFA_TARGET_NETNSID: _bindgen_ty_54 = _bindgen_ty_54::IFA_TARGET_NETNSID;
-pub const IFA_PROTO: _bindgen_ty_54 = _bindgen_ty_54::IFA_PROTO;
-pub const __IFA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFA_MAX;
-pub const NDA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::NDA_UNSPEC;
-pub const NDA_DST: _bindgen_ty_55 = _bindgen_ty_55::NDA_DST;
-pub const NDA_LLADDR: _bindgen_ty_55 = _bindgen_ty_55::NDA_LLADDR;
-pub const NDA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::NDA_CACHEINFO;
-pub const NDA_PROBES: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROBES;
-pub const NDA_VLAN: _bindgen_ty_55 = _bindgen_ty_55::NDA_VLAN;
-pub const NDA_PORT: _bindgen_ty_55 = _bindgen_ty_55::NDA_PORT;
-pub const NDA_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_VNI;
-pub const NDA_IFINDEX: _bindgen_ty_55 = _bindgen_ty_55::NDA_IFINDEX;
-pub const NDA_MASTER: _bindgen_ty_55 = _bindgen_ty_55::NDA_MASTER;
-pub const NDA_LINK_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::NDA_LINK_NETNSID;
-pub const NDA_SRC_VNI: _bindgen_ty_55 = _bindgen_ty_55::NDA_SRC_VNI;
-pub const NDA_PROTOCOL: _bindgen_ty_55 = _bindgen_ty_55::NDA_PROTOCOL;
-pub const NDA_NH_ID: _bindgen_ty_55 = _bindgen_ty_55::NDA_NH_ID;
-pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_55 = _bindgen_ty_55::NDA_FDB_EXT_ATTRS;
-pub const NDA_FLAGS_EXT: _bindgen_ty_55 = _bindgen_ty_55::NDA_FLAGS_EXT;
-pub const NDA_NDM_STATE_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_STATE_MASK;
-pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_55 = _bindgen_ty_55::NDA_NDM_FLAGS_MASK;
-pub const __NDA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__NDA_MAX;
-pub const NDTPA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UNSPEC;
-pub const NDTPA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_IFINDEX;
-pub const NDTPA_REFCNT: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REFCNT;
-pub const NDTPA_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_REACHABLE_TIME;
-pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_BASE_REACHABLE_TIME;
-pub const NDTPA_RETRANS_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_RETRANS_TIME;
-pub const NDTPA_GC_STALETIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_GC_STALETIME;
-pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_DELAY_PROBE_TIME;
-pub const NDTPA_QUEUE_LEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LEN;
-pub const NDTPA_APP_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_APP_PROBES;
-pub const NDTPA_UCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_UCAST_PROBES;
-pub const NDTPA_MCAST_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_PROBES;
-pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_ANYCAST_DELAY;
-pub const NDTPA_PROXY_DELAY: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_DELAY;
-pub const NDTPA_PROXY_QLEN: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PROXY_QLEN;
-pub const NDTPA_LOCKTIME: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_LOCKTIME;
-pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_QUEUE_LENBYTES;
-pub const NDTPA_MCAST_REPROBES: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_MCAST_REPROBES;
-pub const NDTPA_PAD: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_PAD;
-pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_56 = _bindgen_ty_56::NDTPA_INTERVAL_PROBE_TIME_MS;
-pub const __NDTPA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDTPA_MAX;
-pub const NDTA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTA_UNSPEC;
-pub const NDTA_NAME: _bindgen_ty_57 = _bindgen_ty_57::NDTA_NAME;
-pub const NDTA_THRESH1: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH1;
-pub const NDTA_THRESH2: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH2;
-pub const NDTA_THRESH3: _bindgen_ty_57 = _bindgen_ty_57::NDTA_THRESH3;
-pub const NDTA_CONFIG: _bindgen_ty_57 = _bindgen_ty_57::NDTA_CONFIG;
-pub const NDTA_PARMS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PARMS;
-pub const NDTA_STATS: _bindgen_ty_57 = _bindgen_ty_57::NDTA_STATS;
-pub const NDTA_GC_INTERVAL: _bindgen_ty_57 = _bindgen_ty_57::NDTA_GC_INTERVAL;
-pub const NDTA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTA_PAD;
-pub const __NDTA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTA_MAX;
-pub const FDB_NOTIFY_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_BIT;
-pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_58 = _bindgen_ty_58::FDB_NOTIFY_INACTIVE_BIT;
-pub const NFEA_UNSPEC: _bindgen_ty_59 = _bindgen_ty_59::NFEA_UNSPEC;
-pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_59 = _bindgen_ty_59::NFEA_ACTIVITY_NOTIFY;
-pub const NFEA_DONT_REFRESH: _bindgen_ty_59 = _bindgen_ty_59::NFEA_DONT_REFRESH;
-pub const __NFEA_MAX: _bindgen_ty_59 = _bindgen_ty_59::__NFEA_MAX;
-pub const RTM_BASE: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_NEWLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_BASE;
-pub const RTM_DELLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINK;
-pub const RTM_GETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINK;
-pub const RTM_SETLINK: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETLINK;
-pub const RTM_NEWADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDR;
-pub const RTM_DELADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDR;
-pub const RTM_GETADDR: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDR;
-pub const RTM_NEWROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWROUTE;
-pub const RTM_DELROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELROUTE;
-pub const RTM_GETROUTE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETROUTE;
-pub const RTM_NEWNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGH;
-pub const RTM_DELNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEIGH;
-pub const RTM_GETNEIGH: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGH;
-pub const RTM_NEWRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWRULE;
-pub const RTM_DELRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELRULE;
-pub const RTM_GETRULE: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETRULE;
-pub const RTM_NEWQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWQDISC;
-pub const RTM_DELQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELQDISC;
-pub const RTM_GETQDISC: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETQDISC;
-pub const RTM_NEWTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTCLASS;
-pub const RTM_DELTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTCLASS;
-pub const RTM_GETTCLASS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTCLASS;
-pub const RTM_NEWTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTFILTER;
-pub const RTM_DELTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTFILTER;
-pub const RTM_GETTFILTER: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTFILTER;
-pub const RTM_NEWACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWACTION;
-pub const RTM_DELACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELACTION;
-pub const RTM_GETACTION: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETACTION;
-pub const RTM_NEWPREFIX: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWPREFIX;
-pub const RTM_GETMULTICAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMULTICAST;
-pub const RTM_GETANYCAST: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETANYCAST;
-pub const RTM_NEWNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEIGHTBL;
-pub const RTM_GETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEIGHTBL;
-pub const RTM_SETNEIGHTBL: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETNEIGHTBL;
-pub const RTM_NEWNDUSEROPT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNDUSEROPT;
-pub const RTM_NEWADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWADDRLABEL;
-pub const RTM_DELADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELADDRLABEL;
-pub const RTM_GETADDRLABEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETADDRLABEL;
-pub const RTM_GETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETDCB;
-pub const RTM_SETDCB: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETDCB;
-pub const RTM_NEWNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNETCONF;
-pub const RTM_DELNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNETCONF;
-pub const RTM_GETNETCONF: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNETCONF;
-pub const RTM_NEWMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWMDB;
-pub const RTM_DELMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELMDB;
-pub const RTM_GETMDB: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETMDB;
-pub const RTM_NEWNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNSID;
-pub const RTM_DELNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNSID;
-pub const RTM_GETNSID: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNSID;
-pub const RTM_NEWSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWSTATS;
-pub const RTM_GETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETSTATS;
-pub const RTM_SETSTATS: _bindgen_ty_60 = _bindgen_ty_60::RTM_SETSTATS;
-pub const RTM_NEWCACHEREPORT: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCACHEREPORT;
-pub const RTM_NEWCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWCHAIN;
-pub const RTM_DELCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELCHAIN;
-pub const RTM_GETCHAIN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETCHAIN;
-pub const RTM_NEWNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOP;
-pub const RTM_DELNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOP;
-pub const RTM_GETNEXTHOP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOP;
-pub const RTM_NEWLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWLINKPROP;
-pub const RTM_DELLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELLINKPROP;
-pub const RTM_GETLINKPROP: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETLINKPROP;
-pub const RTM_NEWVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWVLAN;
-pub const RTM_DELVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELVLAN;
-pub const RTM_GETVLAN: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETVLAN;
-pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWNEXTHOPBUCKET;
-pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELNEXTHOPBUCKET;
-pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETNEXTHOPBUCKET;
-pub const RTM_NEWTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_NEWTUNNEL;
-pub const RTM_DELTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_DELTUNNEL;
-pub const RTM_GETTUNNEL: _bindgen_ty_60 = _bindgen_ty_60::RTM_GETTUNNEL;
-pub const __RTM_MAX: _bindgen_ty_60 = _bindgen_ty_60::__RTM_MAX;
-pub const RTN_UNSPEC: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNSPEC;
-pub const RTN_UNICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNICAST;
-pub const RTN_LOCAL: _bindgen_ty_61 = _bindgen_ty_61::RTN_LOCAL;
-pub const RTN_BROADCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_BROADCAST;
-pub const RTN_ANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_ANYCAST;
-pub const RTN_MULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTN_MULTICAST;
-pub const RTN_BLACKHOLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_BLACKHOLE;
-pub const RTN_UNREACHABLE: _bindgen_ty_61 = _bindgen_ty_61::RTN_UNREACHABLE;
-pub const RTN_PROHIBIT: _bindgen_ty_61 = _bindgen_ty_61::RTN_PROHIBIT;
-pub const RTN_THROW: _bindgen_ty_61 = _bindgen_ty_61::RTN_THROW;
-pub const RTN_NAT: _bindgen_ty_61 = _bindgen_ty_61::RTN_NAT;
-pub const RTN_XRESOLVE: _bindgen_ty_61 = _bindgen_ty_61::RTN_XRESOLVE;
-pub const __RTN_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTN_MAX;
-pub const RTAX_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTAX_UNSPEC;
-pub const RTAX_LOCK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_LOCK;
-pub const RTAX_MTU: _bindgen_ty_62 = _bindgen_ty_62::RTAX_MTU;
-pub const RTAX_WINDOW: _bindgen_ty_62 = _bindgen_ty_62::RTAX_WINDOW;
-pub const RTAX_RTT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTT;
-pub const RTAX_RTTVAR: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTTVAR;
-pub const RTAX_SSTHRESH: _bindgen_ty_62 = _bindgen_ty_62::RTAX_SSTHRESH;
-pub const RTAX_CWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CWND;
-pub const RTAX_ADVMSS: _bindgen_ty_62 = _bindgen_ty_62::RTAX_ADVMSS;
-pub const RTAX_REORDERING: _bindgen_ty_62 = _bindgen_ty_62::RTAX_REORDERING;
-pub const RTAX_HOPLIMIT: _bindgen_ty_62 = _bindgen_ty_62::RTAX_HOPLIMIT;
-pub const RTAX_INITCWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITCWND;
-pub const RTAX_FEATURES: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FEATURES;
-pub const RTAX_RTO_MIN: _bindgen_ty_62 = _bindgen_ty_62::RTAX_RTO_MIN;
-pub const RTAX_INITRWND: _bindgen_ty_62 = _bindgen_ty_62::RTAX_INITRWND;
-pub const RTAX_QUICKACK: _bindgen_ty_62 = _bindgen_ty_62::RTAX_QUICKACK;
-pub const RTAX_CC_ALGO: _bindgen_ty_62 = _bindgen_ty_62::RTAX_CC_ALGO;
-pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_62 = _bindgen_ty_62::RTAX_FASTOPEN_NO_COOKIE;
-pub const __RTAX_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTAX_MAX;
-pub const PREFIX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_UNSPEC;
-pub const PREFIX_ADDRESS: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_ADDRESS;
-pub const PREFIX_CACHEINFO: _bindgen_ty_63 = _bindgen_ty_63::PREFIX_CACHEINFO;
-pub const __PREFIX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__PREFIX_MAX;
-pub const TCA_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::TCA_UNSPEC;
-pub const TCA_KIND: _bindgen_ty_64 = _bindgen_ty_64::TCA_KIND;
-pub const TCA_OPTIONS: _bindgen_ty_64 = _bindgen_ty_64::TCA_OPTIONS;
-pub const TCA_STATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS;
-pub const TCA_XSTATS: _bindgen_ty_64 = _bindgen_ty_64::TCA_XSTATS;
-pub const TCA_RATE: _bindgen_ty_64 = _bindgen_ty_64::TCA_RATE;
-pub const TCA_FCNT: _bindgen_ty_64 = _bindgen_ty_64::TCA_FCNT;
-pub const TCA_STATS2: _bindgen_ty_64 = _bindgen_ty_64::TCA_STATS2;
-pub const TCA_STAB: _bindgen_ty_64 = _bindgen_ty_64::TCA_STAB;
-pub const TCA_PAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_PAD;
-pub const TCA_DUMP_INVISIBLE: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_INVISIBLE;
-pub const TCA_CHAIN: _bindgen_ty_64 = _bindgen_ty_64::TCA_CHAIN;
-pub const TCA_HW_OFFLOAD: _bindgen_ty_64 = _bindgen_ty_64::TCA_HW_OFFLOAD;
-pub const TCA_INGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_INGRESS_BLOCK;
-pub const TCA_EGRESS_BLOCK: _bindgen_ty_64 = _bindgen_ty_64::TCA_EGRESS_BLOCK;
-pub const TCA_DUMP_FLAGS: _bindgen_ty_64 = _bindgen_ty_64::TCA_DUMP_FLAGS;
-pub const TCA_EXT_WARN_MSG: _bindgen_ty_64 = _bindgen_ty_64::TCA_EXT_WARN_MSG;
-pub const __TCA_MAX: _bindgen_ty_64 = _bindgen_ty_64::__TCA_MAX;
-pub const NDUSEROPT_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_UNSPEC;
-pub const NDUSEROPT_SRCADDR: _bindgen_ty_65 = _bindgen_ty_65::NDUSEROPT_SRCADDR;
-pub const __NDUSEROPT_MAX: _bindgen_ty_65 = _bindgen_ty_65::__NDUSEROPT_MAX;
-pub const TCA_ROOT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_UNSPEC;
-pub const TCA_ROOT_TAB: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TAB;
-pub const TCA_ROOT_FLAGS: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_FLAGS;
-pub const TCA_ROOT_COUNT: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_COUNT;
-pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_TIME_DELTA;
-pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_66 = _bindgen_ty_66::TCA_ROOT_EXT_WARN_MSG;
-pub const __TCA_ROOT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__TCA_ROOT_MAX;
+pub const IFLA_NETKIT_UNSPEC: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_UNSPEC;
+pub const IFLA_NETKIT_PEER_INFO: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_INFO;
+pub const IFLA_NETKIT_PRIMARY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PRIMARY;
+pub const IFLA_NETKIT_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_POLICY;
+pub const IFLA_NETKIT_PEER_POLICY: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_PEER_POLICY;
+pub const IFLA_NETKIT_MODE: _bindgen_ty_18 = _bindgen_ty_18::IFLA_NETKIT_MODE;
+pub const __IFLA_NETKIT_MAX: _bindgen_ty_18 = _bindgen_ty_18::__IFLA_NETKIT_MAX;
+pub const VNIFILTER_ENTRY_STATS_UNSPEC: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_UNSPEC;
+pub const VNIFILTER_ENTRY_STATS_RX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_RX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_RX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_RX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_RX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_TX_BYTES: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_BYTES;
+pub const VNIFILTER_ENTRY_STATS_TX_PKTS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_PKTS;
+pub const VNIFILTER_ENTRY_STATS_TX_DROPS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_DROPS;
+pub const VNIFILTER_ENTRY_STATS_TX_ERRORS: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_TX_ERRORS;
+pub const VNIFILTER_ENTRY_STATS_PAD: _bindgen_ty_19 = _bindgen_ty_19::VNIFILTER_ENTRY_STATS_PAD;
+pub const __VNIFILTER_ENTRY_STATS_MAX: _bindgen_ty_19 = _bindgen_ty_19::__VNIFILTER_ENTRY_STATS_MAX;
+pub const VXLAN_VNIFILTER_ENTRY_UNSPEC: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY_START: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_START;
+pub const VXLAN_VNIFILTER_ENTRY_END: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_END;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP;
+pub const VXLAN_VNIFILTER_ENTRY_GROUP6: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_GROUP6;
+pub const VXLAN_VNIFILTER_ENTRY_STATS: _bindgen_ty_20 = _bindgen_ty_20::VXLAN_VNIFILTER_ENTRY_STATS;
+pub const __VXLAN_VNIFILTER_ENTRY_MAX: _bindgen_ty_20 = _bindgen_ty_20::__VXLAN_VNIFILTER_ENTRY_MAX;
+pub const VXLAN_VNIFILTER_UNSPEC: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_UNSPEC;
+pub const VXLAN_VNIFILTER_ENTRY: _bindgen_ty_21 = _bindgen_ty_21::VXLAN_VNIFILTER_ENTRY;
+pub const __VXLAN_VNIFILTER_MAX: _bindgen_ty_21 = _bindgen_ty_21::__VXLAN_VNIFILTER_MAX;
+pub const IFLA_VXLAN_UNSPEC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UNSPEC;
+pub const IFLA_VXLAN_ID: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_ID;
+pub const IFLA_VXLAN_GROUP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP;
+pub const IFLA_VXLAN_LINK: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LINK;
+pub const IFLA_VXLAN_LOCAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL;
+pub const IFLA_VXLAN_TTL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL;
+pub const IFLA_VXLAN_TOS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TOS;
+pub const IFLA_VXLAN_LEARNING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LEARNING;
+pub const IFLA_VXLAN_AGEING: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_AGEING;
+pub const IFLA_VXLAN_LIMIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LIMIT;
+pub const IFLA_VXLAN_PORT_RANGE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT_RANGE;
+pub const IFLA_VXLAN_PROXY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PROXY;
+pub const IFLA_VXLAN_RSC: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_RSC;
+pub const IFLA_VXLAN_L2MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L2MISS;
+pub const IFLA_VXLAN_L3MISS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_L3MISS;
+pub const IFLA_VXLAN_PORT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_PORT;
+pub const IFLA_VXLAN_GROUP6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GROUP6;
+pub const IFLA_VXLAN_LOCAL6: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCAL6;
+pub const IFLA_VXLAN_UDP_CSUM: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_CSUM;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_TX;
+pub const IFLA_VXLAN_UDP_ZERO_CSUM6_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_UDP_ZERO_CSUM6_RX;
+pub const IFLA_VXLAN_REMCSUM_TX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_TX;
+pub const IFLA_VXLAN_REMCSUM_RX: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_RX;
+pub const IFLA_VXLAN_GBP: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GBP;
+pub const IFLA_VXLAN_REMCSUM_NOPARTIAL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_REMCSUM_NOPARTIAL;
+pub const IFLA_VXLAN_COLLECT_METADATA: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_COLLECT_METADATA;
+pub const IFLA_VXLAN_LABEL: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL;
+pub const IFLA_VXLAN_GPE: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_GPE;
+pub const IFLA_VXLAN_TTL_INHERIT: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_TTL_INHERIT;
+pub const IFLA_VXLAN_DF: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_DF;
+pub const IFLA_VXLAN_VNIFILTER: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_VNIFILTER;
+pub const IFLA_VXLAN_LOCALBYPASS: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LOCALBYPASS;
+pub const IFLA_VXLAN_LABEL_POLICY: _bindgen_ty_22 = _bindgen_ty_22::IFLA_VXLAN_LABEL_POLICY;
+pub const __IFLA_VXLAN_MAX: _bindgen_ty_22 = _bindgen_ty_22::__IFLA_VXLAN_MAX;
+pub const IFLA_GENEVE_UNSPEC: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UNSPEC;
+pub const IFLA_GENEVE_ID: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_ID;
+pub const IFLA_GENEVE_REMOTE: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE;
+pub const IFLA_GENEVE_TTL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL;
+pub const IFLA_GENEVE_TOS: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TOS;
+pub const IFLA_GENEVE_PORT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_PORT;
+pub const IFLA_GENEVE_COLLECT_METADATA: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_COLLECT_METADATA;
+pub const IFLA_GENEVE_REMOTE6: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_REMOTE6;
+pub const IFLA_GENEVE_UDP_CSUM: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_CSUM;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_TX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_TX;
+pub const IFLA_GENEVE_UDP_ZERO_CSUM6_RX: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_UDP_ZERO_CSUM6_RX;
+pub const IFLA_GENEVE_LABEL: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_LABEL;
+pub const IFLA_GENEVE_TTL_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_TTL_INHERIT;
+pub const IFLA_GENEVE_DF: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_DF;
+pub const IFLA_GENEVE_INNER_PROTO_INHERIT: _bindgen_ty_23 = _bindgen_ty_23::IFLA_GENEVE_INNER_PROTO_INHERIT;
+pub const __IFLA_GENEVE_MAX: _bindgen_ty_23 = _bindgen_ty_23::__IFLA_GENEVE_MAX;
+pub const IFLA_BAREUDP_UNSPEC: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_UNSPEC;
+pub const IFLA_BAREUDP_PORT: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_PORT;
+pub const IFLA_BAREUDP_ETHERTYPE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_ETHERTYPE;
+pub const IFLA_BAREUDP_SRCPORT_MIN: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_SRCPORT_MIN;
+pub const IFLA_BAREUDP_MULTIPROTO_MODE: _bindgen_ty_24 = _bindgen_ty_24::IFLA_BAREUDP_MULTIPROTO_MODE;
+pub const __IFLA_BAREUDP_MAX: _bindgen_ty_24 = _bindgen_ty_24::__IFLA_BAREUDP_MAX;
+pub const IFLA_PPP_UNSPEC: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_UNSPEC;
+pub const IFLA_PPP_DEV_FD: _bindgen_ty_25 = _bindgen_ty_25::IFLA_PPP_DEV_FD;
+pub const __IFLA_PPP_MAX: _bindgen_ty_25 = _bindgen_ty_25::__IFLA_PPP_MAX;
+pub const IFLA_GTP_UNSPEC: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_UNSPEC;
+pub const IFLA_GTP_FD0: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD0;
+pub const IFLA_GTP_FD1: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_FD1;
+pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_HASHSIZE;
+pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
+pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
+pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
+pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
+pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
+pub const IFLA_BOND_ACTIVE_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ACTIVE_SLAVE;
+pub const IFLA_BOND_MIIMON: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIIMON;
+pub const IFLA_BOND_UPDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UPDELAY;
+pub const IFLA_BOND_DOWNDELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_DOWNDELAY;
+pub const IFLA_BOND_USE_CARRIER: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_USE_CARRIER;
+pub const IFLA_BOND_ARP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_INTERVAL;
+pub const IFLA_BOND_ARP_IP_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_IP_TARGET;
+pub const IFLA_BOND_ARP_VALIDATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_VALIDATE;
+pub const IFLA_BOND_ARP_ALL_TARGETS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ARP_ALL_TARGETS;
+pub const IFLA_BOND_PRIMARY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY;
+pub const IFLA_BOND_PRIMARY_RESELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PRIMARY_RESELECT;
+pub const IFLA_BOND_FAIL_OVER_MAC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_FAIL_OVER_MAC;
+pub const IFLA_BOND_XMIT_HASH_POLICY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_XMIT_HASH_POLICY;
+pub const IFLA_BOND_RESEND_IGMP: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_RESEND_IGMP;
+pub const IFLA_BOND_NUM_PEER_NOTIF: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NUM_PEER_NOTIF;
+pub const IFLA_BOND_ALL_SLAVES_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_ALL_SLAVES_ACTIVE;
+pub const IFLA_BOND_MIN_LINKS: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MIN_LINKS;
+pub const IFLA_BOND_LP_INTERVAL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_LP_INTERVAL;
+pub const IFLA_BOND_PACKETS_PER_SLAVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PACKETS_PER_SLAVE;
+pub const IFLA_BOND_AD_LACP_RATE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_RATE;
+pub const IFLA_BOND_AD_SELECT: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_SELECT;
+pub const IFLA_BOND_AD_INFO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_INFO;
+pub const IFLA_BOND_AD_ACTOR_SYS_PRIO: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYS_PRIO;
+pub const IFLA_BOND_AD_USER_PORT_KEY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_USER_PORT_KEY;
+pub const IFLA_BOND_AD_ACTOR_SYSTEM: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_ACTOR_SYSTEM;
+pub const IFLA_BOND_TLB_DYNAMIC_LB: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_TLB_DYNAMIC_LB;
+pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_PEER_NOTIF_DELAY;
+pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
+pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
+pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
+pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
+pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
+pub const IFLA_BOND_AD_INFO_NUM_PORTS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_NUM_PORTS;
+pub const IFLA_BOND_AD_INFO_ACTOR_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_ACTOR_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_KEY: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_KEY;
+pub const IFLA_BOND_AD_INFO_PARTNER_MAC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_PARTNER_MAC;
+pub const __IFLA_BOND_AD_INFO_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_BOND_AD_INFO_MAX;
+pub const IFLA_BOND_SLAVE_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_UNSPEC;
+pub const IFLA_BOND_SLAVE_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_STATE;
+pub const IFLA_BOND_SLAVE_MII_STATUS: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_MII_STATUS;
+pub const IFLA_BOND_SLAVE_LINK_FAILURE_COUNT: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_LINK_FAILURE_COUNT;
+pub const IFLA_BOND_SLAVE_PERM_HWADDR: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PERM_HWADDR;
+pub const IFLA_BOND_SLAVE_QUEUE_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_QUEUE_ID;
+pub const IFLA_BOND_SLAVE_AD_AGGREGATOR_ID: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_AGGREGATOR_ID;
+pub const IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE;
+pub const IFLA_BOND_SLAVE_PRIO: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_SLAVE_PRIO;
+pub const __IFLA_BOND_SLAVE_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_SLAVE_MAX;
+pub const IFLA_VF_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO_UNSPEC;
+pub const IFLA_VF_INFO: _bindgen_ty_30 = _bindgen_ty_30::IFLA_VF_INFO;
+pub const __IFLA_VF_INFO_MAX: _bindgen_ty_30 = _bindgen_ty_30::__IFLA_VF_INFO_MAX;
+pub const IFLA_VF_UNSPEC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_UNSPEC;
+pub const IFLA_VF_MAC: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_MAC;
+pub const IFLA_VF_VLAN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN;
+pub const IFLA_VF_TX_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TX_RATE;
+pub const IFLA_VF_SPOOFCHK: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_SPOOFCHK;
+pub const IFLA_VF_LINK_STATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_LINK_STATE;
+pub const IFLA_VF_RATE: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RATE;
+pub const IFLA_VF_RSS_QUERY_EN: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_RSS_QUERY_EN;
+pub const IFLA_VF_STATS: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_STATS;
+pub const IFLA_VF_TRUST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_TRUST;
+pub const IFLA_VF_IB_NODE_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_NODE_GUID;
+pub const IFLA_VF_IB_PORT_GUID: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_IB_PORT_GUID;
+pub const IFLA_VF_VLAN_LIST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_VLAN_LIST;
+pub const IFLA_VF_BROADCAST: _bindgen_ty_31 = _bindgen_ty_31::IFLA_VF_BROADCAST;
+pub const __IFLA_VF_MAX: _bindgen_ty_31 = _bindgen_ty_31::__IFLA_VF_MAX;
+pub const IFLA_VF_VLAN_INFO_UNSPEC: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO_UNSPEC;
+pub const IFLA_VF_VLAN_INFO: _bindgen_ty_32 = _bindgen_ty_32::IFLA_VF_VLAN_INFO;
+pub const __IFLA_VF_VLAN_INFO_MAX: _bindgen_ty_32 = _bindgen_ty_32::__IFLA_VF_VLAN_INFO_MAX;
+pub const IFLA_VF_LINK_STATE_AUTO: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_AUTO;
+pub const IFLA_VF_LINK_STATE_ENABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_ENABLE;
+pub const IFLA_VF_LINK_STATE_DISABLE: _bindgen_ty_33 = _bindgen_ty_33::IFLA_VF_LINK_STATE_DISABLE;
+pub const __IFLA_VF_LINK_STATE_MAX: _bindgen_ty_33 = _bindgen_ty_33::__IFLA_VF_LINK_STATE_MAX;
+pub const IFLA_VF_STATS_RX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_PACKETS;
+pub const IFLA_VF_STATS_TX_PACKETS: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_PACKETS;
+pub const IFLA_VF_STATS_RX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_BYTES;
+pub const IFLA_VF_STATS_TX_BYTES: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_BYTES;
+pub const IFLA_VF_STATS_BROADCAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_BROADCAST;
+pub const IFLA_VF_STATS_MULTICAST: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_MULTICAST;
+pub const IFLA_VF_STATS_PAD: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_PAD;
+pub const IFLA_VF_STATS_RX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_RX_DROPPED;
+pub const IFLA_VF_STATS_TX_DROPPED: _bindgen_ty_34 = _bindgen_ty_34::IFLA_VF_STATS_TX_DROPPED;
+pub const __IFLA_VF_STATS_MAX: _bindgen_ty_34 = _bindgen_ty_34::__IFLA_VF_STATS_MAX;
+pub const IFLA_VF_PORT_UNSPEC: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT_UNSPEC;
+pub const IFLA_VF_PORT: _bindgen_ty_35 = _bindgen_ty_35::IFLA_VF_PORT;
+pub const __IFLA_VF_PORT_MAX: _bindgen_ty_35 = _bindgen_ty_35::__IFLA_VF_PORT_MAX;
+pub const IFLA_PORT_UNSPEC: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_UNSPEC;
+pub const IFLA_PORT_VF: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VF;
+pub const IFLA_PORT_PROFILE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_PROFILE;
+pub const IFLA_PORT_VSI_TYPE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_VSI_TYPE;
+pub const IFLA_PORT_INSTANCE_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_INSTANCE_UUID;
+pub const IFLA_PORT_HOST_UUID: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_HOST_UUID;
+pub const IFLA_PORT_REQUEST: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_REQUEST;
+pub const IFLA_PORT_RESPONSE: _bindgen_ty_36 = _bindgen_ty_36::IFLA_PORT_RESPONSE;
+pub const __IFLA_PORT_MAX: _bindgen_ty_36 = _bindgen_ty_36::__IFLA_PORT_MAX;
+pub const PORT_REQUEST_PREASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE;
+pub const PORT_REQUEST_PREASSOCIATE_RR: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_PREASSOCIATE_RR;
+pub const PORT_REQUEST_ASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_ASSOCIATE;
+pub const PORT_REQUEST_DISASSOCIATE: _bindgen_ty_37 = _bindgen_ty_37::PORT_REQUEST_DISASSOCIATE;
+pub const PORT_VDP_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_SUCCESS;
+pub const PORT_VDP_RESPONSE_INVALID_FORMAT: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INVALID_FORMAT;
+pub const PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_VDP_RESPONSE_UNUSED_VTID: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_UNUSED_VTID;
+pub const PORT_VDP_RESPONSE_VTID_VIOLATION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VIOLATION;
+pub const PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_VTID_VERSION_VIOALTION;
+pub const PORT_VDP_RESPONSE_OUT_OF_SYNC: _bindgen_ty_38 = _bindgen_ty_38::PORT_VDP_RESPONSE_OUT_OF_SYNC;
+pub const PORT_PROFILE_RESPONSE_SUCCESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_SUCCESS;
+pub const PORT_PROFILE_RESPONSE_INPROGRESS: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INPROGRESS;
+pub const PORT_PROFILE_RESPONSE_INVALID: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INVALID;
+pub const PORT_PROFILE_RESPONSE_BADSTATE: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_BADSTATE;
+pub const PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_INSUFFICIENT_RESOURCES;
+pub const PORT_PROFILE_RESPONSE_ERROR: _bindgen_ty_38 = _bindgen_ty_38::PORT_PROFILE_RESPONSE_ERROR;
+pub const IFLA_IPOIB_UNSPEC: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UNSPEC;
+pub const IFLA_IPOIB_PKEY: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_PKEY;
+pub const IFLA_IPOIB_MODE: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_MODE;
+pub const IFLA_IPOIB_UMCAST: _bindgen_ty_39 = _bindgen_ty_39::IFLA_IPOIB_UMCAST;
+pub const __IFLA_IPOIB_MAX: _bindgen_ty_39 = _bindgen_ty_39::__IFLA_IPOIB_MAX;
+pub const IPOIB_MODE_DATAGRAM: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_DATAGRAM;
+pub const IPOIB_MODE_CONNECTED: _bindgen_ty_40 = _bindgen_ty_40::IPOIB_MODE_CONNECTED;
+pub const HSR_PROTOCOL_HSR: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_HSR;
+pub const HSR_PROTOCOL_PRP: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_PRP;
+pub const HSR_PROTOCOL_MAX: _bindgen_ty_41 = _bindgen_ty_41::HSR_PROTOCOL_MAX;
+pub const IFLA_HSR_UNSPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_UNSPEC;
+pub const IFLA_HSR_SLAVE1: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE1;
+pub const IFLA_HSR_SLAVE2: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SLAVE2;
+pub const IFLA_HSR_MULTICAST_SPEC: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_MULTICAST_SPEC;
+pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SUPERVISION_ADDR;
+pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
+pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
+pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
+pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
+pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
+pub const IFLA_STATS_LINK_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS;
+pub const IFLA_STATS_LINK_XSTATS_SLAVE: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_XSTATS_SLAVE;
+pub const IFLA_STATS_LINK_OFFLOAD_XSTATS: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_OFFLOAD_XSTATS;
+pub const IFLA_STATS_AF_SPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_AF_SPEC;
+pub const __IFLA_STATS_MAX: _bindgen_ty_43 = _bindgen_ty_43::__IFLA_STATS_MAX;
+pub const IFLA_STATS_GETSET_UNSPEC: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GETSET_UNSPEC;
+pub const IFLA_STATS_GET_FILTERS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_GET_FILTERS;
+pub const IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_44 = _bindgen_ty_44::IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_STATS_GETSET_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_STATS_GETSET_MAX;
+pub const LINK_XSTATS_TYPE_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_UNSPEC;
+pub const LINK_XSTATS_TYPE_BRIDGE: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BRIDGE;
+pub const LINK_XSTATS_TYPE_BOND: _bindgen_ty_45 = _bindgen_ty_45::LINK_XSTATS_TYPE_BOND;
+pub const __LINK_XSTATS_TYPE_MAX: _bindgen_ty_45 = _bindgen_ty_45::__LINK_XSTATS_TYPE_MAX;
+pub const IFLA_OFFLOAD_XSTATS_UNSPEC: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_CPU_HIT: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_CPU_HIT;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_HW_S_INFO;
+pub const IFLA_OFFLOAD_XSTATS_L3_STATS: _bindgen_ty_46 = _bindgen_ty_46::IFLA_OFFLOAD_XSTATS_L3_STATS;
+pub const __IFLA_OFFLOAD_XSTATS_MAX: _bindgen_ty_46 = _bindgen_ty_46::__IFLA_OFFLOAD_XSTATS_MAX;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST;
+pub const IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED: _bindgen_ty_47 = _bindgen_ty_47::IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED;
+pub const __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX: _bindgen_ty_47 = _bindgen_ty_47::__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX;
+pub const XDP_ATTACHED_NONE: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_NONE;
+pub const XDP_ATTACHED_DRV: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_DRV;
+pub const XDP_ATTACHED_SKB: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_SKB;
+pub const XDP_ATTACHED_HW: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_HW;
+pub const XDP_ATTACHED_MULTI: _bindgen_ty_48 = _bindgen_ty_48::XDP_ATTACHED_MULTI;
+pub const IFLA_XDP_UNSPEC: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_UNSPEC;
+pub const IFLA_XDP_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FD;
+pub const IFLA_XDP_ATTACHED: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_ATTACHED;
+pub const IFLA_XDP_FLAGS: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_FLAGS;
+pub const IFLA_XDP_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_PROG_ID;
+pub const IFLA_XDP_DRV_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_DRV_PROG_ID;
+pub const IFLA_XDP_SKB_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_SKB_PROG_ID;
+pub const IFLA_XDP_HW_PROG_ID: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_HW_PROG_ID;
+pub const IFLA_XDP_EXPECTED_FD: _bindgen_ty_49 = _bindgen_ty_49::IFLA_XDP_EXPECTED_FD;
+pub const __IFLA_XDP_MAX: _bindgen_ty_49 = _bindgen_ty_49::__IFLA_XDP_MAX;
+pub const IFLA_EVENT_NONE: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NONE;
+pub const IFLA_EVENT_REBOOT: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_REBOOT;
+pub const IFLA_EVENT_FEATURES: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_FEATURES;
+pub const IFLA_EVENT_BONDING_FAILOVER: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_FAILOVER;
+pub const IFLA_EVENT_NOTIFY_PEERS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_NOTIFY_PEERS;
+pub const IFLA_EVENT_IGMP_RESEND: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_IGMP_RESEND;
+pub const IFLA_EVENT_BONDING_OPTIONS: _bindgen_ty_50 = _bindgen_ty_50::IFLA_EVENT_BONDING_OPTIONS;
+pub const IFLA_TUN_UNSPEC: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_UNSPEC;
+pub const IFLA_TUN_OWNER: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_OWNER;
+pub const IFLA_TUN_GROUP: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_GROUP;
+pub const IFLA_TUN_TYPE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_TYPE;
+pub const IFLA_TUN_PI: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PI;
+pub const IFLA_TUN_VNET_HDR: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_VNET_HDR;
+pub const IFLA_TUN_PERSIST: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_PERSIST;
+pub const IFLA_TUN_MULTI_QUEUE: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_MULTI_QUEUE;
+pub const IFLA_TUN_NUM_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_QUEUES;
+pub const IFLA_TUN_NUM_DISABLED_QUEUES: _bindgen_ty_51 = _bindgen_ty_51::IFLA_TUN_NUM_DISABLED_QUEUES;
+pub const __IFLA_TUN_MAX: _bindgen_ty_51 = _bindgen_ty_51::__IFLA_TUN_MAX;
+pub const IFLA_RMNET_UNSPEC: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_UNSPEC;
+pub const IFLA_RMNET_MUX_ID: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_MUX_ID;
+pub const IFLA_RMNET_FLAGS: _bindgen_ty_52 = _bindgen_ty_52::IFLA_RMNET_FLAGS;
+pub const __IFLA_RMNET_MAX: _bindgen_ty_52 = _bindgen_ty_52::__IFLA_RMNET_MAX;
+pub const IFLA_MCTP_UNSPEC: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_UNSPEC;
+pub const IFLA_MCTP_NET: _bindgen_ty_53 = _bindgen_ty_53::IFLA_MCTP_NET;
+pub const __IFLA_MCTP_MAX: _bindgen_ty_53 = _bindgen_ty_53::__IFLA_MCTP_MAX;
+pub const IFLA_DSA_UNSPEC: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_UNSPEC;
+pub const IFLA_DSA_CONDUIT: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const IFLA_DSA_MASTER: _bindgen_ty_54 = _bindgen_ty_54::IFLA_DSA_CONDUIT;
+pub const __IFLA_DSA_MAX: _bindgen_ty_54 = _bindgen_ty_54::__IFLA_DSA_MAX;
+pub const IFA_UNSPEC: _bindgen_ty_55 = _bindgen_ty_55::IFA_UNSPEC;
+pub const IFA_ADDRESS: _bindgen_ty_55 = _bindgen_ty_55::IFA_ADDRESS;
+pub const IFA_LOCAL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LOCAL;
+pub const IFA_LABEL: _bindgen_ty_55 = _bindgen_ty_55::IFA_LABEL;
+pub const IFA_BROADCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_BROADCAST;
+pub const IFA_ANYCAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_ANYCAST;
+pub const IFA_CACHEINFO: _bindgen_ty_55 = _bindgen_ty_55::IFA_CACHEINFO;
+pub const IFA_MULTICAST: _bindgen_ty_55 = _bindgen_ty_55::IFA_MULTICAST;
+pub const IFA_FLAGS: _bindgen_ty_55 = _bindgen_ty_55::IFA_FLAGS;
+pub const IFA_RT_PRIORITY: _bindgen_ty_55 = _bindgen_ty_55::IFA_RT_PRIORITY;
+pub const IFA_TARGET_NETNSID: _bindgen_ty_55 = _bindgen_ty_55::IFA_TARGET_NETNSID;
+pub const IFA_PROTO: _bindgen_ty_55 = _bindgen_ty_55::IFA_PROTO;
+pub const __IFA_MAX: _bindgen_ty_55 = _bindgen_ty_55::__IFA_MAX;
+pub const NDA_UNSPEC: _bindgen_ty_56 = _bindgen_ty_56::NDA_UNSPEC;
+pub const NDA_DST: _bindgen_ty_56 = _bindgen_ty_56::NDA_DST;
+pub const NDA_LLADDR: _bindgen_ty_56 = _bindgen_ty_56::NDA_LLADDR;
+pub const NDA_CACHEINFO: _bindgen_ty_56 = _bindgen_ty_56::NDA_CACHEINFO;
+pub const NDA_PROBES: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROBES;
+pub const NDA_VLAN: _bindgen_ty_56 = _bindgen_ty_56::NDA_VLAN;
+pub const NDA_PORT: _bindgen_ty_56 = _bindgen_ty_56::NDA_PORT;
+pub const NDA_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_VNI;
+pub const NDA_IFINDEX: _bindgen_ty_56 = _bindgen_ty_56::NDA_IFINDEX;
+pub const NDA_MASTER: _bindgen_ty_56 = _bindgen_ty_56::NDA_MASTER;
+pub const NDA_LINK_NETNSID: _bindgen_ty_56 = _bindgen_ty_56::NDA_LINK_NETNSID;
+pub const NDA_SRC_VNI: _bindgen_ty_56 = _bindgen_ty_56::NDA_SRC_VNI;
+pub const NDA_PROTOCOL: _bindgen_ty_56 = _bindgen_ty_56::NDA_PROTOCOL;
+pub const NDA_NH_ID: _bindgen_ty_56 = _bindgen_ty_56::NDA_NH_ID;
+pub const NDA_FDB_EXT_ATTRS: _bindgen_ty_56 = _bindgen_ty_56::NDA_FDB_EXT_ATTRS;
+pub const NDA_FLAGS_EXT: _bindgen_ty_56 = _bindgen_ty_56::NDA_FLAGS_EXT;
+pub const NDA_NDM_STATE_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_STATE_MASK;
+pub const NDA_NDM_FLAGS_MASK: _bindgen_ty_56 = _bindgen_ty_56::NDA_NDM_FLAGS_MASK;
+pub const __NDA_MAX: _bindgen_ty_56 = _bindgen_ty_56::__NDA_MAX;
+pub const NDTPA_UNSPEC: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UNSPEC;
+pub const NDTPA_IFINDEX: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_IFINDEX;
+pub const NDTPA_REFCNT: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REFCNT;
+pub const NDTPA_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_REACHABLE_TIME;
+pub const NDTPA_BASE_REACHABLE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_BASE_REACHABLE_TIME;
+pub const NDTPA_RETRANS_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_RETRANS_TIME;
+pub const NDTPA_GC_STALETIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_GC_STALETIME;
+pub const NDTPA_DELAY_PROBE_TIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_DELAY_PROBE_TIME;
+pub const NDTPA_QUEUE_LEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LEN;
+pub const NDTPA_APP_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_APP_PROBES;
+pub const NDTPA_UCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_UCAST_PROBES;
+pub const NDTPA_MCAST_PROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_PROBES;
+pub const NDTPA_ANYCAST_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_ANYCAST_DELAY;
+pub const NDTPA_PROXY_DELAY: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_DELAY;
+pub const NDTPA_PROXY_QLEN: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PROXY_QLEN;
+pub const NDTPA_LOCKTIME: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_LOCKTIME;
+pub const NDTPA_QUEUE_LENBYTES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_QUEUE_LENBYTES;
+pub const NDTPA_MCAST_REPROBES: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_MCAST_REPROBES;
+pub const NDTPA_PAD: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_PAD;
+pub const NDTPA_INTERVAL_PROBE_TIME_MS: _bindgen_ty_57 = _bindgen_ty_57::NDTPA_INTERVAL_PROBE_TIME_MS;
+pub const __NDTPA_MAX: _bindgen_ty_57 = _bindgen_ty_57::__NDTPA_MAX;
+pub const NDTA_UNSPEC: _bindgen_ty_58 = _bindgen_ty_58::NDTA_UNSPEC;
+pub const NDTA_NAME: _bindgen_ty_58 = _bindgen_ty_58::NDTA_NAME;
+pub const NDTA_THRESH1: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH1;
+pub const NDTA_THRESH2: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH2;
+pub const NDTA_THRESH3: _bindgen_ty_58 = _bindgen_ty_58::NDTA_THRESH3;
+pub const NDTA_CONFIG: _bindgen_ty_58 = _bindgen_ty_58::NDTA_CONFIG;
+pub const NDTA_PARMS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PARMS;
+pub const NDTA_STATS: _bindgen_ty_58 = _bindgen_ty_58::NDTA_STATS;
+pub const NDTA_GC_INTERVAL: _bindgen_ty_58 = _bindgen_ty_58::NDTA_GC_INTERVAL;
+pub const NDTA_PAD: _bindgen_ty_58 = _bindgen_ty_58::NDTA_PAD;
+pub const __NDTA_MAX: _bindgen_ty_58 = _bindgen_ty_58::__NDTA_MAX;
+pub const FDB_NOTIFY_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_BIT;
+pub const FDB_NOTIFY_INACTIVE_BIT: _bindgen_ty_59 = _bindgen_ty_59::FDB_NOTIFY_INACTIVE_BIT;
+pub const NFEA_UNSPEC: _bindgen_ty_60 = _bindgen_ty_60::NFEA_UNSPEC;
+pub const NFEA_ACTIVITY_NOTIFY: _bindgen_ty_60 = _bindgen_ty_60::NFEA_ACTIVITY_NOTIFY;
+pub const NFEA_DONT_REFRESH: _bindgen_ty_60 = _bindgen_ty_60::NFEA_DONT_REFRESH;
+pub const __NFEA_MAX: _bindgen_ty_60 = _bindgen_ty_60::__NFEA_MAX;
+pub const RTM_BASE: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_NEWLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_BASE;
+pub const RTM_DELLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINK;
+pub const RTM_GETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINK;
+pub const RTM_SETLINK: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETLINK;
+pub const RTM_NEWADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDR;
+pub const RTM_DELADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDR;
+pub const RTM_GETADDR: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDR;
+pub const RTM_NEWROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWROUTE;
+pub const RTM_DELROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELROUTE;
+pub const RTM_GETROUTE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETROUTE;
+pub const RTM_NEWNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGH;
+pub const RTM_DELNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEIGH;
+pub const RTM_GETNEIGH: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGH;
+pub const RTM_NEWRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWRULE;
+pub const RTM_DELRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELRULE;
+pub const RTM_GETRULE: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETRULE;
+pub const RTM_NEWQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWQDISC;
+pub const RTM_DELQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELQDISC;
+pub const RTM_GETQDISC: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETQDISC;
+pub const RTM_NEWTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTCLASS;
+pub const RTM_DELTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTCLASS;
+pub const RTM_GETTCLASS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTCLASS;
+pub const RTM_NEWTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTFILTER;
+pub const RTM_DELTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTFILTER;
+pub const RTM_GETTFILTER: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTFILTER;
+pub const RTM_NEWACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWACTION;
+pub const RTM_DELACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELACTION;
+pub const RTM_GETACTION: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETACTION;
+pub const RTM_NEWPREFIX: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWPREFIX;
+pub const RTM_GETMULTICAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMULTICAST;
+pub const RTM_GETANYCAST: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETANYCAST;
+pub const RTM_NEWNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEIGHTBL;
+pub const RTM_GETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEIGHTBL;
+pub const RTM_SETNEIGHTBL: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETNEIGHTBL;
+pub const RTM_NEWNDUSEROPT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNDUSEROPT;
+pub const RTM_NEWADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWADDRLABEL;
+pub const RTM_DELADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELADDRLABEL;
+pub const RTM_GETADDRLABEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETADDRLABEL;
+pub const RTM_GETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETDCB;
+pub const RTM_SETDCB: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETDCB;
+pub const RTM_NEWNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNETCONF;
+pub const RTM_DELNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNETCONF;
+pub const RTM_GETNETCONF: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNETCONF;
+pub const RTM_NEWMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWMDB;
+pub const RTM_DELMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELMDB;
+pub const RTM_GETMDB: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETMDB;
+pub const RTM_NEWNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNSID;
+pub const RTM_DELNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNSID;
+pub const RTM_GETNSID: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNSID;
+pub const RTM_NEWSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWSTATS;
+pub const RTM_GETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETSTATS;
+pub const RTM_SETSTATS: _bindgen_ty_61 = _bindgen_ty_61::RTM_SETSTATS;
+pub const RTM_NEWCACHEREPORT: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCACHEREPORT;
+pub const RTM_NEWCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWCHAIN;
+pub const RTM_DELCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELCHAIN;
+pub const RTM_GETCHAIN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETCHAIN;
+pub const RTM_NEWNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOP;
+pub const RTM_DELNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOP;
+pub const RTM_GETNEXTHOP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOP;
+pub const RTM_NEWLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWLINKPROP;
+pub const RTM_DELLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELLINKPROP;
+pub const RTM_GETLINKPROP: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETLINKPROP;
+pub const RTM_NEWVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWVLAN;
+pub const RTM_DELVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELVLAN;
+pub const RTM_GETVLAN: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETVLAN;
+pub const RTM_NEWNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWNEXTHOPBUCKET;
+pub const RTM_DELNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELNEXTHOPBUCKET;
+pub const RTM_GETNEXTHOPBUCKET: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETNEXTHOPBUCKET;
+pub const RTM_NEWTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_NEWTUNNEL;
+pub const RTM_DELTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_DELTUNNEL;
+pub const RTM_GETTUNNEL: _bindgen_ty_61 = _bindgen_ty_61::RTM_GETTUNNEL;
+pub const __RTM_MAX: _bindgen_ty_61 = _bindgen_ty_61::__RTM_MAX;
+pub const RTN_UNSPEC: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNSPEC;
+pub const RTN_UNICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNICAST;
+pub const RTN_LOCAL: _bindgen_ty_62 = _bindgen_ty_62::RTN_LOCAL;
+pub const RTN_BROADCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_BROADCAST;
+pub const RTN_ANYCAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_ANYCAST;
+pub const RTN_MULTICAST: _bindgen_ty_62 = _bindgen_ty_62::RTN_MULTICAST;
+pub const RTN_BLACKHOLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_BLACKHOLE;
+pub const RTN_UNREACHABLE: _bindgen_ty_62 = _bindgen_ty_62::RTN_UNREACHABLE;
+pub const RTN_PROHIBIT: _bindgen_ty_62 = _bindgen_ty_62::RTN_PROHIBIT;
+pub const RTN_THROW: _bindgen_ty_62 = _bindgen_ty_62::RTN_THROW;
+pub const RTN_NAT: _bindgen_ty_62 = _bindgen_ty_62::RTN_NAT;
+pub const RTN_XRESOLVE: _bindgen_ty_62 = _bindgen_ty_62::RTN_XRESOLVE;
+pub const __RTN_MAX: _bindgen_ty_62 = _bindgen_ty_62::__RTN_MAX;
+pub const RTAX_UNSPEC: _bindgen_ty_63 = _bindgen_ty_63::RTAX_UNSPEC;
+pub const RTAX_LOCK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_LOCK;
+pub const RTAX_MTU: _bindgen_ty_63 = _bindgen_ty_63::RTAX_MTU;
+pub const RTAX_WINDOW: _bindgen_ty_63 = _bindgen_ty_63::RTAX_WINDOW;
+pub const RTAX_RTT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTT;
+pub const RTAX_RTTVAR: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTTVAR;
+pub const RTAX_SSTHRESH: _bindgen_ty_63 = _bindgen_ty_63::RTAX_SSTHRESH;
+pub const RTAX_CWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CWND;
+pub const RTAX_ADVMSS: _bindgen_ty_63 = _bindgen_ty_63::RTAX_ADVMSS;
+pub const RTAX_REORDERING: _bindgen_ty_63 = _bindgen_ty_63::RTAX_REORDERING;
+pub const RTAX_HOPLIMIT: _bindgen_ty_63 = _bindgen_ty_63::RTAX_HOPLIMIT;
+pub const RTAX_INITCWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITCWND;
+pub const RTAX_FEATURES: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FEATURES;
+pub const RTAX_RTO_MIN: _bindgen_ty_63 = _bindgen_ty_63::RTAX_RTO_MIN;
+pub const RTAX_INITRWND: _bindgen_ty_63 = _bindgen_ty_63::RTAX_INITRWND;
+pub const RTAX_QUICKACK: _bindgen_ty_63 = _bindgen_ty_63::RTAX_QUICKACK;
+pub const RTAX_CC_ALGO: _bindgen_ty_63 = _bindgen_ty_63::RTAX_CC_ALGO;
+pub const RTAX_FASTOPEN_NO_COOKIE: _bindgen_ty_63 = _bindgen_ty_63::RTAX_FASTOPEN_NO_COOKIE;
+pub const __RTAX_MAX: _bindgen_ty_63 = _bindgen_ty_63::__RTAX_MAX;
+pub const PREFIX_UNSPEC: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_UNSPEC;
+pub const PREFIX_ADDRESS: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_ADDRESS;
+pub const PREFIX_CACHEINFO: _bindgen_ty_64 = _bindgen_ty_64::PREFIX_CACHEINFO;
+pub const __PREFIX_MAX: _bindgen_ty_64 = _bindgen_ty_64::__PREFIX_MAX;
+pub const TCA_UNSPEC: _bindgen_ty_65 = _bindgen_ty_65::TCA_UNSPEC;
+pub const TCA_KIND: _bindgen_ty_65 = _bindgen_ty_65::TCA_KIND;
+pub const TCA_OPTIONS: _bindgen_ty_65 = _bindgen_ty_65::TCA_OPTIONS;
+pub const TCA_STATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS;
+pub const TCA_XSTATS: _bindgen_ty_65 = _bindgen_ty_65::TCA_XSTATS;
+pub const TCA_RATE: _bindgen_ty_65 = _bindgen_ty_65::TCA_RATE;
+pub const TCA_FCNT: _bindgen_ty_65 = _bindgen_ty_65::TCA_FCNT;
+pub const TCA_STATS2: _bindgen_ty_65 = _bindgen_ty_65::TCA_STATS2;
+pub const TCA_STAB: _bindgen_ty_65 = _bindgen_ty_65::TCA_STAB;
+pub const TCA_PAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_PAD;
+pub const TCA_DUMP_INVISIBLE: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_INVISIBLE;
+pub const TCA_CHAIN: _bindgen_ty_65 = _bindgen_ty_65::TCA_CHAIN;
+pub const TCA_HW_OFFLOAD: _bindgen_ty_65 = _bindgen_ty_65::TCA_HW_OFFLOAD;
+pub const TCA_INGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_INGRESS_BLOCK;
+pub const TCA_EGRESS_BLOCK: _bindgen_ty_65 = _bindgen_ty_65::TCA_EGRESS_BLOCK;
+pub const TCA_DUMP_FLAGS: _bindgen_ty_65 = _bindgen_ty_65::TCA_DUMP_FLAGS;
+pub const TCA_EXT_WARN_MSG: _bindgen_ty_65 = _bindgen_ty_65::TCA_EXT_WARN_MSG;
+pub const __TCA_MAX: _bindgen_ty_65 = _bindgen_ty_65::__TCA_MAX;
+pub const NDUSEROPT_UNSPEC: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_UNSPEC;
+pub const NDUSEROPT_SRCADDR: _bindgen_ty_66 = _bindgen_ty_66::NDUSEROPT_SRCADDR;
+pub const __NDUSEROPT_MAX: _bindgen_ty_66 = _bindgen_ty_66::__NDUSEROPT_MAX;
+pub const TCA_ROOT_UNSPEC: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_UNSPEC;
+pub const TCA_ROOT_TAB: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TAB;
+pub const TCA_ROOT_FLAGS: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_FLAGS;
+pub const TCA_ROOT_COUNT: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_COUNT;
+pub const TCA_ROOT_TIME_DELTA: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_TIME_DELTA;
+pub const TCA_ROOT_EXT_WARN_MSG: _bindgen_ty_67 = _bindgen_ty_67::TCA_ROOT_EXT_WARN_MSG;
+pub const __TCA_ROOT_MAX: _bindgen_ty_67 = _bindgen_ty_67::__TCA_ROOT_MAX;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -1542,6 +1556,8 @@ NL_ATTR_TYPE_NUL_STRING = 12,
 NL_ATTR_TYPE_NESTED = 13,
 NL_ATTR_TYPE_NESTED_ARRAY = 14,
 NL_ATTR_TYPE_BITFIELD32 = 15,
+NL_ATTR_TYPE_SINT = 16,
+NL_ATTR_TYPE_UINT = 17,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1631,7 +1647,8 @@ IFLA_ALLMULTI = 61,
 IFLA_DEVLINK_PORT = 62,
 IFLA_GSO_IPV4_MAX_SIZE = 63,
 IFLA_GRO_IPV4_MAX_SIZE = 64,
-__IFLA_MAX = 65,
+IFLA_DPLL_PIN = 65,
+__IFLA_MAX = 66,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1727,7 +1744,9 @@ IFLA_BR_MCAST_MLD_VERSION = 44,
 IFLA_BR_VLAN_STATS_PER_PORT = 45,
 IFLA_BR_MULTI_BOOLOPT = 46,
 IFLA_BR_MCAST_QUERIER_STATE = 47,
-__IFLA_BR_MAX = 48,
+IFLA_BR_FDB_N_LEARNED = 48,
+IFLA_BR_FDB_MAX_LEARNED = 49,
+__IFLA_BR_MAX = 50,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1784,7 +1803,8 @@ IFLA_BRPORT_MAB = 40,
 IFLA_BRPORT_MCAST_N_GROUPS = 41,
 IFLA_BRPORT_MCAST_MAX_GROUPS = 42,
 IFLA_BRPORT_NEIGH_VLAN_SUPPRESS = 43,
-__IFLA_BRPORT_MAX = 44,
+IFLA_BRPORT_BACKUP_NHID = 44,
+__IFLA_BRPORT_MAX = 45,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -1937,10 +1957,38 @@ IPVLAN_MODE_L3 = 1,
 IPVLAN_MODE_L3S = 2,
 IPVLAN_MODE_MAX = 3,
 }
+#[repr(i32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_action {
+NETKIT_NEXT = -1,
+NETKIT_PASS = 0,
+NETKIT_DROP = 2,
+NETKIT_REDIRECT = 7,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum netkit_mode {
+NETKIT_L2 = 0,
+NETKIT_L3 = 1,
+}
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_18 {
+IFLA_NETKIT_UNSPEC = 0,
+IFLA_NETKIT_PEER_INFO = 1,
+IFLA_NETKIT_PRIMARY = 2,
+IFLA_NETKIT_POLICY = 3,
+IFLA_NETKIT_PEER_POLICY = 4,
+IFLA_NETKIT_MODE = 5,
+__IFLA_NETKIT_MAX = 6,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_19 {
 VNIFILTER_ENTRY_STATS_UNSPEC = 0,
 VNIFILTER_ENTRY_STATS_RX_BYTES = 1,
 VNIFILTER_ENTRY_STATS_RX_PKTS = 2,
@@ -1956,7 +2004,7 @@ __VNIFILTER_ENTRY_STATS_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_19 {
+pub enum _bindgen_ty_20 {
 VXLAN_VNIFILTER_ENTRY_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY_START = 1,
 VXLAN_VNIFILTER_ENTRY_END = 2,
@@ -1968,7 +2016,7 @@ __VXLAN_VNIFILTER_ENTRY_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_20 {
+pub enum _bindgen_ty_21 {
 VXLAN_VNIFILTER_UNSPEC = 0,
 VXLAN_VNIFILTER_ENTRY = 1,
 __VXLAN_VNIFILTER_MAX = 2,
@@ -1976,7 +2024,7 @@ __VXLAN_VNIFILTER_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_21 {
+pub enum _bindgen_ty_22 {
 IFLA_VXLAN_UNSPEC = 0,
 IFLA_VXLAN_ID = 1,
 IFLA_VXLAN_GROUP = 2,
@@ -2009,7 +2057,8 @@ IFLA_VXLAN_TTL_INHERIT = 28,
 IFLA_VXLAN_DF = 29,
 IFLA_VXLAN_VNIFILTER = 30,
 IFLA_VXLAN_LOCALBYPASS = 31,
-__IFLA_VXLAN_MAX = 32,
+IFLA_VXLAN_LABEL_POLICY = 32,
+__IFLA_VXLAN_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2023,7 +2072,15 @@ __VXLAN_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_22 {
+pub enum ifla_vxlan_label_policy {
+VXLAN_LABEL_FIXED = 0,
+VXLAN_LABEL_INHERIT = 1,
+__VXLAN_LABEL_END = 2,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_23 {
 IFLA_GENEVE_UNSPEC = 0,
 IFLA_GENEVE_ID = 1,
 IFLA_GENEVE_REMOTE = 2,
@@ -2053,7 +2110,7 @@ __GENEVE_DF_END = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_23 {
+pub enum _bindgen_ty_24 {
 IFLA_BAREUDP_UNSPEC = 0,
 IFLA_BAREUDP_PORT = 1,
 IFLA_BAREUDP_ETHERTYPE = 2,
@@ -2064,7 +2121,7 @@ __IFLA_BAREUDP_MAX = 5,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_24 {
+pub enum _bindgen_ty_25 {
 IFLA_PPP_UNSPEC = 0,
 IFLA_PPP_DEV_FD = 1,
 __IFLA_PPP_MAX = 2,
@@ -2079,7 +2136,7 @@ GTP_ROLE_SGSN = 1,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_25 {
+pub enum _bindgen_ty_26 {
 IFLA_GTP_UNSPEC = 0,
 IFLA_GTP_FD0 = 1,
 IFLA_GTP_FD1 = 2,
@@ -2092,7 +2149,7 @@ __IFLA_GTP_MAX = 7,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_26 {
+pub enum _bindgen_ty_27 {
 IFLA_BOND_UNSPEC = 0,
 IFLA_BOND_MODE = 1,
 IFLA_BOND_ACTIVE_SLAVE = 2,
@@ -2130,7 +2187,7 @@ __IFLA_BOND_MAX = 32,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_27 {
+pub enum _bindgen_ty_28 {
 IFLA_BOND_AD_INFO_UNSPEC = 0,
 IFLA_BOND_AD_INFO_AGGREGATOR = 1,
 IFLA_BOND_AD_INFO_NUM_PORTS = 2,
@@ -2142,7 +2199,7 @@ __IFLA_BOND_AD_INFO_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_28 {
+pub enum _bindgen_ty_29 {
 IFLA_BOND_SLAVE_UNSPEC = 0,
 IFLA_BOND_SLAVE_STATE = 1,
 IFLA_BOND_SLAVE_MII_STATUS = 2,
@@ -2158,7 +2215,7 @@ __IFLA_BOND_SLAVE_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_29 {
+pub enum _bindgen_ty_30 {
 IFLA_VF_INFO_UNSPEC = 0,
 IFLA_VF_INFO = 1,
 __IFLA_VF_INFO_MAX = 2,
@@ -2166,7 +2223,7 @@ __IFLA_VF_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_30 {
+pub enum _bindgen_ty_31 {
 IFLA_VF_UNSPEC = 0,
 IFLA_VF_MAC = 1,
 IFLA_VF_VLAN = 2,
@@ -2186,7 +2243,7 @@ __IFLA_VF_MAX = 14,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_31 {
+pub enum _bindgen_ty_32 {
 IFLA_VF_VLAN_INFO_UNSPEC = 0,
 IFLA_VF_VLAN_INFO = 1,
 __IFLA_VF_VLAN_INFO_MAX = 2,
@@ -2194,7 +2251,7 @@ __IFLA_VF_VLAN_INFO_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_32 {
+pub enum _bindgen_ty_33 {
 IFLA_VF_LINK_STATE_AUTO = 0,
 IFLA_VF_LINK_STATE_ENABLE = 1,
 IFLA_VF_LINK_STATE_DISABLE = 2,
@@ -2203,7 +2260,7 @@ __IFLA_VF_LINK_STATE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_33 {
+pub enum _bindgen_ty_34 {
 IFLA_VF_STATS_RX_PACKETS = 0,
 IFLA_VF_STATS_TX_PACKETS = 1,
 IFLA_VF_STATS_RX_BYTES = 2,
@@ -2218,7 +2275,7 @@ __IFLA_VF_STATS_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_34 {
+pub enum _bindgen_ty_35 {
 IFLA_VF_PORT_UNSPEC = 0,
 IFLA_VF_PORT = 1,
 __IFLA_VF_PORT_MAX = 2,
@@ -2226,7 +2283,7 @@ __IFLA_VF_PORT_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_35 {
+pub enum _bindgen_ty_36 {
 IFLA_PORT_UNSPEC = 0,
 IFLA_PORT_VF = 1,
 IFLA_PORT_PROFILE = 2,
@@ -2240,7 +2297,7 @@ __IFLA_PORT_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_36 {
+pub enum _bindgen_ty_37 {
 PORT_REQUEST_PREASSOCIATE = 0,
 PORT_REQUEST_PREASSOCIATE_RR = 1,
 PORT_REQUEST_ASSOCIATE = 2,
@@ -2249,7 +2306,7 @@ PORT_REQUEST_DISASSOCIATE = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_37 {
+pub enum _bindgen_ty_38 {
 PORT_VDP_RESPONSE_SUCCESS = 0,
 PORT_VDP_RESPONSE_INVALID_FORMAT = 1,
 PORT_VDP_RESPONSE_INSUFFICIENT_RESOURCES = 2,
@@ -2267,7 +2324,7 @@ PORT_PROFILE_RESPONSE_ERROR = 261,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_38 {
+pub enum _bindgen_ty_39 {
 IFLA_IPOIB_UNSPEC = 0,
 IFLA_IPOIB_PKEY = 1,
 IFLA_IPOIB_MODE = 2,
@@ -2277,14 +2334,14 @@ __IFLA_IPOIB_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_39 {
+pub enum _bindgen_ty_40 {
 IPOIB_MODE_DATAGRAM = 0,
 IPOIB_MODE_CONNECTED = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_40 {
+pub enum _bindgen_ty_41 {
 HSR_PROTOCOL_HSR = 0,
 HSR_PROTOCOL_PRP = 1,
 HSR_PROTOCOL_MAX = 2,
@@ -2292,7 +2349,7 @@ HSR_PROTOCOL_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_41 {
+pub enum _bindgen_ty_42 {
 IFLA_HSR_UNSPEC = 0,
 IFLA_HSR_SLAVE1 = 1,
 IFLA_HSR_SLAVE2 = 2,
@@ -2306,7 +2363,7 @@ __IFLA_HSR_MAX = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_42 {
+pub enum _bindgen_ty_43 {
 IFLA_STATS_UNSPEC = 0,
 IFLA_STATS_LINK_64 = 1,
 IFLA_STATS_LINK_XSTATS = 2,
@@ -2318,7 +2375,7 @@ __IFLA_STATS_MAX = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_43 {
+pub enum _bindgen_ty_44 {
 IFLA_STATS_GETSET_UNSPEC = 0,
 IFLA_STATS_GET_FILTERS = 1,
 IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS = 2,
@@ -2327,7 +2384,7 @@ __IFLA_STATS_GETSET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_44 {
+pub enum _bindgen_ty_45 {
 LINK_XSTATS_TYPE_UNSPEC = 0,
 LINK_XSTATS_TYPE_BRIDGE = 1,
 LINK_XSTATS_TYPE_BOND = 2,
@@ -2336,7 +2393,7 @@ __LINK_XSTATS_TYPE_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_45 {
+pub enum _bindgen_ty_46 {
 IFLA_OFFLOAD_XSTATS_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_CPU_HIT = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO = 2,
@@ -2346,7 +2403,7 @@ __IFLA_OFFLOAD_XSTATS_MAX = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_46 {
+pub enum _bindgen_ty_47 {
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC = 0,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST = 1,
 IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED = 2,
@@ -2355,7 +2412,7 @@ __IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_47 {
+pub enum _bindgen_ty_48 {
 XDP_ATTACHED_NONE = 0,
 XDP_ATTACHED_DRV = 1,
 XDP_ATTACHED_SKB = 2,
@@ -2365,7 +2422,7 @@ XDP_ATTACHED_MULTI = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_48 {
+pub enum _bindgen_ty_49 {
 IFLA_XDP_UNSPEC = 0,
 IFLA_XDP_FD = 1,
 IFLA_XDP_ATTACHED = 2,
@@ -2380,7 +2437,7 @@ __IFLA_XDP_MAX = 9,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_49 {
+pub enum _bindgen_ty_50 {
 IFLA_EVENT_NONE = 0,
 IFLA_EVENT_REBOOT = 1,
 IFLA_EVENT_FEATURES = 2,
@@ -2392,7 +2449,7 @@ IFLA_EVENT_BONDING_OPTIONS = 6,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_50 {
+pub enum _bindgen_ty_51 {
 IFLA_TUN_UNSPEC = 0,
 IFLA_TUN_OWNER = 1,
 IFLA_TUN_GROUP = 2,
@@ -2408,7 +2465,7 @@ __IFLA_TUN_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_51 {
+pub enum _bindgen_ty_52 {
 IFLA_RMNET_UNSPEC = 0,
 IFLA_RMNET_MUX_ID = 1,
 IFLA_RMNET_FLAGS = 2,
@@ -2417,7 +2474,7 @@ __IFLA_RMNET_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_52 {
+pub enum _bindgen_ty_53 {
 IFLA_MCTP_UNSPEC = 0,
 IFLA_MCTP_NET = 1,
 __IFLA_MCTP_MAX = 2,
@@ -2425,15 +2482,15 @@ __IFLA_MCTP_MAX = 2,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_53 {
+pub enum _bindgen_ty_54 {
 IFLA_DSA_UNSPEC = 0,
-IFLA_DSA_MASTER = 1,
+IFLA_DSA_CONDUIT = 1,
 __IFLA_DSA_MAX = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_54 {
+pub enum _bindgen_ty_55 {
 IFA_UNSPEC = 0,
 IFA_ADDRESS = 1,
 IFA_LOCAL = 2,
@@ -2451,7 +2508,7 @@ __IFA_MAX = 12,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_55 {
+pub enum _bindgen_ty_56 {
 NDA_UNSPEC = 0,
 NDA_DST = 1,
 NDA_LLADDR = 2,
@@ -2475,7 +2532,7 @@ __NDA_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_56 {
+pub enum _bindgen_ty_57 {
 NDTPA_UNSPEC = 0,
 NDTPA_IFINDEX = 1,
 NDTPA_REFCNT = 2,
@@ -2501,7 +2558,7 @@ __NDTPA_MAX = 20,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_57 {
+pub enum _bindgen_ty_58 {
 NDTA_UNSPEC = 0,
 NDTA_NAME = 1,
 NDTA_THRESH1 = 2,
@@ -2517,14 +2574,14 @@ __NDTA_MAX = 10,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_58 {
+pub enum _bindgen_ty_59 {
 FDB_NOTIFY_BIT = 1,
 FDB_NOTIFY_INACTIVE_BIT = 2,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_59 {
+pub enum _bindgen_ty_60 {
 NFEA_UNSPEC = 0,
 NFEA_ACTIVITY_NOTIFY = 1,
 NFEA_DONT_REFRESH = 2,
@@ -2533,7 +2590,7 @@ __NFEA_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_60 {
+pub enum _bindgen_ty_61 {
 RTM_BASE = 16,
 RTM_DELLINK = 17,
 RTM_GETLINK = 18,
@@ -2610,7 +2667,7 @@ __RTM_MAX = 123,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_61 {
+pub enum _bindgen_ty_62 {
 RTN_UNSPEC = 0,
 RTN_UNICAST = 1,
 RTN_LOCAL = 2,
@@ -2686,7 +2743,7 @@ __RTA_MAX = 31,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_62 {
+pub enum _bindgen_ty_63 {
 RTAX_UNSPEC = 0,
 RTAX_LOCK = 1,
 RTAX_MTU = 2,
@@ -2710,7 +2767,7 @@ __RTAX_MAX = 18,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_63 {
+pub enum _bindgen_ty_64 {
 PREFIX_UNSPEC = 0,
 PREFIX_ADDRESS = 1,
 PREFIX_CACHEINFO = 2,
@@ -2719,7 +2776,7 @@ __PREFIX_MAX = 3,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_64 {
+pub enum _bindgen_ty_65 {
 TCA_UNSPEC = 0,
 TCA_KIND = 1,
 TCA_OPTIONS = 2,
@@ -2742,7 +2799,7 @@ __TCA_MAX = 17,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_65 {
+pub enum _bindgen_ty_66 {
 NDUSEROPT_UNSPEC = 0,
 NDUSEROPT_SRCADDR = 1,
 __NDUSEROPT_MAX = 2,
@@ -2793,7 +2850,7 @@ __RTNLGRP_MAX = 37,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_66 {
+pub enum _bindgen_ty_67 {
 TCA_ROOT_UNSPEC = 0,
 TCA_ROOT_TAB = 1,
 TCA_ROOT_FLAGS = 2,
@@ -2856,6 +2913,9 @@ pub const MACSEC_OFFLOAD_MAX: macsec_offload = macsec_offload::MACSEC_OFFLOAD_MA
 }
 impl ifla_vxlan_df {
 pub const VXLAN_DF_MAX: ifla_vxlan_df = ifla_vxlan_df::VXLAN_DF_INHERIT;
+}
+impl ifla_vxlan_label_policy {
+pub const VXLAN_LABEL_MAX: ifla_vxlan_label_policy = ifla_vxlan_label_policy::VXLAN_LABEL_INHERIT;
 }
 impl ifla_geneve_df {
 pub const GENEVE_DF_MAX: ifla_geneve_df = ifla_geneve_df::GENEVE_DF_INHERIT;

--- a/src/x86_64/prctl.rs
+++ b/src/x86_64/prctl.rs
@@ -218,6 +218,7 @@ pub const PR_SME_VL_LEN_MASK: u32 = 65535;
 pub const PR_SME_VL_INHERIT: u32 = 131072;
 pub const PR_SET_MDWE: u32 = 65;
 pub const PR_MDWE_REFUSE_EXEC_GAIN: u32 = 1;
+pub const PR_MDWE_NO_INHERIT: u32 = 2;
 pub const PR_GET_MDWE: u32 = 66;
 pub const PR_SET_VMA: u32 = 1398164801;
 pub const PR_SET_VMA_ANON_NAME: u32 = 0;

--- a/src/x86_64/xdp.rs
+++ b/src/x86_64/xdp.rs
@@ -83,6 +83,7 @@ pub len: __u64,
 pub chunk_size: __u32,
 pub headroom: __u32,
 pub flags: __u32,
+pub tx_metadata_len: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -98,6 +99,23 @@ pub tx_ring_empty_descs: __u64,
 #[derive(Debug, Copy, Clone)]
 pub struct xdp_options {
 pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct xsk_tx_metadata {
+pub flags: __u64,
+pub __bindgen_anon_1: xsk_tx_metadata__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1 {
+pub csum_start: __u16,
+pub csum_offset: __u16,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2 {
+pub tx_timestamp: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -140,7 +158,9 @@ pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
 pub const XDP_USE_NEED_WAKEUP: u32 = 8;
+pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
+pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;
@@ -157,5 +177,13 @@ pub const XDP_UMEM_PGOFF_FILL_RING: u64 = 4294967296;
 pub const XDP_UMEM_PGOFF_COMPLETION_RING: u64 = 6442450944;
 pub const XSK_UNALIGNED_BUF_OFFSET_SHIFT: u32 = 48;
 pub const XSK_UNALIGNED_BUF_ADDR_MASK: u64 = 281474976710655;
-pub const XDP_USE_SG: u32 = 16;
+pub const XDP_TXMD_FLAGS_TIMESTAMP: u32 = 1;
+pub const XDP_TXMD_FLAGS_CHECKSUM: u32 = 2;
 pub const XDP_PKT_CONTD: u32 = 1;
+pub const XDP_TX_METADATA: u32 = 2;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union xsk_tx_metadata__bindgen_ty_1 {
+pub request: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_1,
+pub completion: xsk_tx_metadata__bindgen_ty_1__bindgen_ty_2,
+}


### PR DESCRIPTION
Updates the bindings to target linux 6.8. This is necessary to support the new statmount syscall. Besides the new structs there are also some reserved fields in older structs that are now used making this a breaking change