### PR TITLE
Add syscall functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 #[cfg(feature = "std")]
 pub use std::os::raw as ctypes;
 
+pub mod syscall;
+
 #[cfg(all(not(feature = "std"), feature = "no_std"))]
 pub mod ctypes {
     // The signedness of `char` is platform-specific, and we have to match

--- a/src/syscall/aarch64.rs
+++ b/src/syscall/aarch64.rs
@@ -1,0 +1,259 @@
+//! aarch64 Linux system calls.
+
+use super::Reg;
+use core::arch::asm;
+
+#[cfg(target_pointer_width = "32")]
+compile_error!("arm64-ilp32 is not supported yet");
+
+#[inline(always)]
+pub unsafe fn syscall0_readonly<R: From<Reg>>(nr: u32) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("x8") nr,
+        lateout("x0") r0,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub unsafe fn syscall1<R: From<Reg>>(nr: u32, a0: impl Into<Reg>) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("x8") nr,
+        inlateout("x0") a0.into().0 => r0,
+        options(nostack, preserves_flags)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub unsafe fn syscall1_readonly<R: From<Reg>>(nr: u32, a0: impl Into<Reg>) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("x8") nr,
+        inlateout("x0") a0.into().0 => r0,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub unsafe fn syscall1_noreturn<R: From<Reg>>(nr: u32, a0: impl Into<Reg>) -> ! {
+    asm!(
+        "svc 0",
+        in("x8") nr,
+        in("x0") a0.into().0,
+        options(nostack, noreturn)
+    )
+}
+
+#[inline(always)]
+pub unsafe fn syscall2<R: From<Reg>>(nr: u32, a0: impl Into<Reg>, a1: impl Into<Reg>) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("x8") nr,
+        inlateout("x0") a0.into().0 => r0,
+        in("x1") a1.into().0,
+        options(nostack, preserves_flags)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub unsafe fn syscall2_readonly<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("x8") nr,
+        inlateout("x0") a0.into().0 => r0,
+        in("x1") a1.into().0,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub unsafe fn syscall3<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("x8") nr,
+        inlateout("x0") a0.into().0 => r0,
+        in("x1") a1.into().0,
+        in("x2") a2.into().0,
+        options(nostack, preserves_flags)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub unsafe fn syscall3_readonly<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("x8") nr,
+        inlateout("x0") a0.into().0 => r0,
+        in("x1") a1.into().0,
+        in("x2") a2.into().0,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub unsafe fn syscall4<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("x8") nr,
+        inlateout("x0") a0.into().0 => r0,
+        in("x1") a1.into().0,
+        in("x2") a2.into().0,
+        in("x3") a3.into().0,
+        options(nostack, preserves_flags)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub unsafe fn syscall4_readonly<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("x8") nr,
+        inlateout("x0") a0.into().0 => r0,
+        in("x1") a1.into().0,
+        in("x2") a2.into().0,
+        in("x3") a3.into().0,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub unsafe fn syscall5<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+    a4: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("x8") nr,
+        inlateout("x0") a0.into().0 => r0,
+        in("x1") a1.into().0,
+        in("x2") a2.into().0,
+        in("x3") a3.into().0,
+        in("x4") a4.into().0,
+        options(nostack, preserves_flags)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub unsafe fn syscall5_readonly<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+    a4: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("x8") nr,
+        inlateout("x0") a0.into().0 => r0,
+        in("x1") a1.into().0,
+        in("x2") a2.into().0,
+        in("x3") a3.into().0,
+        in("x4") a4.into().0,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub unsafe fn syscall6<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+    a4: impl Into<Reg>,
+    a5: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("x8") nr,
+        inlateout("x0") a0.into().0 => r0,
+        in("x1") a1.into().0,
+        in("x2") a2.into().0,
+        in("x3") a3.into().0,
+        in("x4") a4.into().0,
+        in("x5") a5.into().0,
+        options(nostack, preserves_flags)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub unsafe fn syscall6_readonly<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+    a4: impl Into<Reg>,
+    a5: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("x8") nr,
+        inlateout("x0") a0.into().0 => r0,
+        in("x1") a1.into().0,
+        in("x2") a2.into().0,
+        in("x3") a3.into().0,
+        in("x4") a4.into().0,
+        in("x5") a5.into().0,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(r0))
+}

--- a/src/syscall/arm.rs
+++ b/src/syscall/arm.rs
@@ -1,0 +1,260 @@
+//! arm Linux system calls.
+
+use super::Reg;
+use core::arch::asm;
+
+#[inline(always)]
+pub(in crate::backend) unsafe fn syscall0_readonly<R: From<Reg>>(nr: u32) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("r7") nr.to_asm(),
+        lateout("r0") r0,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub(in crate::backend) unsafe fn syscall1<R: From<Reg>>(nr: u32, a0: impl Into<Reg>) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("r7") nr.to_asm(),
+        inlateout("r0") a0.into().0 => r0,
+        options(nostack, preserves_flags)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub(in crate::backend) unsafe fn syscall1_readonly<R: From<Reg>>(nr: u32, a0: impl Into<Reg>) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("r7") nr.to_asm(),
+        inlateout("r0") a0.into().0 => r0,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub(in crate::backend) unsafe fn syscall1_noreturn<R: From<Reg>>(nr: u32, a0: impl Into<Reg>) -> ! {
+    asm!(
+        "svc 0",
+        in("r7") nr.to_asm(),
+        in("r0") a0.into().0,
+        options(nostack, noreturn)
+    )
+}
+
+#[inline(always)]
+pub(in crate::backend) unsafe fn syscall2<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("r7") nr.to_asm(),
+        inlateout("r0") a0.into().0 => r0,
+        in("r1") a1.into().0,
+        options(nostack, preserves_flags)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub(in crate::backend) unsafe fn syscall2_readonly<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("r7") nr.to_asm(),
+        inlateout("r0") a0.into().0 => r0,
+        in("r1") a1.into().0,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub(in crate::backend) unsafe fn syscall3<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("r7") nr.to_asm(),
+        inlateout("r0") a0.into().0 => r0,
+        in("r1") a1.into().0,
+        in("r2") a2.into().0,
+        options(nostack, preserves_flags)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub(in crate::backend) unsafe fn syscall3_readonly<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("r7") nr.to_asm(),
+        inlateout("r0") a0.into().0 => r0,
+        in("r1") a1.into().0,
+        in("r2") a2.into().0,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub(in crate::backend) unsafe fn syscall4<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("r7") nr.to_asm(),
+        inlateout("r0") a0.into().0 => r0,
+        in("r1") a1.into().0,
+        in("r2") a2.into().0,
+        in("r3") a3.into().0,
+        options(nostack, preserves_flags)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub(in crate::backend) unsafe fn syscall4_readonly<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("r7") nr.to_asm(),
+        inlateout("r0") a0.into().0 => r0,
+        in("r1") a1.into().0,
+        in("r2") a2.into().0,
+        in("r3") a3.into().0,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub(in crate::backend) unsafe fn syscall5<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+    a4: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("r7") nr.to_asm(),
+        inlateout("r0") a0.into().0 => r0,
+        in("r1") a1.into().0,
+        in("r2") a2.into().0,
+        in("r3") a3.into().0,
+        in("r4") a4.into().0,
+        options(nostack, preserves_flags)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub(in crate::backend) unsafe fn syscall5_readonly<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+    a4: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("r7") nr.to_asm(),
+        inlateout("r0") a0.into().0 => r0,
+        in("r1") a1.into().0,
+        in("r2") a2.into().0,
+        in("r3") a3.into().0,
+        in("r4") a4.into().0,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub(in crate::backend) unsafe fn syscall6<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+    a4: impl Into<Reg>,
+    a5: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("r7") nr.to_asm(),
+        inlateout("r0") a0.into().0 => r0,
+        in("r1") a1.into().0,
+        in("r2") a2.into().0,
+        in("r3") a3.into().0,
+        in("r4") a4.into().0,
+        in("r5") a5.into().0,
+        options(nostack, preserves_flags)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub(in crate::backend) unsafe fn syscall6_readonly<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+    a4: impl Into<Reg>,
+    a5: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "svc 0",
+        in("r7") nr.to_asm(),
+        inlateout("r0") a0.into().0 => r0,
+        in("r1") a1.into().0,
+        in("r2") a2.into().0,
+        in("r3") a3.into().0,
+        in("r4") a4.into().0,
+        in("r5") a5.into().0,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(r0))
+}

--- a/src/syscall/mips.rs
+++ b/src/syscall/mips.rs
@@ -1,0 +1,534 @@
+//! mipsel Linux system calls.
+//!
+//! On mipsel, Linux indicates success or failure using `$a3` rather
+//! than by returning a negative error code as most other architectures do.
+//!
+//! Mips-family platforms have a special calling convention for `__NR_pipe`,
+//! however we use `__NR_pipe2` instead to avoid having to implement it.
+
+use super::Reg;
+use core::arch::asm;
+
+#[inline(always)]
+pub unsafe fn syscall0_readonly<R: From<Reg>>(nr: SyscallNumber) -> R {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr as usize => x0,
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(if err != 0 {
+        x0.wrapping_neg() as *mut _
+    } else {
+        x0 as *mut _
+    }))
+}
+
+#[inline(always)]
+pub unsafe fn syscall1<R: From<Reg>>(nr: u32, a0: impl Into<Reg>) -> R {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr as usize => x0,
+        in("$4" /*$a0*/) a0.0,
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    R::from(Reg(if err != 0 {
+        x0.wrapping_neg() as *mut _
+    } else {
+        x0 as *mut _
+    }))
+}
+
+#[inline(always)]
+pub unsafe fn syscall1_readonly<R: From<Reg>>(nr: u32, a0: impl Into<Reg>) -> R {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr as usize => x0,
+        in("$4" /*$a0*/) a0.0,
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(if err != 0 {
+        x0.wrapping_neg() as *mut _
+    } else {
+        x0 as *mut _
+    }))
+}
+
+#[inline(always)]
+pub unsafe fn syscall1_noreturn<R: From<Reg>>(nr: u32, a0: impl Into<Reg>) -> ! {
+    asm!(
+        "syscall",
+        in("$2" /*$v0*/) nr,
+        in("$4" /*$a0*/) a0.0,
+        options(nostack, noreturn)
+    )
+}
+
+#[inline(always)]
+pub unsafe fn syscall2<R: From<Reg>>(nr: u32, a0: impl Into<Reg>, a1: impl Into<Reg>) -> R {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr as usize => x0,
+        in("$4" /*$a0*/) a0.0,
+        in("$5" /*$a1*/) a1.0,
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    R::from(Reg(if err != 0 {
+        x0.wrapping_neg() as *mut _
+    } else {
+        x0 as *mut _
+    }))
+}
+
+#[inline(always)]
+pub unsafe fn syscall2_readonly<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+) -> R {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr as usize => x0,
+        in("$4" /*$a0*/) a0.0,
+        in("$5" /*$a1*/) a1.0,
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(if err != 0 {
+        x0.wrapping_neg() as *mut _
+    } else {
+        x0 as *mut _
+    }))
+}
+
+#[inline(always)]
+pub unsafe fn syscall3<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+) -> R {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr as usize => x0,
+        in("$4" /*$a0*/) a0.0,
+        in("$5" /*$a1*/) a1.0,
+        in("$6" /*$a2*/) a2.0,
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    R::from(Reg(if err != 0 {
+        x0.wrapping_neg() as *mut _
+    } else {
+        x0 as *mut _
+    }))
+}
+
+#[inline(always)]
+pub unsafe fn syscall3_readonly<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+) -> R {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr as usize => x0,
+        in("$4" /*$a0*/) a0.0,
+        in("$5" /*$a1*/) a1.0,
+        in("$6" /*$a2*/) a2.0,
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(if err != 0 {
+        x0.wrapping_neg() as *mut _
+    } else {
+        x0 as *mut _
+    }))
+}
+
+#[inline(always)]
+pub unsafe fn syscall4<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+) -> R {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr as usize => x0,
+        in("$4" /*$a0*/) a0.0,
+        in("$5" /*$a1*/) a1.0,
+        in("$6" /*$a2*/) a2.0,
+        inlateout("$7" /*$a3*/) a3.0 as usize => err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    R::from(Reg(if err != 0 {
+        x0.wrapping_neg() as *mut _
+    } else {
+        x0 as *mut _
+    }))
+}
+
+#[inline(always)]
+pub unsafe fn syscall4_readonly<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+) -> R {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr as usize => x0,
+        in("$4" /*$a0*/) a0.0,
+        in("$5" /*$a1*/) a1.0,
+        in("$6" /*$a2*/) a2.0,
+        inlateout("$7" /*$a3*/) a3.0 as usize => err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(if err != 0 {
+        x0.wrapping_neg() as *mut _
+    } else {
+        x0 as *mut _
+    }))
+}
+
+#[inline(always)]
+pub unsafe fn syscall5<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+    a4: impl Into<Reg>,
+) -> R {
+    let x0;
+    let err: usize;
+    asm!(
+        ".set noat",
+        "subu $sp, 32",
+        "sw {}, 16($sp)",
+        "syscall",
+        "addu $sp, 32",
+        ".set at",
+        in(reg) a4.0,
+        inlateout("$2" /*$v0*/) nr as usize => x0,
+        in("$4" /*$a0*/) a0.0,
+        in("$5" /*$a1*/) a1.0,
+        in("$6" /*$a2*/) a2.0,
+        inlateout("$7" /*$a3*/) a3.0 as usize => err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(preserves_flags)
+    );
+    R::from(Reg(if err != 0 {
+        x0.wrapping_neg() as *mut _
+    } else {
+        x0 as *mut _
+    }))
+}
+
+#[inline(always)]
+pub unsafe fn syscall5_readonly<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+    a4: impl Into<Reg>,
+) -> R {
+    let x0;
+    let err: usize;
+    asm!(
+        ".set noat",
+        "subu $sp, 32",
+        "sw {}, 16($sp)",
+        "syscall",
+        "addu $sp, 32",
+        ".set at",
+        in(reg) a4.0,
+        inlateout("$2" /*$v0*/) nr as usize => x0,
+        in("$4" /*$a0*/) a0.0,
+        in("$5" /*$a1*/) a1.0,
+        in("$6" /*$a2*/) a2.0,
+        inlateout("$7" /*$a3*/) a3.0 as usize => err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(preserves_flags, readonly)
+    );
+    R::from(Reg(if err != 0 {
+        x0.wrapping_neg() as *mut _
+    } else {
+        x0 as *mut _
+    }))
+}
+
+#[inline(always)]
+pub unsafe fn syscall6<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+    a4: impl Into<Reg>,
+    a5: impl Into<Reg>,
+) -> R {
+    let x0;
+    let err: usize;
+    asm!(
+        ".set noat",
+        "subu $sp, 32",
+        "sw {}, 16($sp)",
+        "sw {}, 20($sp)",
+        "syscall",
+        "addu $sp, 32",
+        ".set at",
+        in(reg) a4.0,
+        in(reg) a5.0,
+        inlateout("$2" /*$v0*/) nr as usize => x0,
+        in("$4" /*$a0*/) a0.0,
+        in("$5" /*$a1*/) a1.0,
+        in("$6" /*$a2*/) a2.0,
+        inlateout("$7" /*$a3*/) a3.0 as usize => err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(preserves_flags)
+    );
+    R::from(Reg(if err != 0 {
+        x0.wrapping_neg() as *mut _
+    } else {
+        x0 as *mut _
+    }))
+}
+
+#[inline(always)]
+pub unsafe fn syscall6_readonly<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+    a4: impl Into<Reg>,
+    a5: impl Into<Reg>,
+) -> R {
+    let x0;
+    let err: usize;
+    asm!(
+        ".set noat",
+        "subu $sp, 32",
+        "sw {}, 16($sp)",
+        "sw {}, 20($sp)",
+        "syscall",
+        "addu $sp, 32",
+        ".set at",
+        in(reg) a4.0,
+        in(reg) a5.0,
+        inlateout("$2" /*$v0*/) nr as usize => x0,
+        in("$4" /*$a0*/) a0.0,
+        in("$5" /*$a1*/) a1.0,
+        in("$6" /*$a2*/) a2.0,
+        inlateout("$7" /*$a3*/) a3.0 as usize => err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(preserves_flags, readonly)
+    );
+    R::from(Reg(if err != 0 {
+        x0.wrapping_neg() as *mut _
+    } else {
+        x0 as *mut _
+    }))
+}
+
+#[inline(always)]
+pub unsafe fn syscall7_readonly<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+    a4: impl Into<Reg>,
+    a5: impl Into<Reg>,
+    a6: impl Into<Reg>,
+) -> R {
+    let x0;
+    let err: usize;
+    asm!(
+        ".set noat",
+        "subu $sp, 32",
+        "sw {}, 16($sp)",
+        "sw {}, 20($sp)",
+        "sw {}, 24($sp)",
+        "syscall",
+        "addu $sp, 32",
+        ".set at",
+        in(reg) a4.0,
+        in(reg) a5.0,
+        in(reg) a6.0,
+        inlateout("$2" /*$v0*/) nr as usize => x0,
+        in("$4" /*$a0*/) a0.0,
+        in("$5" /*$a1*/) a1.0,
+        in("$6" /*$a2*/) a2.0,
+        inlateout("$7" /*$a3*/) a3.0 as usize => err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(preserves_flags, readonly)
+    );
+    R::from(Reg(if err != 0 {
+        x0.wrapping_neg() as *mut _
+    } else {
+        x0 as *mut _
+    }))
+}

--- a/src/syscall/mips32r6.rs
+++ b/src/syscall/mips32r6.rs
@@ -1,0 +1,543 @@
+//! mipsisa32r6el Linux system calls.
+//!
+//! On mipsisa32r6el, Linux indicates success or failure using `$a3` rather
+//! than by returning a negative error code as most other architectures do.
+//!
+//! Mips-family platforms have a special calling convention for `__NR_pipe`,
+//! however we use `__NR_pipe2` instead to avoid having to implement it.
+
+use crate::backend::reg::{
+    ArgReg, FromAsm, RetReg, SyscallNumber, ToAsm, A0, A1, A2, A3, A4, A5, A6, R0,
+};
+use core::arch::asm;
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall0_readonly(nr: SyscallNumber) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
+    asm!(
+        "syscall",
+        in("$2" /*$v0*/) nr.to_asm(),
+        in("$4" /*$a0*/) a0.to_asm(),
+        options(nostack, noreturn)
+    )
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall2(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall2_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall3(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall3_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall4(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall4_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall5(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        ".set noat",
+        "subu $sp, 32",
+        "sw {}, 16($sp)",
+        "syscall",
+        "addu $sp, 32",
+        ".set at",
+        in(reg) a4.to_asm(),
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall5_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        ".set noat",
+        "subu $sp, 32",
+        "sw {}, 16($sp)",
+        "syscall",
+        "addu $sp, 32",
+        ".set at",
+        in(reg) a4.to_asm(),
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall6(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        ".set noat",
+        "subu $sp, 32",
+        "sw {}, 16($sp)",
+        "sw {}, 20($sp)",
+        "syscall",
+        "addu $sp, 32",
+        ".set at",
+        in(reg) a4.to_asm(),
+        in(reg) a5.to_asm(),
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall6_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        ".set noat",
+        "subu $sp, 32",
+        "sw {}, 16($sp)",
+        "sw {}, 20($sp)",
+        "syscall",
+        "addu $sp, 32",
+        ".set at",
+        in(reg) a4.to_asm(),
+        in(reg) a5.to_asm(),
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall7_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+    a6: ArgReg<'_, A6>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        ".set noat",
+        "subu $sp, 32",
+        "sw {}, 16($sp)",
+        "sw {}, 20($sp)",
+        "sw {}, 24($sp)",
+        "syscall",
+        "addu $sp, 32",
+        ".set at",
+        in(reg) a4.to_asm(),
+        in(reg) a5.to_asm(),
+        in(reg) a6.to_asm(),
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        lateout("$8" /*$t0*/) _,
+        lateout("$9" /*$t1*/) _,
+        lateout("$10" /*$t2*/) _,
+        lateout("$11" /*$t3*/) _,
+        lateout("$12" /*$t4*/) _,
+        lateout("$13" /*$t5*/) _,
+        lateout("$14" /*$t6*/) _,
+        lateout("$15" /*$t7*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}

--- a/src/syscall/mips64.rs
+++ b/src/syscall/mips64.rs
@@ -1,0 +1,466 @@
+//! mips64el Linux system calls.
+//!
+//! On mips64el, Linux indicates success or failure using `$a3` (`$7`) rather
+//! than by returning a negative error code as most other architectures do.
+//!
+//! Mips-family platforms have a special calling convention for `__NR_pipe`,
+//! however we use `__NR_pipe2` instead to avoid having to implement it.
+
+use crate::backend::reg::{
+    ArgReg, FromAsm, RetReg, SyscallNumber, ToAsm, A0, A1, A2, A3, A4, A5, R0,
+};
+use core::arch::asm;
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall0_readonly(nr: SyscallNumber) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
+    asm!(
+        "syscall",
+        in("$2" /*$v0*/) nr.to_asm(),
+        in("$4" /*$a0*/) a0.to_asm(),
+        options(nostack, noreturn)
+    )
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall2(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall2_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall3(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall3_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall4(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall4_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall5(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        inlateout("$8" /*$a4*/) a4.to_asm() => _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall5_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        inlateout("$8" /*$a4*/) a4.to_asm() => _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall6(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        inlateout("$8" /*$a4*/) a4.to_asm() => _,
+        inlateout("$9" /*$a5*/) a5.to_asm() => _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall6_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        inlateout("$8" /*$a4*/) a4.to_asm() => _,
+        inlateout("$9" /*$a5*/) a5.to_asm() => _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}

--- a/src/syscall/mips64r6.rs
+++ b/src/syscall/mips64r6.rs
@@ -1,0 +1,470 @@
+//! mipsisa64r6el Linux system calls.
+//!
+//! On mipsisa64r6el, Linux indicates success or failure using `$a3` (`$7`)
+//! rather than by returning a negative error code as most other architectures
+//! do.
+//!
+//! Mips-family platforms have a special calling convention for `__NR_pipe`,
+//! however we use `__NR_pipe2` instead to avoid having to implement it.
+//!
+//! Note that MIPS R6 inline assembly currently doesn't differ from MIPS,
+//! because no explicit call of R6-only or R2-only instructions exist here.
+
+use crate::backend::reg::{
+    ArgReg, FromAsm, RetReg, SyscallNumber, ToAsm, A0, A1, A2, A3, A4, A5, R0,
+};
+use core::arch::asm;
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall0_readonly(nr: SyscallNumber) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
+    asm!(
+        "syscall",
+        in("$2" /*$v0*/) nr.to_asm(),
+        in("$4" /*$a0*/) a0.to_asm(),
+        options(nostack, noreturn)
+    )
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall2(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall2_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall3(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall3_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        lateout("$7" /*$a3*/) err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall4(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall4_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        lateout("$8" /*$a4*/) _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall5(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        inlateout("$8" /*$a4*/) a4.to_asm() => _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall5_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        inlateout("$8" /*$a4*/) a4.to_asm() => _,
+        lateout("$9" /*$a5*/) _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall6(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        inlateout("$8" /*$a4*/) a4.to_asm() => _,
+        inlateout("$9" /*$a5*/) a5.to_asm() => _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall6_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    let x0;
+    let err: usize;
+    asm!(
+        "syscall",
+        inlateout("$2" /*$v0*/) nr.to_asm() => x0,
+        in("$4" /*$a0*/) a0.to_asm(),
+        in("$5" /*$a1*/) a1.to_asm(),
+        in("$6" /*$a2*/) a2.to_asm(),
+        inlateout("$7" /*$a3*/) a3.to_asm() => err,
+        inlateout("$8" /*$a4*/) a4.to_asm() => _,
+        inlateout("$9" /*$a5*/) a5.to_asm() => _,
+        lateout("$10" /*$a6*/) _,
+        lateout("$11" /*$a7*/) _,
+        lateout("$12" /*$t0*/) _,
+        lateout("$13" /*$t1*/) _,
+        lateout("$14" /*$t2*/) _,
+        lateout("$15" /*$t3*/) _,
+        lateout("$24" /*$t8*/) _,
+        lateout("$25" /*$t9*/) _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(if err != 0 {
+        (x0 as usize).wrapping_neg() as *mut _
+    } else {
+        x0
+    })
+}

--- a/src/syscall/mod.rs
+++ b/src/syscall/mod.rs
@@ -1,0 +1,36 @@
+//! Sytem call functions.
+//!
+//! The calling conventions for Linux syscalls are [documented here].
+//!
+//! [documented here]: https://man7.org/linux/man-pages/man2/syscall.2.html
+//!
+//! # Safety
+//!
+//! The system call functions contains the inline `asm` statements performing the syscall
+//! instructions.
+
+// The module-level safety notice applies to all functions in this module.
+#![allow(clippy::missing_safety_doc)]
+
+/// Value passed in a CPU register.
+///
+/// This value should be casted to/from type dependent on used syscall.
+///
+/// Raw pointer is used instead of `usize` to preserve provenance.
+#[repr(transparent)]
+pub struct Reg(pub *mut ());
+
+#[cfg_attr(target_arch = "aarch64", path = "aarch64.rs")]
+#[cfg_attr(all(target_arch = "arm", not(thumb_mode)), path = "arm.rs")]
+#[cfg_attr(all(target_arch = "arm", thumb_mode), path = "thumb.rs")]
+#[cfg_attr(target_arch = "mips", path = "mips.rs")]
+#[cfg_attr(target_arch = "mips32r6", path = "mips32r6.rs")]
+#[cfg_attr(target_arch = "mips64", path = "mips64.rs")]
+#[cfg_attr(target_arch = "mips64r6", path = "mips64r6.rs")]
+#[cfg_attr(target_arch = "powerpc64", path = "powerpc64.rs")]
+#[cfg_attr(target_arch = "riscv64", path = "riscv64.rs")]
+#[cfg_attr(target_arch = "x86", path = "x86.rs")]
+#[cfg_attr(target_arch = "x86_64", path = "x86_64.rs")]
+mod asm;
+
+pub use asm::*;

--- a/src/syscall/powerpc64.rs
+++ b/src/syscall/powerpc64.rs
@@ -1,0 +1,413 @@
+//! powerpc64le Linux system calls.
+//!
+//! On powerpc64le, Linux indicates success or failure using `cr0.SO` rather
+//! than by returning a negative error code as most other architectures do. In
+//! theory we could immediately translate this into a `Result`, and it'd save a
+//! few branches. And in theory we could have specialized sequences for use
+//! with syscalls that are known to never fail. However, those would require
+//! more extensive changes in rustix's platform-independent code. For now, we
+//! check the flag and negate the error value to make PowerPC64 look like other
+//! architectures.
+
+use crate::backend::reg::{
+    ArgReg, FromAsm, RetReg, SyscallNumber, ToAsm, A0, A1, A2, A3, A4, A5, R0,
+};
+use core::arch::asm;
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall0_readonly(nr: SyscallNumber<'_>) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "sc",
+        "bns 0f",
+        "neg 3, 3",
+        "0:",
+        inlateout("r0") nr.to_asm() => _,
+        lateout("r3") r0,
+        lateout("r4") _,
+        lateout("r5") _,
+        lateout("r6") _,
+        lateout("r7") _,
+        lateout("r8") _,
+        lateout("r9") _,
+        lateout("r10") _,
+        lateout("r11") _,
+        lateout("r12") _,
+        lateout("cr0") _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "sc",
+        "bns 0f",
+        "neg 3, 3",
+        "0:",
+        inlateout("r0") nr.to_asm() => _,
+        inlateout("r3") a0.to_asm() => r0,
+        lateout("r4") _,
+        lateout("r5") _,
+        lateout("r6") _,
+        lateout("r7") _,
+        lateout("r8") _,
+        lateout("r9") _,
+        lateout("r10") _,
+        lateout("r11") _,
+        lateout("r12") _,
+        lateout("cr0") _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "sc",
+        "bns 0f",
+        "neg 3, 3",
+        "0:",
+        inlateout("r0") nr.to_asm() => _,
+        inlateout("r3") a0.to_asm() => r0,
+        lateout("r4") _,
+        lateout("r5") _,
+        lateout("r6") _,
+        lateout("r7") _,
+        lateout("r8") _,
+        lateout("r9") _,
+        lateout("r10") _,
+        lateout("r11") _,
+        lateout("r12") _,
+        lateout("cr0") _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
+    asm!(
+        "sc",
+        in("r0") nr.to_asm(),
+        in("r3") a0.to_asm(),
+        options(nostack, noreturn)
+    )
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall2(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "sc",
+        "bns 0f",
+        "neg 3, 3",
+        "0:",
+        inlateout("r0") nr.to_asm() => _,
+        inlateout("r3") a0.to_asm() => r0,
+        inlateout("r4") a1.to_asm() => _,
+        lateout("r5") _,
+        lateout("r6") _,
+        lateout("r7") _,
+        lateout("r8") _,
+        lateout("r9") _,
+        lateout("r10") _,
+        lateout("r11") _,
+        lateout("r12") _,
+        lateout("cr0") _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall2_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "sc",
+        "bns 0f",
+        "neg 3, 3",
+        "0:",
+        inlateout("r0") nr.to_asm() => _,
+        inlateout("r3") a0.to_asm() => r0,
+        inlateout("r4") a1.to_asm() => _,
+        lateout("r5") _,
+        lateout("r6") _,
+        lateout("r7") _,
+        lateout("r8") _,
+        lateout("r9") _,
+        lateout("r10") _,
+        lateout("r11") _,
+        lateout("r12") _,
+        lateout("cr0") _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall3(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "sc",
+        "bns 0f",
+        "neg 3, 3",
+        "0:",
+        inlateout("r0") nr.to_asm() => _,
+        inlateout("r3") a0.to_asm() => r0,
+        inlateout("r4") a1.to_asm() => _,
+        inlateout("r5") a2.to_asm() => _,
+        lateout("r6") _,
+        lateout("r7") _,
+        lateout("r8") _,
+        lateout("r9") _,
+        lateout("r10") _,
+        lateout("r11") _,
+        lateout("r12") _,
+        lateout("cr0") _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall3_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "sc",
+        "bns 0f",
+        "neg 3, 3",
+        "0:",
+        inlateout("r0") nr.to_asm() => _,
+        inlateout("r3") a0.to_asm() => r0,
+        inlateout("r4") a1.to_asm() => _,
+        inlateout("r5") a2.to_asm() => _,
+        lateout("r6") _,
+        lateout("r7") _,
+        lateout("r8") _,
+        lateout("r9") _,
+        lateout("r10") _,
+        lateout("r11") _,
+        lateout("r12") _,
+        lateout("cr0") _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall4(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "sc",
+        "bns 0f",
+        "neg 3, 3",
+        "0:",
+        inlateout("r0") nr.to_asm() => _,
+        inlateout("r3") a0.to_asm() => r0,
+        inlateout("r4") a1.to_asm() => _,
+        inlateout("r5") a2.to_asm() => _,
+        inlateout("r6") a3.to_asm() => _,
+        lateout("r7") _,
+        lateout("r8") _,
+        lateout("r9") _,
+        lateout("r10") _,
+        lateout("r11") _,
+        lateout("r12") _,
+        lateout("cr0") _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall4_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "sc",
+        "bns 0f",
+        "neg 3, 3",
+        "0:",
+        inlateout("r0") nr.to_asm() => _,
+        inlateout("r3") a0.to_asm() => r0,
+        inlateout("r4") a1.to_asm() => _,
+        inlateout("r5") a2.to_asm() => _,
+        inlateout("r6") a3.to_asm() => _,
+        lateout("r7") _,
+        lateout("r8") _,
+        lateout("r9") _,
+        lateout("r10") _,
+        lateout("r11") _,
+        lateout("r12") _,
+        lateout("cr0") _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall5(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "sc",
+        "bns 0f",
+        "neg 3, 3",
+        "0:",
+        inlateout("r0") nr.to_asm() => _,
+        inlateout("r3") a0.to_asm() => r0,
+        inlateout("r4") a1.to_asm() => _,
+        inlateout("r5") a2.to_asm() => _,
+        inlateout("r6") a3.to_asm() => _,
+        inlateout("r7") a4.to_asm() => _,
+        lateout("r8") _,
+        lateout("r9") _,
+        lateout("r10") _,
+        lateout("r11") _,
+        lateout("r12") _,
+        lateout("cr0") _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall5_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "sc",
+        "bns 0f",
+        "neg 3, 3",
+        "0:",
+        inlateout("r0") nr.to_asm() => _,
+        inlateout("r3") a0.to_asm() => r0,
+        inlateout("r4") a1.to_asm() => _,
+        inlateout("r5") a2.to_asm() => _,
+        inlateout("r6") a3.to_asm() => _,
+        inlateout("r7") a4.to_asm() => _,
+        lateout("r8") _,
+        lateout("r9") _,
+        lateout("r10") _,
+        lateout("r11") _,
+        lateout("r12") _,
+        lateout("cr0") _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall6(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "sc",
+        "bns 0f",
+        "neg 3, 3",
+        "0:",
+        inlateout("r0") nr.to_asm() => _,
+        inlateout("r3") a0.to_asm() => r0,
+        inlateout("r4") a1.to_asm() => _,
+        inlateout("r5") a2.to_asm() => _,
+        inlateout("r6") a3.to_asm() => _,
+        inlateout("r7") a4.to_asm() => _,
+        inlateout("r8") a5.to_asm() => _,
+        lateout("r9") _,
+        lateout("r10") _,
+        lateout("r11") _,
+        lateout("r12") _,
+        lateout("cr0") _,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall6_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "sc",
+        "bns 0f",
+        "neg 3, 3",
+        "0:",
+        inlateout("r0") nr.to_asm() => _,
+        inlateout("r3") a0.to_asm() => r0,
+        inlateout("r4") a1.to_asm() => _,
+        inlateout("r5") a2.to_asm() => _,
+        inlateout("r6") a3.to_asm() => _,
+        inlateout("r7") a4.to_asm() => _,
+        inlateout("r8") a5.to_asm() => _,
+        lateout("r9") _,
+        lateout("r10") _,
+        lateout("r11") _,
+        lateout("r12") _,
+        lateout("cr0") _,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}

--- a/src/syscall/riscv64.rs
+++ b/src/syscall/riscv64.rs
@@ -1,0 +1,265 @@
+//! riscv64 Linux system calls.
+
+use crate::backend::reg::{
+    ArgReg, FromAsm, RetReg, SyscallNumber, ToAsm, A0, A1, A2, A3, A4, A5, R0,
+};
+use core::arch::asm;
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall0_readonly(nr: SyscallNumber<'_>) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "ecall",
+        in("a7") nr.to_asm(),
+        lateout("a0") r0,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "ecall",
+        in("a7") nr.to_asm(),
+        inlateout("a0") a0.to_asm() => r0,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "ecall",
+        in("a7") nr.to_asm(),
+        inlateout("a0") a0.to_asm() => r0,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
+    asm!(
+        "ecall",
+        in("a7") nr.to_asm(),
+        in("a0") a0.to_asm(),
+        options(nostack, noreturn)
+    );
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall2(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "ecall",
+        in("a7") nr.to_asm(),
+        inlateout("a0") a0.to_asm() => r0,
+        in("a1") a1.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall2_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "ecall",
+        in("a7") nr.to_asm(),
+        inlateout("a0") a0.to_asm() => r0,
+        in("a1") a1.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall3(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "ecall",
+        in("a7") nr.to_asm(),
+        inlateout("a0") a0.to_asm() => r0,
+        in("a1") a1.to_asm(),
+        in("a2") a2.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall3_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "ecall",
+        in("a7") nr.to_asm(),
+        inlateout("a0") a0.to_asm() => r0,
+        in("a1") a1.to_asm(),
+        in("a2") a2.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall4(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "ecall",
+        in("a7") nr.to_asm(),
+        inlateout("a0") a0.to_asm() => r0,
+        in("a1") a1.to_asm(),
+        in("a2") a2.to_asm(),
+        in("a3") a3.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall4_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "ecall",
+        in("a7") nr.to_asm(),
+        inlateout("a0") a0.to_asm() => r0,
+        in("a1") a1.to_asm(),
+        in("a2") a2.to_asm(),
+        in("a3") a3.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall5(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "ecall",
+        in("a7") nr.to_asm(),
+        inlateout("a0") a0.to_asm() => r0,
+        in("a1") a1.to_asm(),
+        in("a2") a2.to_asm(),
+        in("a3") a3.to_asm(),
+        in("a4") a4.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall5_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "ecall",
+        in("a7") nr.to_asm(),
+        inlateout("a0") a0.to_asm() => r0,
+        in("a1") a1.to_asm(),
+        in("a2") a2.to_asm(),
+        in("a3") a3.to_asm(),
+        in("a4") a4.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall6(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "ecall",
+        in("a7") nr.to_asm(),
+        inlateout("a0") a0.to_asm() => r0,
+        in("a1") a1.to_asm(),
+        in("a2") a2.to_asm(),
+        in("a3") a3.to_asm(),
+        in("a4") a4.to_asm(),
+        in("a5") a5.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall6_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "ecall",
+        in("a7") nr.to_asm(),
+        inlateout("a0") a0.to_asm() => r0,
+        in("a1") a1.to_asm(),
+        in("a2") a2.to_asm(),
+        in("a3") a3.to_asm(),
+        in("a4") a4.to_asm(),
+        in("a5") a5.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}

--- a/src/syscall/thumb.rs
+++ b/src/syscall/thumb.rs
@@ -1,0 +1,322 @@
+//! arm Linux system calls, using thumb-mode.
+//!
+//! In thumb-mode, r7 is the frame pointer and is not permitted to be used in
+//! an inline asm operand, so we have to use a different register and copy it
+//! into r7 inside the inline asm.
+
+use crate::backend::reg::{
+    ArgReg, FromAsm, RetReg, SyscallNumber, ToAsm, A0, A1, A2, A3, A4, A5, R0,
+};
+use core::arch::asm;
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall0_readonly(nr: SyscallNumber<'_>) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        lateout("r0") r0,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        inlateout("r0") a0.to_asm() => r0,
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        inlateout("r0") a0.to_asm() => r0,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
+    asm!(
+        "mov r7, {nr}",
+        "svc 0",
+        nr = in(reg) nr.to_asm(),
+        in("r0") a0.to_asm(),
+        options(nostack, noreturn)
+    )
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall2(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        inlateout("r0") a0.to_asm() => r0,
+        in("r1") a1.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall2_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        inlateout("r0") a0.to_asm() => r0,
+        in("r1") a1.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall3(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        inlateout("r0") a0.to_asm() => r0,
+        in("r1") a1.to_asm(),
+        in("r2") a2.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall3_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        inlateout("r0") a0.to_asm() => r0,
+        in("r1") a1.to_asm(),
+        in("r2") a2.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall4(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        inlateout("r0") a0.to_asm() => r0,
+        in("r1") a1.to_asm(),
+        in("r2") a2.to_asm(),
+        in("r3") a3.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall4_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        inlateout("r0") a0.to_asm() => r0,
+        in("r1") a1.to_asm(),
+        in("r2") a2.to_asm(),
+        in("r3") a3.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall5(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        inlateout("r0") a0.to_asm() => r0,
+        in("r1") a1.to_asm(),
+        in("r2") a2.to_asm(),
+        in("r3") a3.to_asm(),
+        in("r4") a4.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall5_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        inlateout("r0") a0.to_asm() => r0,
+        in("r1") a1.to_asm(),
+        in("r2") a2.to_asm(),
+        in("r3") a3.to_asm(),
+        in("r4") a4.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall6(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        inlateout("r0") a0.to_asm() => r0,
+        in("r1") a1.to_asm(),
+        in("r2") a2.to_asm(),
+        in("r3") a3.to_asm(),
+        in("r4") a4.to_asm(),
+        in("r5") a5.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall6_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "mov {tmp}, r7",
+        "mov r7, {nr}",
+        "svc 0",
+        "mov r7, {tmp}",
+        nr = in(reg) nr.to_asm(),
+        tmp = out(reg) _,
+        inlateout("r0") a0.to_asm() => r0,
+        in("r1") a1.to_asm(),
+        in("r2") a2.to_asm(),
+        in("r3") a3.to_asm(),
+        in("r4") a4.to_asm(),
+        in("r5") a5.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}

--- a/src/syscall/x86.rs
+++ b/src/syscall/x86.rs
@@ -1,0 +1,489 @@
+//! 32-bit x86 Linux system calls.
+//!
+//! There are two forms; `indirect_*` which take a callee, which allow calling
+//! through the vDSO when possible, and plain forms, which use the `int 0x80`
+//! instruction.
+//!
+//! Most `rustix` syscalls use the vsyscall mechanism rather than going using
+//! `int 0x80` sequences, as vsyscall is much faster.
+//!
+//! Syscalls made with `int 0x80` preserve the flags register, while syscalls
+//! made using vsyscall do not.
+
+#![allow(dead_code)]
+
+use crate::backend::reg::{
+    ArgReg, FromAsm, RetReg, SyscallNumber, ToAsm, A0, A1, A2, A3, A4, A5, R0,
+};
+use crate::backend::vdso_wrappers::SyscallType;
+use core::arch::asm;
+
+#[inline]
+pub(in crate::backend) unsafe fn indirect_syscall0(
+    callee: SyscallType,
+    nr: SyscallNumber<'_>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "call {callee}",
+        callee = in(reg) callee,
+        inlateout("eax") nr.to_asm() => r0,
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn indirect_syscall1(
+    callee: SyscallType,
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "call {callee}",
+        callee = in(reg) callee,
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn indirect_syscall1_noreturn(
+    callee: SyscallType,
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+) -> ! {
+    asm!(
+        "call {callee}",
+        callee = in(reg) callee,
+        in("eax") nr.to_asm(),
+        in("ebx") a0.to_asm(),
+        options(noreturn)
+    )
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn indirect_syscall2(
+    callee: SyscallType,
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "call {callee}",
+        callee = in(reg) callee,
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn indirect_syscall3(
+    callee: SyscallType,
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "call {callee}",
+        callee = in(reg) callee,
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        in("edx") a2.to_asm(),
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn indirect_syscall4(
+    callee: SyscallType,
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    let r0;
+    // a3 should go in esi, but `asm!` won't let us use it as an operand.
+    // Temporarily swap it into place, and then swap it back afterward.
+    //
+    // We hard-code the callee operand to use edi instead of `in(reg)` because
+    // even though we can't name esi as an operand, the compiler can use esi to
+    // satisfy `in(reg)`.
+    asm!(
+        "xchg esi, {a3}",
+        "call edi",
+        "xchg esi, {a3}",
+        a3 = in(reg) a3.to_asm(),
+        in("edi") callee,
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        in("edx") a2.to_asm(),
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn indirect_syscall5(
+    callee: SyscallType,
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    let r0;
+    // Oof. a3 should go in esi, and `asm!` won't let us use that register as
+    // an operand. And we can't request stack slots. And there are no other
+    // registers free. Use eax as a temporary pointer to a slice, since it gets
+    // clobbered as the return value anyway.
+    asm!(
+        "push esi",
+        "push [eax + 0]",
+        "mov esi, [eax + 4]",
+        "mov eax, [eax + 8]",
+        "call [esp]",
+        "pop esi",
+        "pop esi",
+        inout("eax") &[callee as _, a3.to_asm(), nr.to_asm()] => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        in("edx") a2.to_asm(),
+        in("edi") a4.to_asm(),
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn indirect_syscall6(
+    callee: SyscallType,
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    let r0;
+    // Oof again. a3 should go in esi, and a5 should go in ebp, and `asm!`
+    // won't let us use either of those registers as operands. And we can't
+    // request stack slots. And there are no other registers free. Use eax as a
+    // temporary pointer to a slice, since it gets clobbered as the return
+    // value anyway.
+    //
+    // This is another reason that syscalls should be compiler intrinsics
+    // rather than inline asm.
+    asm!(
+        "push ebp",
+        "push esi",
+        "push [eax + 0]",
+        "mov esi, [eax + 4]",
+        "mov ebp, [eax + 8]",
+        "mov eax, [eax + 12]",
+        "call [esp]",
+        "pop esi",
+        "pop esi",
+        "pop ebp",
+        inout("eax") &[callee as _, a3.to_asm(), a5.to_asm(), nr.to_asm()] => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        in("edx") a2.to_asm(),
+        in("edi") a4.to_asm(),
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall0_readonly(nr: SyscallNumber<'_>) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "int $$0x80",
+        inlateout("eax") nr.to_asm() => r0,
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "int $$0x80",
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "int $$0x80",
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall1_noreturn(nr: SyscallNumber<'_>, a0: ArgReg<'_, A0>) -> ! {
+    asm!(
+        "int $$0x80",
+        in("eax") nr.to_asm(),
+        in("ebx") a0.to_asm(),
+        options(nostack, noreturn)
+    )
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall2(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "int $$0x80",
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall2_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "int $$0x80",
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall3(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "int $$0x80",
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        in("edx") a2.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall3_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "int $$0x80",
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        in("edx") a2.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall4(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    let r0;
+    // a3 should go in esi, but `asm!` won't let us use it as an operand.
+    // Temporarily swap it into place, and then swap it back afterward.
+    asm!(
+        "xchg esi, {a3}",
+        "int $$0x80",
+        "xchg esi, {a3}",
+        a3 = in(reg) a3.to_asm(),
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        in("edx") a2.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall4_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+) -> RetReg<R0> {
+    let r0;
+    asm!(
+        "xchg esi, {a3}",
+        "int $$0x80",
+        "xchg esi, {a3}",
+        a3 = in(reg) a3.to_asm(),
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        in("edx") a2.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall5(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    let r0;
+    // As in `syscall4`, use xchg to handle a3. a4 should go in edi, and we can
+    // use that register as an operand. Unlike in `indirect_syscall5`, we don't
+    // have a `callee` operand taking up a register, so we have enough
+    // registers and don't need to use a slice.
+    asm!(
+        "xchg esi, {a3}",
+        "int $$0x80",
+        "xchg esi, {a3}",
+        a3 = in(reg) a3.to_asm(),
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        in("edx") a2.to_asm(),
+        in("edi") a4.to_asm(),
+        options(nostack, preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall5_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+) -> RetReg<R0> {
+    let r0;
+    // See the comments in `syscall5`.
+    asm!(
+        "xchg esi, {a3}",
+        "int $$0x80",
+        "xchg esi, {a3}",
+        a3 = in(reg) a3.to_asm(),
+        inlateout("eax") nr.to_asm() => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        in("edx") a2.to_asm(),
+        in("edi") a4.to_asm(),
+        options(nostack, preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall6(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    let r0;
+    // See the comments in `indirect_syscall6`.
+    asm!(
+        "push ebp",
+        "push esi",
+        "mov esi, [eax + 0]",
+        "mov ebp, [eax + 4]",
+        "mov eax, [eax + 8]",
+        "int $$0x80",
+        "pop esi",
+        "pop ebp",
+        inout("eax") &[a3.to_asm(), a5.to_asm(), nr.to_asm()] => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        in("edx") a2.to_asm(),
+        in("edi") a4.to_asm(),
+        options(preserves_flags)
+    );
+    FromAsm::from_asm(r0)
+}
+
+#[inline]
+pub(in crate::backend) unsafe fn syscall6_readonly(
+    nr: SyscallNumber<'_>,
+    a0: ArgReg<'_, A0>,
+    a1: ArgReg<'_, A1>,
+    a2: ArgReg<'_, A2>,
+    a3: ArgReg<'_, A3>,
+    a4: ArgReg<'_, A4>,
+    a5: ArgReg<'_, A5>,
+) -> RetReg<R0> {
+    let r0;
+    // See the comments in `indirect_syscall6`.
+    asm!(
+        "push ebp",
+        "push esi",
+        "mov esi, [eax + 0]",
+        "mov ebp, [eax + 4]",
+        "mov eax, [eax + 8]",
+        "int $$0x80",
+        "pop esi",
+        "pop ebp",
+        inout("eax") &[a3.to_asm(), a5.to_asm(), nr.to_asm()] => r0,
+        in("ebx") a0.to_asm(),
+        in("ecx") a1.to_asm(),
+        in("edx") a2.to_asm(),
+        in("edi") a4.to_asm(),
+        options(preserves_flags, readonly)
+    );
+    FromAsm::from_asm(r0)
+}

--- a/src/syscall/x86_64.rs
+++ b/src/syscall/x86_64.rs
@@ -1,0 +1,284 @@
+//! x86-64 Linux system calls.
+
+use super::Reg;
+use core::arch::asm;
+
+#[cfg(target_pointer_width = "32")]
+compile_error!("x32 is not yet supported");
+
+#[inline(always)]
+pub unsafe fn syscall0_readonly<R: From<Reg>>(nr: u32) -> R {
+    let r0;
+    asm!(
+        "syscall",
+        inlateout("rax") nr as *mut () => r0,
+        lateout("rcx") _,
+        lateout("r11") _,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub unsafe fn syscall1<R: From<Reg>>(nr: u32, a0: impl Into<Reg>) -> R {
+    let r0;
+    asm!(
+        "syscall",
+        inlateout("rax") nr as *mut () => r0,
+        in("rdi") a0.into().0,
+        lateout("rcx") _,
+        lateout("r11") _,
+        options(nostack, preserves_flags)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub unsafe fn syscall1_readonly<R: From<Reg>>(nr: u32, a0: impl Into<Reg>) -> R {
+    let r0;
+    asm!(
+        "syscall",
+        inlateout("rax") nr as *mut () => r0,
+        in("rdi") a0.into().0,
+        lateout("rcx") _,
+        lateout("r11") _,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub unsafe fn syscall1_noreturn<R: From<Reg>>(nr: u32, a0: impl Into<Reg>) -> ! {
+    asm!(
+        "syscall",
+        in("rax") nr as *mut (),
+        in("rdi") a0.into().0,
+        options(nostack, noreturn)
+    )
+}
+
+#[inline(always)]
+pub unsafe fn syscall2<R: From<Reg>>(nr: u32, a0: impl Into<Reg>, a1: impl Into<Reg>) -> R {
+    let r0;
+    asm!(
+        "syscall",
+        inlateout("rax") nr as *mut () => r0,
+        in("rdi") a0.into().0,
+        in("rsi") a1.into().0,
+        lateout("rcx") _,
+        lateout("r11") _,
+        options(nostack, preserves_flags)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub unsafe fn syscall2_readonly<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "syscall",
+        inlateout("rax") nr as *mut () => r0,
+        in("rdi") a0.into().0,
+        in("rsi") a1.into().0,
+        lateout("rcx") _,
+        lateout("r11") _,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub unsafe fn syscall3<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "syscall",
+        inlateout("rax") nr as *mut () => r0,
+        in("rdi") a0.into().0,
+        in("rsi") a1.into().0,
+        in("rdx") a2.into().0,
+        lateout("rcx") _,
+        lateout("r11") _,
+        options(nostack, preserves_flags)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub unsafe fn syscall3_readonly<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "syscall",
+        inlateout("rax") nr as *mut () => r0,
+        in("rdi") a0.into().0,
+        in("rsi") a1.into().0,
+        in("rdx") a2.into().0,
+        lateout("rcx") _,
+        lateout("r11") _,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub unsafe fn syscall4<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "syscall",
+        inlateout("rax") nr as *mut () => r0,
+        in("rdi") a0.into().0,
+        in("rsi") a1.into().0,
+        in("rdx") a2.into().0,
+        in("r10") a3.into().0,
+        lateout("rcx") _,
+        lateout("r11") _,
+        options(nostack, preserves_flags)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub unsafe fn syscall4_readonly<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "syscall",
+        inlateout("rax") nr as *mut () => r0,
+        in("rdi") a0.into().0,
+        in("rsi") a1.into().0,
+        in("rdx") a2.into().0,
+        in("r10") a3.into().0,
+        lateout("rcx") _,
+        lateout("r11") _,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub unsafe fn syscall5<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+    a4: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "syscall",
+        inlateout("rax") nr as *mut () => r0,
+        in("rdi") a0.into().0,
+        in("rsi") a1.into().0,
+        in("rdx") a2.into().0,
+        in("r10") a3.into().0,
+        in("r8") a4.into().0,
+        lateout("rcx") _,
+        lateout("r11") _,
+        options(nostack, preserves_flags)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub unsafe fn syscall5_readonly<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+    a4: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "syscall",
+        inlateout("rax") nr as *mut () => r0,
+        in("rdi") a0.into().0,
+        in("rsi") a1.into().0,
+        in("rdx") a2.into().0,
+        in("r10") a3.into().0,
+        in("r8") a4.into().0,
+        lateout("rcx") _,
+        lateout("r11") _,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub unsafe fn syscall6<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+    a4: impl Into<Reg>,
+    a5: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "syscall",
+        inlateout("rax") nr as *mut () => r0,
+        in("rdi") a0.into().0,
+        in("rsi") a1.into().0,
+        in("rdx") a2.into().0,
+        in("r10") a3.into().0,
+        in("r8") a4.into().0,
+        in("r9") a5.into().0,
+        lateout("rcx") _,
+        lateout("r11") _,
+        options(nostack, preserves_flags)
+    );
+    R::from(Reg(r0))
+}
+
+#[inline(always)]
+pub unsafe fn syscall6_readonly<R: From<Reg>>(
+    nr: u32,
+    a0: impl Into<Reg>,
+    a1: impl Into<Reg>,
+    a2: impl Into<Reg>,
+    a3: impl Into<Reg>,
+    a4: impl Into<Reg>,
+    a5: impl Into<Reg>,
+) -> R {
+    let r0;
+    asm!(
+        "syscall",
+        inlateout("rax") nr as *mut () => r0,
+        in("rdi") a0.into().0,
+        in("rsi") a1.into().0,
+        in("rdx") a2.into().0,
+        in("r10") a3.into().0,
+        in("r8") a4.into().0,
+        in("r9") a5.into().0,
+        lateout("rcx") _,
+        lateout("r11") _,
+        options(nostack, preserves_flags, readonly)
+    );
+    R::from(Reg(r0))
+}


### PR DESCRIPTION
Draft for resolving https://github.com/bytecodealliance/rustix/issues/1055

If the outlined approach is acceptable, I will port the remaining arches and tweak the `gen` crate.

I am not sure what to do with x86. Duplicating the vDSO stuff looks a bit too heavy, while using `into 0x80` would be too inefficient. We could use the GS register with 0x10 offset, but IIUC it relies on C runtime, which may not be present in some rare cases and the offset may not be stable across platforms. After cursory reading it looks like we could use the `sysenter` instruction, it's performance should be comparable to vDSO, but I wonder why it was not used in the `rustix` crate.