### PR TITLE
Add definition of `c_char` for SPARC

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod ctypes {
     #[cfg(any(
         target_arch = "mips",
         target_arch = "mips64",
+        target_arch = "sparc",
         target_arch = "sparc64",
         target_arch = "x86",
         target_arch = "x86_64",


### PR DESCRIPTION
SPARC 32 bit is a tier 3 platform in Rust, though rustix checks against it. A proposed update to 0.6.4 for this library degraded those checks as SPARC 32 bit lacks a definition for `c_char`.

The best evidence I could find as to the signedness of SPARC 32 bit is the blog post linked below, though I have not replicated their findings.

https://github.com/bytecodealliance/rustix/actions/runs/8955815255/job/24596945878?pr=1056 https://trofi.github.io/posts/203-signed-char-or-unsigned-char.html