### PR TITLE
Update `xdp.h`file to kernel version 6.8

### DIFF
--- a/gen/modules/xdp.h
+++ b/gen/modules/xdp.h
@@ -8,7 +8,7 @@
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0)
 #include <linux/if_xdp.h>
 
-// v1 versions of xdp structs. They are defined in linux/net/xdp/xsk.c and
+// Previous versions of xdp structs. They are defined in linux/net/xdp/xsk.c and
 // don't appear in header files, so they are defined here for backwards compatibility.
 
 // https://github.com/torvalds/linux/blob/v6.6/net/xdp/xsk.h#L14-L18
@@ -34,21 +34,21 @@ struct xdp_umem_reg_v1 {
     __u32 headroom;
 };
 
+// https://github.com/torvalds/linux/blob/v6.8/net/xdp/xsk.c#L1334-L1340
+struct xdp_umem_reg_v2 {
+	__u64 addr;
+	__u64 len;
+	__u32 chunk_size;
+	__u32 headroom;
+	__u32 flags;
+};
+
 // https://github.com/torvalds/linux/blob/v6.6/net/xdp/xsk.c#L1367-L1371
 struct xdp_statistics_v1 {
     __u64 rx_dropped;
     __u64 rx_invalid_descs;
     __u64 tx_invalid_descs;
 };
-
-// The following two definitions were added in kernel version 6.6 and can be removed
-// when the crate is updated to kernel version 6.6.
-
-// https://github.com/torvalds/linux/blob/master/include/uapi/linux/if_xdp.h#L33
-#define XDP_USE_SG	(1 << 4)
-
-// https://github.com/torvalds/linux/blob/master/include/uapi/linux/if_xdp.h#L122
-#define XDP_PKT_CONTD (1 << 0)
 
 #endif
 

--- a/src/aarch64/xdp.rs
+++ b/src/aarch64/xdp.rs
@@ -149,6 +149,15 @@ pub headroom: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct xdp_umem_reg_v2 {
+pub addr: __u64,
+pub len: __u64,
+pub chunk_size: __u32,
+pub headroom: __u32,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct xdp_statistics_v1 {
 pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,

--- a/src/arm/xdp.rs
+++ b/src/arm/xdp.rs
@@ -147,6 +147,15 @@ pub headroom: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct xdp_umem_reg_v2 {
+pub addr: __u64,
+pub len: __u64,
+pub chunk_size: __u32,
+pub headroom: __u32,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct xdp_statistics_v1 {
 pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,

--- a/src/csky/xdp.rs
+++ b/src/csky/xdp.rs
@@ -147,6 +147,15 @@ pub headroom: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct xdp_umem_reg_v2 {
+pub addr: __u64,
+pub len: __u64,
+pub chunk_size: __u32,
+pub headroom: __u32,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct xdp_statistics_v1 {
 pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,

--- a/src/loongarch64/xdp.rs
+++ b/src/loongarch64/xdp.rs
@@ -149,6 +149,15 @@ pub headroom: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct xdp_umem_reg_v2 {
+pub addr: __u64,
+pub len: __u64,
+pub chunk_size: __u32,
+pub headroom: __u32,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct xdp_statistics_v1 {
 pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,

--- a/src/mips/xdp.rs
+++ b/src/mips/xdp.rs
@@ -147,6 +147,15 @@ pub headroom: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct xdp_umem_reg_v2 {
+pub addr: __u64,
+pub len: __u64,
+pub chunk_size: __u32,
+pub headroom: __u32,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct xdp_statistics_v1 {
 pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,

--- a/src/mips32r6/xdp.rs
+++ b/src/mips32r6/xdp.rs
@@ -147,6 +147,15 @@ pub headroom: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct xdp_umem_reg_v2 {
+pub addr: __u64,
+pub len: __u64,
+pub chunk_size: __u32,
+pub headroom: __u32,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct xdp_statistics_v1 {
 pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,

--- a/src/mips64/xdp.rs
+++ b/src/mips64/xdp.rs
@@ -149,6 +149,15 @@ pub headroom: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct xdp_umem_reg_v2 {
+pub addr: __u64,
+pub len: __u64,
+pub chunk_size: __u32,
+pub headroom: __u32,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct xdp_statistics_v1 {
 pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,

--- a/src/mips64r6/xdp.rs
+++ b/src/mips64r6/xdp.rs
@@ -149,6 +149,15 @@ pub headroom: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct xdp_umem_reg_v2 {
+pub addr: __u64,
+pub len: __u64,
+pub chunk_size: __u32,
+pub headroom: __u32,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct xdp_statistics_v1 {
 pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,

--- a/src/powerpc/xdp.rs
+++ b/src/powerpc/xdp.rs
@@ -153,6 +153,15 @@ pub headroom: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct xdp_umem_reg_v2 {
+pub addr: __u64,
+pub len: __u64,
+pub chunk_size: __u32,
+pub headroom: __u32,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct xdp_statistics_v1 {
 pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,

--- a/src/powerpc64/xdp.rs
+++ b/src/powerpc64/xdp.rs
@@ -155,6 +155,15 @@ pub headroom: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct xdp_umem_reg_v2 {
+pub addr: __u64,
+pub len: __u64,
+pub chunk_size: __u32,
+pub headroom: __u32,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct xdp_statistics_v1 {
 pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,

--- a/src/riscv32/xdp.rs
+++ b/src/riscv32/xdp.rs
@@ -147,6 +147,15 @@ pub headroom: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct xdp_umem_reg_v2 {
+pub addr: __u64,
+pub len: __u64,
+pub chunk_size: __u32,
+pub headroom: __u32,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct xdp_statistics_v1 {
 pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,

--- a/src/riscv64/xdp.rs
+++ b/src/riscv64/xdp.rs
@@ -149,6 +149,15 @@ pub headroom: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct xdp_umem_reg_v2 {
+pub addr: __u64,
+pub len: __u64,
+pub chunk_size: __u32,
+pub headroom: __u32,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct xdp_statistics_v1 {
 pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,

--- a/src/s390x/xdp.rs
+++ b/src/s390x/xdp.rs
@@ -163,6 +163,15 @@ pub headroom: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct xdp_umem_reg_v2 {
+pub addr: __u64,
+pub len: __u64,
+pub chunk_size: __u32,
+pub headroom: __u32,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct xdp_statistics_v1 {
 pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,

--- a/src/sparc/xdp.rs
+++ b/src/sparc/xdp.rs
@@ -147,6 +147,15 @@ pub headroom: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct xdp_umem_reg_v2 {
+pub addr: __u64,
+pub len: __u64,
+pub chunk_size: __u32,
+pub headroom: __u32,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct xdp_statistics_v1 {
 pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,

--- a/src/sparc64/xdp.rs
+++ b/src/sparc64/xdp.rs
@@ -155,6 +155,15 @@ pub headroom: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct xdp_umem_reg_v2 {
+pub addr: __u64,
+pub len: __u64,
+pub chunk_size: __u32,
+pub headroom: __u32,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct xdp_statistics_v1 {
 pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,

--- a/src/x32/xdp.rs
+++ b/src/x32/xdp.rs
@@ -149,6 +149,15 @@ pub headroom: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct xdp_umem_reg_v2 {
+pub addr: __u64,
+pub len: __u64,
+pub chunk_size: __u32,
+pub headroom: __u32,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct xdp_statistics_v1 {
 pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,

--- a/src/x86/xdp.rs
+++ b/src/x86/xdp.rs
@@ -147,6 +147,15 @@ pub headroom: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct xdp_umem_reg_v2 {
+pub addr: __u64,
+pub len: __u64,
+pub chunk_size: __u32,
+pub headroom: __u32,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct xdp_statistics_v1 {
 pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,

--- a/src/x86_64/xdp.rs
+++ b/src/x86_64/xdp.rs
@@ -149,6 +149,15 @@ pub headroom: __u32,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct xdp_umem_reg_v2 {
+pub addr: __u64,
+pub len: __u64,
+pub chunk_size: __u32,
+pub headroom: __u32,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct xdp_statistics_v1 {
 pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,


### PR DESCRIPTION
* Removes back-ported definitions no longer needed since targeting kernel 6.8.
* Adds `xdp_umem_reg_v2` since it does not appear in the if_xdp.h file