### PR TITLE
Add c_char definition for loongarch64

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod ctypes {
     ))]
     pub type c_char = c_uchar;
     #[cfg(any(
+        target_arch = "loongarch64"
         target_arch = "mips",
         target_arch = "mips64",
         target_arch = "sparc",


### PR DESCRIPTION
This PR sets c_char value to signed for loongarch64

> For all [base ABI types](https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html#base-abi-type-marks) of LoongArch, the char datatype is signed by default.

https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html