### PR TITLE
Don't warn about `target_arch = "xtensa". (#128)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,5 +75,5 @@ jobs:
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo add-apt-repository -y 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy main'
         sudo apt install libclang-dev
-        cd gen && LD_LIBRARY_PATH=/usr/lib/llvm-19/lib cargo run --release
+        cd gen && LD_LIBRARY_PATH=/usr/lib/llvm-20/lib cargo run --release
         git diff --exit-code

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,12 @@ libc = "0.2.100"
 features = ["default", "bootparam", "ioctl", "netlink", "io_uring", "if_arp", "if_ether", "if_packet", "net", "prctl", "elf", "xdp", "mempolicy", "system", "loop_device"]
 targets = ["x86_64-unknown-linux-gnu", "i686-unknown-linux-gnu"]
 
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(target_arch, values("xtensa"))',
+]
+
 # The rest of this file is auto-generated!
 [features]
 bootparam = []


### PR DESCRIPTION
* Don't warn about `target_arch = "xtensa".

* Update LLVM version.