### PR TITLE
Update bindings to linux 6.11

### DIFF
--- a/gen/src/main.rs
+++ b/gen/src/main.rs
@@ -10,7 +10,7 @@ use std::process::Command;
 use std::{env, fs};
 
 #[allow(unused_doc_comments)]
-const LINUX_VERSION: &str = "v6.8";
+const LINUX_VERSION: &str = "v6.11";
 
 /// Some commonly used features.
 const DEFAULT_FEATURES: &str = "\"general\", \"errno\"";

--- a/src/aarch64/btrfs.rs
+++ b/src/aarch64/btrfs.rs
@@ -138,7 +138,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -156,7 +156,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -166,6 +167,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -181,6 +183,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -247,6 +261,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -857,10 +890,17 @@ pub physical: __le64,
 }
 #[repr(C, packed)]
 pub struct btrfs_stripe_extent {
-pub encoding: __u8,
-pub reserved: [__u8; 7usize],
+pub __bindgen_anon_1: btrfs_stripe_extent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct btrfs_stripe_extent__bindgen_ty_1 {
+pub __empty_strides: btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1,
 pub strides: __IncompleteArrayField<btrfs_raid_stride>,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct btrfs_extent_item {
@@ -1129,6 +1169,7 @@ pub encryption: __u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _IOC_NRBITS: u32 = 8;
 pub const _IOC_TYPEBITS: u32 = 8;
 pub const _IOC_SIZEBITS: u32 = 14;
@@ -1276,13 +1317,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1354,6 +1399,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1386,6 +1432,7 @@ pub const BTRFS_QGROUP_LIMIT_RSV_EXCL: u32 = 8;
 pub const BTRFS_QGROUP_LIMIT_RFER_CMPR: u32 = 16;
 pub const BTRFS_QGROUP_LIMIT_EXCL_CMPR: u32 = 32;
 pub const BTRFS_QGROUP_INHERIT_SET_LIMITS: u32 = 1;
+pub const BTRFS_QGROUP_INHERIT_FLAGS_SUPP: u32 = 1;
 pub const BTRFS_DEVICE_REMOVE_ARGS_MASK: u32 = 8;
 pub const BTRFS_SUBVOL_CREATE_ARGS_MASK: u32 = 6;
 pub const BTRFS_SUBVOL_DELETE_ARGS_MASK: u32 = 16;
@@ -1591,14 +1638,6 @@ pub const BTRFS_SYSTEM_CHUNK_ARRAY_SIZE: u32 = 2048;
 pub const BTRFS_NUM_BACKUP_ROOTS: u32 = 4;
 pub const BTRFS_FREE_SPACE_EXTENT: u32 = 1;
 pub const BTRFS_FREE_SPACE_BITMAP: u32 = 2;
-pub const BTRFS_STRIPE_RAID0: u32 = 1;
-pub const BTRFS_STRIPE_RAID1: u32 = 2;
-pub const BTRFS_STRIPE_DUP: u32 = 3;
-pub const BTRFS_STRIPE_RAID10: u32 = 4;
-pub const BTRFS_STRIPE_RAID5: u32 = 5;
-pub const BTRFS_STRIPE_RAID6: u32 = 6;
-pub const BTRFS_STRIPE_RAID1C3: u32 = 7;
-pub const BTRFS_STRIPE_RAID1C4: u32 = 8;
 pub const BTRFS_HEADER_FLAG_WRITTEN: u32 = 1;
 pub const BTRFS_HEADER_FLAG_RELOC: u32 = 2;
 pub const BTRFS_SUPER_FLAG_ERROR: u32 = 4;
@@ -1607,6 +1646,9 @@ pub const BTRFS_SUPER_FLAG_METADUMP: u64 = 8589934592;
 pub const BTRFS_SUPER_FLAG_METADUMP_V2: u64 = 17179869184;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID: u64 = 34359738368;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID_V2: u64 = 68719476736;
+pub const BTRFS_SUPER_FLAG_CHANGING_BG_TREE: u64 = 274877906944;
+pub const BTRFS_SUPER_FLAG_CHANGING_DATA_CSUM: u64 = 549755813888;
+pub const BTRFS_SUPER_FLAG_CHANGING_META_CSUM: u64 = 1099511627776;
 pub const BTRFS_EXTENT_FLAG_DATA: u32 = 1;
 pub const BTRFS_EXTENT_FLAG_TREE_BLOCK: u32 = 2;
 pub const BTRFS_BLOCK_FLAG_FULL_BACKREF: u32 = 256;
@@ -1662,6 +1704,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/aarch64/general.rs
+++ b/src/aarch64/general.rs
@@ -162,6 +162,14 @@ pub data: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct epoll_params {
+pub busy_poll_usecs: __u32,
+pub busy_poll_budget: __u16,
+pub prefer_busy_poll: __u8,
+pub __pad: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct fscrypt_policy_v1 {
 pub version: __u8,
 pub contents_encryption_mode: __u8,
@@ -244,7 +252,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -262,7 +270,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -272,6 +281,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -287,6 +297,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -356,6 +378,25 @@ pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct futex_waitv {
 pub val: __u64,
 pub uaddr: __u64,
@@ -411,6 +452,14 @@ pub struct rand_pool_info {
 pub entropy_count: crate::ctypes::c_int,
 pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vgetrandom_opaque_params {
+pub size_of_opaque_state: __u32,
+pub mmap_prot: __u32,
+pub mmap_flags: __u32,
+pub reserved: [__u32; 13usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -644,7 +693,12 @@ pub stx_dev_minor: __u32,
 pub stx_mnt_id: __u64,
 pub stx_dio_mem_align: __u32,
 pub stx_dio_offset_align: __u32,
-pub __spare3: [__u64; 12usize],
+pub stx_subvol: __u64,
+pub stx_atomic_write_unit_min: __u32,
+pub stx_atomic_write_unit_max: __u32,
+pub stx_atomic_write_segments_max: __u32,
+pub __spare1: [__u32; 1usize],
+pub __spare3: [__u64; 9usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -944,9 +998,9 @@ pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 395264;
+pub const LINUX_VERSION_CODE: u32 = 396032;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 11;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_MINSIGSTKSZ: u32 = 51;
@@ -975,7 +1029,10 @@ pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_RSEQ_FEATURE_SIZE: u32 = 27;
 pub const AT_RSEQ_ALIGN: u32 = 28;
+pub const AT_HWCAP3: u32 = 29;
+pub const AT_HWCAP4: u32 = 30;
 pub const AT_EXECFN: u32 = 31;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
 pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
@@ -1107,9 +1164,10 @@ pub const RESOLVE_IN_ROOT: u32 = 16;
 pub const RESOLVE_CACHED: u32 = 32;
 pub const F_SETLEASE: u32 = 1024;
 pub const F_GETLEASE: u32 = 1025;
+pub const F_NOTIFY: u32 = 1026;
+pub const F_DUPFD_QUERY: u32 = 1027;
 pub const F_CANCELLK: u32 = 1029;
 pub const F_DUPFD_CLOEXEC: u32 = 1030;
-pub const F_NOTIFY: u32 = 1026;
 pub const F_SETPIPE_SZ: u32 = 1031;
 pub const F_GETPIPE_SZ: u32 = 1032;
 pub const F_ADD_SEALS: u32 = 1033;
@@ -1155,6 +1213,7 @@ pub const EPOLL_CLOEXEC: u32 = 524288;
 pub const EPOLL_CTL_ADD: u32 = 1;
 pub const EPOLL_CTL_DEL: u32 = 2;
 pub const EPOLL_CTL_MOD: u32 = 3;
+pub const EPOLL_IOC_TYPE: u32 = 138;
 pub const POSIX_FADV_NORMAL: u32 = 0;
 pub const POSIX_FADV_RANDOM: u32 = 1;
 pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
@@ -1316,13 +1375,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1394,6 +1457,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1522,6 +1586,7 @@ pub const EFIVARFS_MAGIC: u32 = 3730735588;
 pub const HOSTFS_SUPER_MAGIC: u32 = 12648430;
 pub const OVERLAYFS_SUPER_MAGIC: u32 = 2035054128;
 pub const FUSE_SUPER_MAGIC: u32 = 1702057286;
+pub const BCACHEFS_SUPER_MAGIC: u32 = 3393526350;
 pub const MINIX_SUPER_MAGIC: u32 = 4991;
 pub const MINIX_SUPER_MAGIC2: u32 = 5007;
 pub const MINIX2_SUPER_MAGIC: u32 = 9320;
@@ -1571,6 +1636,7 @@ pub const UDF_SUPER_MAGIC: u32 = 352400198;
 pub const DMA_BUF_MAGIC: u32 = 1145913666;
 pub const DEVMEM_MAGIC: u32 = 1162691661;
 pub const SECRETMEM_MAGIC: u32 = 1397048141;
+pub const PID_FS_MAGIC: u32 = 1346978886;
 pub const PROT_READ: u32 = 1;
 pub const PROT_WRITE: u32 = 2;
 pub const PROT_EXEC: u32 = 4;
@@ -1655,6 +1721,7 @@ pub const OVERCOMMIT_NEVER: u32 = 2;
 pub const MAP_SHARED: u32 = 1;
 pub const MAP_PRIVATE: u32 = 2;
 pub const MAP_SHARED_VALIDATE: u32 = 3;
+pub const MAP_DROPPABLE: u32 = 8;
 pub const MAP_HUGE_SHIFT: u32 = 26;
 pub const MAP_HUGE_MASK: u32 = 63;
 pub const MAP_HUGE_16KB: u32 = 939524096;
@@ -1964,6 +2031,8 @@ pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
 pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
+pub const STATX_SUBVOL: u32 = 32768;
+pub const STATX_WRITE_ATOMIC: u32 = 65536;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -1975,6 +2044,7 @@ pub const STATX_ATTR_AUTOMOUNT: u32 = 4096;
 pub const STATX_ATTR_MOUNT_ROOT: u32 = 8192;
 pub const STATX_ATTR_VERITY: u32 = 1048576;
 pub const STATX_ATTR_DAX: u32 = 2097152;
+pub const STATX_ATTR_WRITE_ATOMIC: u32 = 4194304;
 pub const IGNBRK: u32 = 1;
 pub const BRKINT: u32 = 2;
 pub const IGNPAR: u32 = 4;
@@ -2187,7 +2257,7 @@ pub const __NR_epoll_ctl: u32 = 21;
 pub const __NR_epoll_pwait: u32 = 22;
 pub const __NR_dup: u32 = 23;
 pub const __NR_dup3: u32 = 24;
-pub const __NR3264_fcntl: u32 = 25;
+pub const __NR_fcntl: u32 = 25;
 pub const __NR_inotify_init1: u32 = 26;
 pub const __NR_inotify_add_watch: u32 = 27;
 pub const __NR_inotify_rm_watch: u32 = 28;
@@ -2205,10 +2275,10 @@ pub const __NR_umount2: u32 = 39;
 pub const __NR_mount: u32 = 40;
 pub const __NR_pivot_root: u32 = 41;
 pub const __NR_nfsservctl: u32 = 42;
-pub const __NR3264_statfs: u32 = 43;
-pub const __NR3264_fstatfs: u32 = 44;
-pub const __NR3264_truncate: u32 = 45;
-pub const __NR3264_ftruncate: u32 = 46;
+pub const __NR_statfs: u32 = 43;
+pub const __NR_fstatfs: u32 = 44;
+pub const __NR_truncate: u32 = 45;
+pub const __NR_ftruncate: u32 = 46;
 pub const __NR_fallocate: u32 = 47;
 pub const __NR_faccessat: u32 = 48;
 pub const __NR_chdir: u32 = 49;
@@ -2224,7 +2294,7 @@ pub const __NR_vhangup: u32 = 58;
 pub const __NR_pipe2: u32 = 59;
 pub const __NR_quotactl: u32 = 60;
 pub const __NR_getdents64: u32 = 61;
-pub const __NR3264_lseek: u32 = 62;
+pub const __NR_lseek: u32 = 62;
 pub const __NR_read: u32 = 63;
 pub const __NR_write: u32 = 64;
 pub const __NR_readv: u32 = 65;
@@ -2233,7 +2303,7 @@ pub const __NR_pread64: u32 = 67;
 pub const __NR_pwrite64: u32 = 68;
 pub const __NR_preadv: u32 = 69;
 pub const __NR_pwritev: u32 = 70;
-pub const __NR3264_sendfile: u32 = 71;
+pub const __NR_sendfile: u32 = 71;
 pub const __NR_pselect6: u32 = 72;
 pub const __NR_ppoll: u32 = 73;
 pub const __NR_signalfd4: u32 = 74;
@@ -2241,8 +2311,8 @@ pub const __NR_vmsplice: u32 = 75;
 pub const __NR_splice: u32 = 76;
 pub const __NR_tee: u32 = 77;
 pub const __NR_readlinkat: u32 = 78;
-pub const __NR3264_fstatat: u32 = 79;
-pub const __NR3264_fstat: u32 = 80;
+pub const __NR_newfstatat: u32 = 79;
+pub const __NR_fstat: u32 = 80;
 pub const __NR_sync: u32 = 81;
 pub const __NR_fsync: u32 = 82;
 pub const __NR_fdatasync: u32 = 83;
@@ -2384,8 +2454,8 @@ pub const __NR_request_key: u32 = 218;
 pub const __NR_keyctl: u32 = 219;
 pub const __NR_clone: u32 = 220;
 pub const __NR_execve: u32 = 221;
-pub const __NR3264_mmap: u32 = 222;
-pub const __NR3264_fadvise64: u32 = 223;
+pub const __NR_mmap: u32 = 222;
+pub const __NR_fadvise64: u32 = 223;
 pub const __NR_swapon: u32 = 224;
 pub const __NR_swapoff: u32 = 225;
 pub const __NR_mprotect: u32 = 226;
@@ -2406,7 +2476,6 @@ pub const __NR_rt_tgsigqueueinfo: u32 = 240;
 pub const __NR_perf_event_open: u32 = 241;
 pub const __NR_accept4: u32 = 242;
 pub const __NR_recvmmsg: u32 = 243;
-pub const __NR_arch_specific_syscall: u32 = 244;
 pub const __NR_wait4: u32 = 260;
 pub const __NR_prlimit64: u32 = 261;
 pub const __NR_fanotify_init: u32 = 262;
@@ -2480,18 +2549,7 @@ pub const __NR_listmount: u32 = 458;
 pub const __NR_lsm_get_self_attr: u32 = 459;
 pub const __NR_lsm_set_self_attr: u32 = 460;
 pub const __NR_lsm_list_modules: u32 = 461;
-pub const __NR_syscalls: u32 = 462;
-pub const __NR_fcntl: u32 = 25;
-pub const __NR_statfs: u32 = 43;
-pub const __NR_fstatfs: u32 = 44;
-pub const __NR_truncate: u32 = 45;
-pub const __NR_ftruncate: u32 = 46;
-pub const __NR_lseek: u32 = 62;
-pub const __NR_sendfile: u32 = 71;
-pub const __NR_newfstatat: u32 = 79;
-pub const __NR_fstat: u32 = 80;
-pub const __NR_mmap: u32 = 222;
-pub const __NR_fadvise64: u32 = 223;
+pub const __NR_mseal: u32 = 462;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
 pub const WSTOPPED: u32 = 2;
@@ -2676,6 +2734,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/aarch64/if_arp.rs
+++ b/src/aarch64/if_arp.rs
@@ -612,6 +612,7 @@ pub ar_hln: crate::ctypes::c_uchar,
 pub ar_pln: crate::ctypes::c_uchar,
 pub ar_op: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1381,6 +1382,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
@@ -1414,6 +1417,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1515,6 +1519,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
@@ -2281,7 +2286,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2319,7 +2326,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2495,7 +2503,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/aarch64/if_ether.rs
+++ b/src/aarch64/if_ether.rs
@@ -57,6 +57,7 @@ pub h_dest: [crate::ctypes::c_uchar; 6usize],
 pub h_source: [crate::ctypes::c_uchar; 6usize],
 pub h_proto: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const ETH_ALEN: u32 = 6;
 pub const ETH_TLEN: u32 = 2;
 pub const ETH_HLEN: u32 = 14;

--- a/src/aarch64/if_packet.rs
+++ b/src/aarch64/if_packet.rs
@@ -205,6 +205,7 @@ pub type_flags: __u16,
 pub max_num_members: __u32,
 }
 pub const __LITTLE_ENDIAN: u32 = 1234;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PACKET_HOST: u32 = 0;
 pub const PACKET_BROADCAST: u32 = 1;
 pub const PACKET_MULTICAST: u32 = 2;

--- a/src/aarch64/io_uring.rs
+++ b/src/aarch64/io_uring.rs
@@ -140,7 +140,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -158,7 +158,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -168,6 +169,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -183,6 +185,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -249,6 +263,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -492,6 +525,14 @@ pub resv: [__u32; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_napi {
+pub busy_poll_to: __u32,
+pub prefer_busy_poll: __u8,
+pub pad: [__u8; 3usize],
+pub resv: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -557,6 +598,7 @@ pub const IOC_OUT: u32 = 2147483648;
 pub const IOC_INOUT: u32 = 3221225472;
 pub const IOCSIZE_MASK: u32 = 1073676288;
 pub const IOCSIZE_SHIFT: u32 = 16;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const FSCRYPT_POLICY_FLAGS_PAD_4: u32 = 0;
 pub const FSCRYPT_POLICY_FLAGS_PAD_8: u32 = 1;
 pub const FSCRYPT_POLICY_FLAGS_PAD_16: u32 = 2;
@@ -671,13 +713,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -749,6 +795,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -804,15 +851,20 @@ pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
 pub const IORING_SEND_ZC_REPORT_USAGE: u32 = 8;
+pub const IORING_RECVSEND_BUNDLE: u32 = 16;
 pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
+pub const IORING_ACCEPT_DONTWAIT: u32 = 2;
+pub const IORING_ACCEPT_POLL_FIRST: u32 = 4;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
 pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
+pub const IORING_NOP_INJECT_RESULT: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
 pub const IORING_CQE_F_NOTIF: u32 = 8;
+pub const IORING_CQE_BUFFER_SHIFT: u32 = 16;
 pub const IORING_OFF_SQ_RING: u32 = 0;
 pub const IORING_OFF_CQ_RING: u32 = 134217728;
 pub const IORING_OFF_SQES: u32 = 268435456;
@@ -842,60 +894,10 @@ pub const IORING_FEAT_RSRC_TAGS: u32 = 1024;
 pub const IORING_FEAT_CQE_SKIP: u32 = 2048;
 pub const IORING_FEAT_LINKED_FILE: u32 = 4096;
 pub const IORING_FEAT_REG_REG_RING: u32 = 8192;
+pub const IORING_FEAT_RECVSEND_BUNDLE: u32 = 16384;
 pub const IORING_RSRC_REGISTER_SPARSE: u32 = 1;
 pub const IORING_REGISTER_FILES_SKIP: i32 = -2;
 pub const IO_URING_OP_SUPPORTED: u32 = 1;
-pub const IOSQE_FIXED_FILE_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_FIXED_FILE_BIT;
-pub const IOSQE_IO_DRAIN_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_DRAIN_BIT;
-pub const IOSQE_IO_LINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_LINK_BIT;
-pub const IOSQE_IO_HARDLINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_HARDLINK_BIT;
-pub const IOSQE_ASYNC_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_ASYNC_BIT;
-pub const IOSQE_BUFFER_SELECT_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_BUFFER_SELECT_BIT;
-pub const IOSQE_CQE_SKIP_SUCCESS_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_CQE_SKIP_SUCCESS_BIT;
-pub const IORING_MSG_DATA: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_DATA;
-pub const IORING_MSG_SEND_FD: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_SEND_FD;
-pub const IORING_CQE_BUFFER_SHIFT: _bindgen_ty_3 = _bindgen_ty_3::IORING_CQE_BUFFER_SHIFT;
-pub const IORING_REGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS;
-pub const IORING_UNREGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_BUFFERS;
-pub const IORING_REGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES;
-pub const IORING_UNREGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_FILES;
-pub const IORING_REGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD;
-pub const IORING_UNREGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_EVENTFD;
-pub const IORING_REGISTER_FILES_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE;
-pub const IORING_REGISTER_EVENTFD_ASYNC: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD_ASYNC;
-pub const IORING_REGISTER_PROBE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PROBE;
-pub const IORING_REGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PERSONALITY;
-pub const IORING_UNREGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PERSONALITY;
-pub const IORING_REGISTER_RESTRICTIONS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RESTRICTIONS;
-pub const IORING_REGISTER_ENABLE_RINGS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_ENABLE_RINGS;
-pub const IORING_REGISTER_FILES2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES2;
-pub const IORING_REGISTER_FILES_UPDATE2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE2;
-pub const IORING_REGISTER_BUFFERS2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS2;
-pub const IORING_REGISTER_BUFFERS_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS_UPDATE;
-pub const IORING_REGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_AFF;
-pub const IORING_UNREGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_IOWQ_AFF;
-pub const IORING_REGISTER_IOWQ_MAX_WORKERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_MAX_WORKERS;
-pub const IORING_REGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RING_FDS;
-pub const IORING_UNREGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_RING_FDS;
-pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_RING;
-pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
-pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
-pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
-pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
-pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
-pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
-pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
-pub const IO_WQ_UNBOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_UNBOUND;
-pub const IOU_PBUF_RING_MMAP: _bindgen_ty_6 = _bindgen_ty_6::IOU_PBUF_RING_MMAP;
-pub const IORING_RESTRICTION_REGISTER_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_REGISTER_OP;
-pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_OP;
-pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
-pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
-pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
-pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
-pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
-pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
-pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -913,7 +915,18 @@ FSCONFIG_CMD_CREATE_EXCL = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_1 {
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum io_uring_sqe_flags_bit {
 IOSQE_FIXED_FILE_BIT = 0,
 IOSQE_IO_DRAIN_BIT = 1,
 IOSQE_IO_LINK_BIT = 2,
@@ -981,25 +994,22 @@ IORING_OP_FUTEX_WAIT = 51,
 IORING_OP_FUTEX_WAKE = 52,
 IORING_OP_FUTEX_WAITV = 53,
 IORING_OP_FIXED_FD_INSTALL = 54,
-IORING_OP_LAST = 55,
+IORING_OP_FTRUNCATE = 55,
+IORING_OP_BIND = 56,
+IORING_OP_LISTEN = 57,
+IORING_OP_LAST = 58,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_2 {
+pub enum io_uring_msg_ring_flags {
 IORING_MSG_DATA = 0,
 IORING_MSG_SEND_FD = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_3 {
-IORING_CQE_BUFFER_SHIFT = 16,
-}
-#[repr(u32)]
-#[non_exhaustive]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_4 {
+pub enum io_uring_register_op {
 IORING_REGISTER_BUFFERS = 0,
 IORING_UNREGISTER_BUFFERS = 1,
 IORING_REGISTER_FILES = 2,
@@ -1027,26 +1037,28 @@ IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
 IORING_REGISTER_PBUF_STATUS = 26,
-IORING_REGISTER_LAST = 27,
+IORING_REGISTER_NAPI = 27,
+IORING_UNREGISTER_NAPI = 28,
+IORING_REGISTER_LAST = 29,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_5 {
+pub enum io_wq_type {
 IO_WQ_BOUND = 0,
 IO_WQ_UNBOUND = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_6 {
+pub enum io_uring_register_pbuf_ring_flags {
 IOU_PBUF_RING_MMAP = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_7 {
+pub enum io_uring_register_restriction_op {
 IORING_RESTRICTION_REGISTER_OP = 0,
 IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
@@ -1056,7 +1068,7 @@ IORING_RESTRICTION_LAST = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_8 {
+pub enum io_uring_socket_op {
 SOCKET_URING_OP_SIOCINQ = 0,
 SOCKET_URING_OP_SIOCOUTQ = 1,
 SOCKET_URING_OP_GETSOCKOPT = 2,
@@ -1115,6 +1127,7 @@ pub uring_cmd_flags: __u32,
 pub waitid_flags: __u32,
 pub futex_flags: __u32,
 pub install_fd_flags: __u32,
+pub nop_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]

--- a/src/aarch64/loop_device.rs
+++ b/src/aarch64/loop_device.rs
@@ -93,6 +93,7 @@ pub __reserved: [__u64; 8usize],
 }
 pub const LO_NAME_SIZE: u32 = 64;
 pub const LO_KEY_SIZE: u32 = 32;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const LO_CRYPT_NONE: u32 = 0;
 pub const LO_CRYPT_XOR: u32 = 1;
 pub const LO_CRYPT_DES: u32 = 2;

--- a/src/aarch64/mempolicy.rs
+++ b/src/aarch64/mempolicy.rs
@@ -158,6 +158,7 @@ pub const MPOL_BIND: _bindgen_ty_1 = _bindgen_ty_1::MPOL_BIND;
 pub const MPOL_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_INTERLEAVE;
 pub const MPOL_LOCAL: _bindgen_ty_1 = _bindgen_ty_1::MPOL_LOCAL;
 pub const MPOL_PREFERRED_MANY: _bindgen_ty_1 = _bindgen_ty_1::MPOL_PREFERRED_MANY;
+pub const MPOL_WEIGHTED_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_WEIGHTED_INTERLEAVE;
 pub const MPOL_MAX: _bindgen_ty_1 = _bindgen_ty_1::MPOL_MAX;
 #[repr(u32)]
 #[non_exhaustive]
@@ -169,5 +170,6 @@ MPOL_BIND = 2,
 MPOL_INTERLEAVE = 3,
 MPOL_LOCAL = 4,
 MPOL_PREFERRED_MANY = 5,
-MPOL_MAX = 6,
+MPOL_WEIGHTED_INTERLEAVE = 6,
+MPOL_MAX = 7,
 }

--- a/src/aarch64/net.rs
+++ b/src/aarch64/net.rs
@@ -854,6 +854,7 @@ pub _address: u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1267,6 +1268,7 @@ pub const TCP_AO_DEL_KEY: u32 = 39;
 pub const TCP_AO_INFO: u32 = 40;
 pub const TCP_AO_GET_KEYS: u32 = 41;
 pub const TCP_AO_REPAIR: u32 = 42;
+pub const TCP_IS_MPTCP: u32 = 43;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1553,6 +1555,7 @@ pub const IPPROTO_UDPLITE: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_UDPLITE;
 pub const IPPROTO_MPLS: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPLS;
 pub const IPPROTO_ETHERNET: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ETHERNET;
 pub const IPPROTO_RAW: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_RAW;
+pub const IPPROTO_SMC: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_SMC;
 pub const IPPROTO_MPTCP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPTCP;
 pub const IPPROTO_MAX: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MAX;
 pub const IPV4_DEVCONF_FORWARDING: _bindgen_ty_2 = _bindgen_ty_2::IPV4_DEVCONF_FORWARDING;
@@ -1741,6 +1744,7 @@ IPPROTO_UDPLITE = 136,
 IPPROTO_MPLS = 137,
 IPPROTO_ETHERNET = 143,
 IPPROTO_RAW = 255,
+IPPROTO_SMC = 256,
 IPPROTO_MPTCP = 262,
 IPPROTO_MAX = 263,
 }

--- a/src/aarch64/netlink.rs
+++ b/src/aarch64/netlink.rs
@@ -549,6 +549,7 @@ pub const SOCK_BUF_LOCK_MASK: u32 = 3;
 pub const SOCK_TXREHASH_DEFAULT: u32 = 255;
 pub const SOCK_TXREHASH_DISABLED: u32 = 0;
 pub const SOCK_TXREHASH_ENABLED: u32 = 1;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const NETLINK_ROUTE: u32 = 0;
 pub const NETLINK_UNUSED: u32 = 1;
 pub const NETLINK_USERSOCK: u32 = 2;
@@ -1096,6 +1097,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
@@ -1129,6 +1132,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1230,6 +1234,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
@@ -2144,7 +2149,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2182,7 +2189,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2358,7 +2366,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/aarch64/prctl.rs
+++ b/src/aarch64/prctl.rs
@@ -68,6 +68,7 @@ pub auxv: *mut __u64,
 pub auxv_size: __u32,
 pub exe_fd: __u32,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PR_SET_PDEATHSIG: u32 = 1;
 pub const PR_GET_PDEATHSIG: u32 = 2;
 pub const PR_GET_DUMPABLE: u32 = 3;
@@ -234,3 +235,20 @@ pub const PR_RISCV_V_VSTATE_CTRL_INHERIT: u32 = 16;
 pub const PR_RISCV_V_VSTATE_CTRL_CUR_MASK: u32 = 3;
 pub const PR_RISCV_V_VSTATE_CTRL_NEXT_MASK: u32 = 12;
 pub const PR_RISCV_V_VSTATE_CTRL_MASK: u32 = 31;
+pub const PR_RISCV_SET_ICACHE_FLUSH_CTX: u32 = 71;
+pub const PR_RISCV_CTX_SW_FENCEI_ON: u32 = 0;
+pub const PR_RISCV_CTX_SW_FENCEI_OFF: u32 = 1;
+pub const PR_RISCV_SCOPE_PER_PROCESS: u32 = 0;
+pub const PR_RISCV_SCOPE_PER_THREAD: u32 = 1;
+pub const PR_PPC_GET_DEXCR: u32 = 72;
+pub const PR_PPC_SET_DEXCR: u32 = 73;
+pub const PR_PPC_DEXCR_SBHE: u32 = 0;
+pub const PR_PPC_DEXCR_IBRTPD: u32 = 1;
+pub const PR_PPC_DEXCR_SRAPD: u32 = 2;
+pub const PR_PPC_DEXCR_NPHIE: u32 = 3;
+pub const PR_PPC_DEXCR_CTRL_EDITABLE: u32 = 1;
+pub const PR_PPC_DEXCR_CTRL_SET: u32 = 2;
+pub const PR_PPC_DEXCR_CTRL_CLEAR: u32 = 4;
+pub const PR_PPC_DEXCR_CTRL_SET_ONEXEC: u32 = 8;
+pub const PR_PPC_DEXCR_CTRL_CLEAR_ONEXEC: u32 = 16;
+pub const PR_PPC_DEXCR_CTRL_MASK: u32 = 31;

--- a/src/aarch64/system.rs
+++ b/src/aarch64/system.rs
@@ -99,6 +99,7 @@ pub version: [crate::ctypes::c_char; 65usize],
 pub machine: [crate::ctypes::c_char; 65usize],
 pub domainname: [crate::ctypes::c_char; 65usize],
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const SI_LOAD_SHIFT: u32 = 16;
 pub const __OLD_UTS_LEN: u32 = 8;
 pub const __NEW_UTS_LEN: u32 = 64;

--- a/src/aarch64/xdp.rs
+++ b/src/aarch64/xdp.rs
@@ -154,6 +154,7 @@ pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,
 pub tx_invalid_descs: __u64,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
@@ -161,6 +162,7 @@ pub const XDP_USE_NEED_WAKEUP: u32 = 8;
 pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
 pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
+pub const XDP_UMEM_TX_METADATA_LEN: u32 = 4;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;

--- a/src/arm/btrfs.rs
+++ b/src/arm/btrfs.rs
@@ -136,7 +136,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -154,7 +154,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -164,6 +165,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -179,6 +181,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -245,6 +259,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -855,10 +888,17 @@ pub physical: __le64,
 }
 #[repr(C, packed)]
 pub struct btrfs_stripe_extent {
-pub encoding: __u8,
-pub reserved: [__u8; 7usize],
+pub __bindgen_anon_1: btrfs_stripe_extent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct btrfs_stripe_extent__bindgen_ty_1 {
+pub __empty_strides: btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1,
 pub strides: __IncompleteArrayField<btrfs_raid_stride>,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct btrfs_extent_item {
@@ -1127,6 +1167,7 @@ pub encryption: __u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _IOC_NRBITS: u32 = 8;
 pub const _IOC_TYPEBITS: u32 = 8;
 pub const _IOC_SIZEBITS: u32 = 14;
@@ -1274,13 +1315,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1352,6 +1397,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1384,6 +1430,7 @@ pub const BTRFS_QGROUP_LIMIT_RSV_EXCL: u32 = 8;
 pub const BTRFS_QGROUP_LIMIT_RFER_CMPR: u32 = 16;
 pub const BTRFS_QGROUP_LIMIT_EXCL_CMPR: u32 = 32;
 pub const BTRFS_QGROUP_INHERIT_SET_LIMITS: u32 = 1;
+pub const BTRFS_QGROUP_INHERIT_FLAGS_SUPP: u32 = 1;
 pub const BTRFS_DEVICE_REMOVE_ARGS_MASK: u32 = 8;
 pub const BTRFS_SUBVOL_CREATE_ARGS_MASK: u32 = 6;
 pub const BTRFS_SUBVOL_DELETE_ARGS_MASK: u32 = 16;
@@ -1589,14 +1636,6 @@ pub const BTRFS_SYSTEM_CHUNK_ARRAY_SIZE: u32 = 2048;
 pub const BTRFS_NUM_BACKUP_ROOTS: u32 = 4;
 pub const BTRFS_FREE_SPACE_EXTENT: u32 = 1;
 pub const BTRFS_FREE_SPACE_BITMAP: u32 = 2;
-pub const BTRFS_STRIPE_RAID0: u32 = 1;
-pub const BTRFS_STRIPE_RAID1: u32 = 2;
-pub const BTRFS_STRIPE_DUP: u32 = 3;
-pub const BTRFS_STRIPE_RAID10: u32 = 4;
-pub const BTRFS_STRIPE_RAID5: u32 = 5;
-pub const BTRFS_STRIPE_RAID6: u32 = 6;
-pub const BTRFS_STRIPE_RAID1C3: u32 = 7;
-pub const BTRFS_STRIPE_RAID1C4: u32 = 8;
 pub const BTRFS_HEADER_FLAG_WRITTEN: u32 = 1;
 pub const BTRFS_HEADER_FLAG_RELOC: u32 = 2;
 pub const BTRFS_SUPER_FLAG_ERROR: u32 = 4;
@@ -1605,6 +1644,9 @@ pub const BTRFS_SUPER_FLAG_METADUMP: u64 = 8589934592;
 pub const BTRFS_SUPER_FLAG_METADUMP_V2: u64 = 17179869184;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID: u64 = 34359738368;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID_V2: u64 = 68719476736;
+pub const BTRFS_SUPER_FLAG_CHANGING_BG_TREE: u64 = 274877906944;
+pub const BTRFS_SUPER_FLAG_CHANGING_DATA_CSUM: u64 = 549755813888;
+pub const BTRFS_SUPER_FLAG_CHANGING_META_CSUM: u64 = 1099511627776;
 pub const BTRFS_EXTENT_FLAG_DATA: u32 = 1;
 pub const BTRFS_EXTENT_FLAG_TREE_BLOCK: u32 = 2;
 pub const BTRFS_BLOCK_FLAG_FULL_BACKREF: u32 = 256;
@@ -1660,6 +1702,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/arm/general.rs
+++ b/src/arm/general.rs
@@ -160,6 +160,14 @@ pub data: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct epoll_params {
+pub busy_poll_usecs: __u32,
+pub busy_poll_budget: __u16,
+pub prefer_busy_poll: __u8,
+pub __pad: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct fscrypt_policy_v1 {
 pub version: __u8,
 pub contents_encryption_mode: __u8,
@@ -242,7 +250,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -260,7 +268,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -270,6 +279,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -285,6 +295,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -354,6 +376,25 @@ pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct futex_waitv {
 pub val: __u64,
 pub uaddr: __u64,
@@ -409,6 +450,14 @@ pub struct rand_pool_info {
 pub entropy_count: crate::ctypes::c_int,
 pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vgetrandom_opaque_params {
+pub size_of_opaque_state: __u32,
+pub mmap_prot: __u32,
+pub mmap_flags: __u32,
+pub reserved: [__u32; 13usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -637,7 +686,12 @@ pub stx_dev_minor: __u32,
 pub stx_mnt_id: __u64,
 pub stx_dio_mem_align: __u32,
 pub stx_dio_offset_align: __u32,
-pub __spare3: [__u64; 12usize],
+pub stx_subvol: __u64,
+pub stx_atomic_write_unit_min: __u32,
+pub stx_atomic_write_unit_max: __u32,
+pub stx_atomic_write_segments_max: __u32,
+pub __spare1: [__u32; 1usize],
+pub __spare3: [__u64; 9usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -973,9 +1027,9 @@ pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 395264;
+pub const LINUX_VERSION_CODE: u32 = 396032;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 11;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_NULL: u32 = 0;
@@ -1002,8 +1056,11 @@ pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_RSEQ_FEATURE_SIZE: u32 = 27;
 pub const AT_RSEQ_ALIGN: u32 = 28;
+pub const AT_HWCAP3: u32 = 29;
+pub const AT_HWCAP4: u32 = 30;
 pub const AT_EXECFN: u32 = 31;
 pub const AT_MINSIGSTKSZ: u32 = 51;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
 pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
@@ -1138,9 +1195,10 @@ pub const RESOLVE_IN_ROOT: u32 = 16;
 pub const RESOLVE_CACHED: u32 = 32;
 pub const F_SETLEASE: u32 = 1024;
 pub const F_GETLEASE: u32 = 1025;
+pub const F_NOTIFY: u32 = 1026;
+pub const F_DUPFD_QUERY: u32 = 1027;
 pub const F_CANCELLK: u32 = 1029;
 pub const F_DUPFD_CLOEXEC: u32 = 1030;
-pub const F_NOTIFY: u32 = 1026;
 pub const F_SETPIPE_SZ: u32 = 1031;
 pub const F_GETPIPE_SZ: u32 = 1032;
 pub const F_ADD_SEALS: u32 = 1033;
@@ -1186,6 +1244,7 @@ pub const EPOLL_CLOEXEC: u32 = 524288;
 pub const EPOLL_CTL_ADD: u32 = 1;
 pub const EPOLL_CTL_DEL: u32 = 2;
 pub const EPOLL_CTL_MOD: u32 = 3;
+pub const EPOLL_IOC_TYPE: u32 = 138;
 pub const POSIX_FADV_NORMAL: u32 = 0;
 pub const POSIX_FADV_RANDOM: u32 = 1;
 pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
@@ -1347,13 +1406,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1425,6 +1488,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1553,6 +1617,7 @@ pub const EFIVARFS_MAGIC: u32 = 3730735588;
 pub const HOSTFS_SUPER_MAGIC: u32 = 12648430;
 pub const OVERLAYFS_SUPER_MAGIC: u32 = 2035054128;
 pub const FUSE_SUPER_MAGIC: u32 = 1702057286;
+pub const BCACHEFS_SUPER_MAGIC: u32 = 3393526350;
 pub const MINIX_SUPER_MAGIC: u32 = 4991;
 pub const MINIX_SUPER_MAGIC2: u32 = 5007;
 pub const MINIX2_SUPER_MAGIC: u32 = 9320;
@@ -1602,6 +1667,7 @@ pub const UDF_SUPER_MAGIC: u32 = 352400198;
 pub const DMA_BUF_MAGIC: u32 = 1145913666;
 pub const DEVMEM_MAGIC: u32 = 1162691661;
 pub const SECRETMEM_MAGIC: u32 = 1397048141;
+pub const PID_FS_MAGIC: u32 = 1346978886;
 pub const PROT_READ: u32 = 1;
 pub const PROT_WRITE: u32 = 2;
 pub const PROT_EXEC: u32 = 4;
@@ -1684,6 +1750,7 @@ pub const OVERCOMMIT_NEVER: u32 = 2;
 pub const MAP_SHARED: u32 = 1;
 pub const MAP_PRIVATE: u32 = 2;
 pub const MAP_SHARED_VALIDATE: u32 = 3;
+pub const MAP_DROPPABLE: u32 = 8;
 pub const MAP_HUGE_SHIFT: u32 = 26;
 pub const MAP_HUGE_MASK: u32 = 63;
 pub const MAP_HUGE_16KB: u32 = 939524096;
@@ -1992,6 +2059,8 @@ pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
 pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
+pub const STATX_SUBVOL: u32 = 32768;
+pub const STATX_WRITE_ATOMIC: u32 = 65536;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2003,6 +2072,7 @@ pub const STATX_ATTR_AUTOMOUNT: u32 = 4096;
 pub const STATX_ATTR_MOUNT_ROOT: u32 = 8192;
 pub const STATX_ATTR_VERITY: u32 = 1048576;
 pub const STATX_ATTR_DAX: u32 = 2097152;
+pub const STATX_ATTR_WRITE_ATOMIC: u32 = 4194304;
 pub const IGNBRK: u32 = 1;
 pub const BRKINT: u32 = 2;
 pub const IGNPAR: u32 = 4;
@@ -2607,6 +2677,7 @@ pub const __NR_listmount: u32 = 458;
 pub const __NR_lsm_get_self_attr: u32 = 459;
 pub const __NR_lsm_set_self_attr: u32 = 460;
 pub const __NR_lsm_list_modules: u32 = 461;
+pub const __NR_mseal: u32 = 462;
 pub const __NR_sync_file_range2: u32 = 341;
 pub const __ARM_NR_BASE: u32 = 983040;
 pub const __ARM_NR_breakpoint: u32 = 983041;
@@ -2800,6 +2871,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/arm/if_arp.rs
+++ b/src/arm/if_arp.rs
@@ -610,6 +610,7 @@ pub ar_hln: crate::ctypes::c_uchar,
 pub ar_pln: crate::ctypes::c_uchar,
 pub ar_op: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1379,6 +1380,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
@@ -1412,6 +1415,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1513,6 +1517,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
@@ -2279,7 +2284,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2317,7 +2324,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2493,7 +2501,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/arm/if_ether.rs
+++ b/src/arm/if_ether.rs
@@ -55,6 +55,7 @@ pub h_dest: [crate::ctypes::c_uchar; 6usize],
 pub h_source: [crate::ctypes::c_uchar; 6usize],
 pub h_proto: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const ETH_ALEN: u32 = 6;
 pub const ETH_TLEN: u32 = 2;
 pub const ETH_HLEN: u32 = 14;

--- a/src/arm/if_packet.rs
+++ b/src/arm/if_packet.rs
@@ -203,6 +203,7 @@ pub type_flags: __u16,
 pub max_num_members: __u32,
 }
 pub const __LITTLE_ENDIAN: u32 = 1234;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PACKET_HOST: u32 = 0;
 pub const PACKET_BROADCAST: u32 = 1;
 pub const PACKET_MULTICAST: u32 = 2;

--- a/src/arm/io_uring.rs
+++ b/src/arm/io_uring.rs
@@ -138,7 +138,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -156,7 +156,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -166,6 +167,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -181,6 +183,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -247,6 +261,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -490,6 +523,14 @@ pub resv: [__u32; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_napi {
+pub busy_poll_to: __u32,
+pub prefer_busy_poll: __u8,
+pub pad: [__u8; 3usize],
+pub resv: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -555,6 +596,7 @@ pub const IOC_OUT: u32 = 2147483648;
 pub const IOC_INOUT: u32 = 3221225472;
 pub const IOCSIZE_MASK: u32 = 1073676288;
 pub const IOCSIZE_SHIFT: u32 = 16;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const FSCRYPT_POLICY_FLAGS_PAD_4: u32 = 0;
 pub const FSCRYPT_POLICY_FLAGS_PAD_8: u32 = 1;
 pub const FSCRYPT_POLICY_FLAGS_PAD_16: u32 = 2;
@@ -669,13 +711,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -747,6 +793,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -802,15 +849,20 @@ pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
 pub const IORING_SEND_ZC_REPORT_USAGE: u32 = 8;
+pub const IORING_RECVSEND_BUNDLE: u32 = 16;
 pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
+pub const IORING_ACCEPT_DONTWAIT: u32 = 2;
+pub const IORING_ACCEPT_POLL_FIRST: u32 = 4;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
 pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
+pub const IORING_NOP_INJECT_RESULT: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
 pub const IORING_CQE_F_NOTIF: u32 = 8;
+pub const IORING_CQE_BUFFER_SHIFT: u32 = 16;
 pub const IORING_OFF_SQ_RING: u32 = 0;
 pub const IORING_OFF_CQ_RING: u32 = 134217728;
 pub const IORING_OFF_SQES: u32 = 268435456;
@@ -840,60 +892,10 @@ pub const IORING_FEAT_RSRC_TAGS: u32 = 1024;
 pub const IORING_FEAT_CQE_SKIP: u32 = 2048;
 pub const IORING_FEAT_LINKED_FILE: u32 = 4096;
 pub const IORING_FEAT_REG_REG_RING: u32 = 8192;
+pub const IORING_FEAT_RECVSEND_BUNDLE: u32 = 16384;
 pub const IORING_RSRC_REGISTER_SPARSE: u32 = 1;
 pub const IORING_REGISTER_FILES_SKIP: i32 = -2;
 pub const IO_URING_OP_SUPPORTED: u32 = 1;
-pub const IOSQE_FIXED_FILE_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_FIXED_FILE_BIT;
-pub const IOSQE_IO_DRAIN_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_DRAIN_BIT;
-pub const IOSQE_IO_LINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_LINK_BIT;
-pub const IOSQE_IO_HARDLINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_HARDLINK_BIT;
-pub const IOSQE_ASYNC_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_ASYNC_BIT;
-pub const IOSQE_BUFFER_SELECT_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_BUFFER_SELECT_BIT;
-pub const IOSQE_CQE_SKIP_SUCCESS_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_CQE_SKIP_SUCCESS_BIT;
-pub const IORING_MSG_DATA: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_DATA;
-pub const IORING_MSG_SEND_FD: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_SEND_FD;
-pub const IORING_CQE_BUFFER_SHIFT: _bindgen_ty_3 = _bindgen_ty_3::IORING_CQE_BUFFER_SHIFT;
-pub const IORING_REGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS;
-pub const IORING_UNREGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_BUFFERS;
-pub const IORING_REGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES;
-pub const IORING_UNREGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_FILES;
-pub const IORING_REGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD;
-pub const IORING_UNREGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_EVENTFD;
-pub const IORING_REGISTER_FILES_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE;
-pub const IORING_REGISTER_EVENTFD_ASYNC: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD_ASYNC;
-pub const IORING_REGISTER_PROBE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PROBE;
-pub const IORING_REGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PERSONALITY;
-pub const IORING_UNREGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PERSONALITY;
-pub const IORING_REGISTER_RESTRICTIONS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RESTRICTIONS;
-pub const IORING_REGISTER_ENABLE_RINGS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_ENABLE_RINGS;
-pub const IORING_REGISTER_FILES2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES2;
-pub const IORING_REGISTER_FILES_UPDATE2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE2;
-pub const IORING_REGISTER_BUFFERS2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS2;
-pub const IORING_REGISTER_BUFFERS_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS_UPDATE;
-pub const IORING_REGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_AFF;
-pub const IORING_UNREGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_IOWQ_AFF;
-pub const IORING_REGISTER_IOWQ_MAX_WORKERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_MAX_WORKERS;
-pub const IORING_REGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RING_FDS;
-pub const IORING_UNREGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_RING_FDS;
-pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_RING;
-pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
-pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
-pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
-pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
-pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
-pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
-pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
-pub const IO_WQ_UNBOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_UNBOUND;
-pub const IOU_PBUF_RING_MMAP: _bindgen_ty_6 = _bindgen_ty_6::IOU_PBUF_RING_MMAP;
-pub const IORING_RESTRICTION_REGISTER_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_REGISTER_OP;
-pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_OP;
-pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
-pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
-pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
-pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
-pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
-pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
-pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -911,7 +913,18 @@ FSCONFIG_CMD_CREATE_EXCL = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_1 {
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum io_uring_sqe_flags_bit {
 IOSQE_FIXED_FILE_BIT = 0,
 IOSQE_IO_DRAIN_BIT = 1,
 IOSQE_IO_LINK_BIT = 2,
@@ -979,25 +992,22 @@ IORING_OP_FUTEX_WAIT = 51,
 IORING_OP_FUTEX_WAKE = 52,
 IORING_OP_FUTEX_WAITV = 53,
 IORING_OP_FIXED_FD_INSTALL = 54,
-IORING_OP_LAST = 55,
+IORING_OP_FTRUNCATE = 55,
+IORING_OP_BIND = 56,
+IORING_OP_LISTEN = 57,
+IORING_OP_LAST = 58,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_2 {
+pub enum io_uring_msg_ring_flags {
 IORING_MSG_DATA = 0,
 IORING_MSG_SEND_FD = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_3 {
-IORING_CQE_BUFFER_SHIFT = 16,
-}
-#[repr(u32)]
-#[non_exhaustive]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_4 {
+pub enum io_uring_register_op {
 IORING_REGISTER_BUFFERS = 0,
 IORING_UNREGISTER_BUFFERS = 1,
 IORING_REGISTER_FILES = 2,
@@ -1025,26 +1035,28 @@ IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
 IORING_REGISTER_PBUF_STATUS = 26,
-IORING_REGISTER_LAST = 27,
+IORING_REGISTER_NAPI = 27,
+IORING_UNREGISTER_NAPI = 28,
+IORING_REGISTER_LAST = 29,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_5 {
+pub enum io_wq_type {
 IO_WQ_BOUND = 0,
 IO_WQ_UNBOUND = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_6 {
+pub enum io_uring_register_pbuf_ring_flags {
 IOU_PBUF_RING_MMAP = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_7 {
+pub enum io_uring_register_restriction_op {
 IORING_RESTRICTION_REGISTER_OP = 0,
 IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
@@ -1054,7 +1066,7 @@ IORING_RESTRICTION_LAST = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_8 {
+pub enum io_uring_socket_op {
 SOCKET_URING_OP_SIOCINQ = 0,
 SOCKET_URING_OP_SIOCOUTQ = 1,
 SOCKET_URING_OP_GETSOCKOPT = 2,
@@ -1113,6 +1125,7 @@ pub uring_cmd_flags: __u32,
 pub waitid_flags: __u32,
 pub futex_flags: __u32,
 pub install_fd_flags: __u32,
+pub nop_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]

--- a/src/arm/loop_device.rs
+++ b/src/arm/loop_device.rs
@@ -91,6 +91,7 @@ pub __reserved: [__u64; 8usize],
 }
 pub const LO_NAME_SIZE: u32 = 64;
 pub const LO_KEY_SIZE: u32 = 32;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const LO_CRYPT_NONE: u32 = 0;
 pub const LO_CRYPT_XOR: u32 = 1;
 pub const LO_CRYPT_DES: u32 = 2;

--- a/src/arm/mempolicy.rs
+++ b/src/arm/mempolicy.rs
@@ -158,6 +158,7 @@ pub const MPOL_BIND: _bindgen_ty_1 = _bindgen_ty_1::MPOL_BIND;
 pub const MPOL_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_INTERLEAVE;
 pub const MPOL_LOCAL: _bindgen_ty_1 = _bindgen_ty_1::MPOL_LOCAL;
 pub const MPOL_PREFERRED_MANY: _bindgen_ty_1 = _bindgen_ty_1::MPOL_PREFERRED_MANY;
+pub const MPOL_WEIGHTED_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_WEIGHTED_INTERLEAVE;
 pub const MPOL_MAX: _bindgen_ty_1 = _bindgen_ty_1::MPOL_MAX;
 #[repr(u32)]
 #[non_exhaustive]
@@ -169,5 +170,6 @@ MPOL_BIND = 2,
 MPOL_INTERLEAVE = 3,
 MPOL_LOCAL = 4,
 MPOL_PREFERRED_MANY = 5,
-MPOL_MAX = 6,
+MPOL_WEIGHTED_INTERLEAVE = 6,
+MPOL_MAX = 7,
 }

--- a/src/arm/net.rs
+++ b/src/arm/net.rs
@@ -854,6 +854,7 @@ pub _address: u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1259,6 +1260,7 @@ pub const TCP_AO_DEL_KEY: u32 = 39;
 pub const TCP_AO_INFO: u32 = 40;
 pub const TCP_AO_GET_KEYS: u32 = 41;
 pub const TCP_AO_REPAIR: u32 = 42;
+pub const TCP_IS_MPTCP: u32 = 43;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1545,6 +1547,7 @@ pub const IPPROTO_UDPLITE: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_UDPLITE;
 pub const IPPROTO_MPLS: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPLS;
 pub const IPPROTO_ETHERNET: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ETHERNET;
 pub const IPPROTO_RAW: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_RAW;
+pub const IPPROTO_SMC: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_SMC;
 pub const IPPROTO_MPTCP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPTCP;
 pub const IPPROTO_MAX: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MAX;
 pub const IPV4_DEVCONF_FORWARDING: _bindgen_ty_2 = _bindgen_ty_2::IPV4_DEVCONF_FORWARDING;
@@ -1733,6 +1736,7 @@ IPPROTO_UDPLITE = 136,
 IPPROTO_MPLS = 137,
 IPPROTO_ETHERNET = 143,
 IPPROTO_RAW = 255,
+IPPROTO_SMC = 256,
 IPPROTO_MPTCP = 262,
 IPPROTO_MAX = 263,
 }

--- a/src/arm/netlink.rs
+++ b/src/arm/netlink.rs
@@ -547,6 +547,7 @@ pub const SOCK_BUF_LOCK_MASK: u32 = 3;
 pub const SOCK_TXREHASH_DEFAULT: u32 = 255;
 pub const SOCK_TXREHASH_DISABLED: u32 = 0;
 pub const SOCK_TXREHASH_ENABLED: u32 = 1;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const NETLINK_ROUTE: u32 = 0;
 pub const NETLINK_UNUSED: u32 = 1;
 pub const NETLINK_USERSOCK: u32 = 2;
@@ -1094,6 +1095,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
@@ -1127,6 +1130,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1228,6 +1232,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
@@ -2142,7 +2147,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2180,7 +2187,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2356,7 +2364,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/arm/prctl.rs
+++ b/src/arm/prctl.rs
@@ -66,6 +66,7 @@ pub auxv: *mut __u64,
 pub auxv_size: __u32,
 pub exe_fd: __u32,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PR_SET_PDEATHSIG: u32 = 1;
 pub const PR_GET_PDEATHSIG: u32 = 2;
 pub const PR_GET_DUMPABLE: u32 = 3;
@@ -232,3 +233,20 @@ pub const PR_RISCV_V_VSTATE_CTRL_INHERIT: u32 = 16;
 pub const PR_RISCV_V_VSTATE_CTRL_CUR_MASK: u32 = 3;
 pub const PR_RISCV_V_VSTATE_CTRL_NEXT_MASK: u32 = 12;
 pub const PR_RISCV_V_VSTATE_CTRL_MASK: u32 = 31;
+pub const PR_RISCV_SET_ICACHE_FLUSH_CTX: u32 = 71;
+pub const PR_RISCV_CTX_SW_FENCEI_ON: u32 = 0;
+pub const PR_RISCV_CTX_SW_FENCEI_OFF: u32 = 1;
+pub const PR_RISCV_SCOPE_PER_PROCESS: u32 = 0;
+pub const PR_RISCV_SCOPE_PER_THREAD: u32 = 1;
+pub const PR_PPC_GET_DEXCR: u32 = 72;
+pub const PR_PPC_SET_DEXCR: u32 = 73;
+pub const PR_PPC_DEXCR_SBHE: u32 = 0;
+pub const PR_PPC_DEXCR_IBRTPD: u32 = 1;
+pub const PR_PPC_DEXCR_SRAPD: u32 = 2;
+pub const PR_PPC_DEXCR_NPHIE: u32 = 3;
+pub const PR_PPC_DEXCR_CTRL_EDITABLE: u32 = 1;
+pub const PR_PPC_DEXCR_CTRL_SET: u32 = 2;
+pub const PR_PPC_DEXCR_CTRL_CLEAR: u32 = 4;
+pub const PR_PPC_DEXCR_CTRL_SET_ONEXEC: u32 = 8;
+pub const PR_PPC_DEXCR_CTRL_CLEAR_ONEXEC: u32 = 16;
+pub const PR_PPC_DEXCR_CTRL_MASK: u32 = 31;

--- a/src/arm/system.rs
+++ b/src/arm/system.rs
@@ -94,6 +94,7 @@ pub version: [crate::ctypes::c_char; 65usize],
 pub machine: [crate::ctypes::c_char; 65usize],
 pub domainname: [crate::ctypes::c_char; 65usize],
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const SI_LOAD_SHIFT: u32 = 16;
 pub const __OLD_UTS_LEN: u32 = 8;
 pub const __NEW_UTS_LEN: u32 = 64;

--- a/src/arm/xdp.rs
+++ b/src/arm/xdp.rs
@@ -152,6 +152,7 @@ pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,
 pub tx_invalid_descs: __u64,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
@@ -159,6 +160,7 @@ pub const XDP_USE_NEED_WAKEUP: u32 = 8;
 pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
 pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
+pub const XDP_UMEM_TX_METADATA_LEN: u32 = 4;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;

--- a/src/csky/btrfs.rs
+++ b/src/csky/btrfs.rs
@@ -136,7 +136,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -154,7 +154,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -164,6 +165,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -179,6 +181,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -245,6 +259,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -855,10 +888,17 @@ pub physical: __le64,
 }
 #[repr(C, packed)]
 pub struct btrfs_stripe_extent {
-pub encoding: __u8,
-pub reserved: [__u8; 7usize],
+pub __bindgen_anon_1: btrfs_stripe_extent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct btrfs_stripe_extent__bindgen_ty_1 {
+pub __empty_strides: btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1,
 pub strides: __IncompleteArrayField<btrfs_raid_stride>,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct btrfs_extent_item {
@@ -1127,6 +1167,7 @@ pub encryption: __u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _IOC_NRBITS: u32 = 8;
 pub const _IOC_TYPEBITS: u32 = 8;
 pub const _IOC_SIZEBITS: u32 = 14;
@@ -1274,13 +1315,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1352,6 +1397,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1384,6 +1430,7 @@ pub const BTRFS_QGROUP_LIMIT_RSV_EXCL: u32 = 8;
 pub const BTRFS_QGROUP_LIMIT_RFER_CMPR: u32 = 16;
 pub const BTRFS_QGROUP_LIMIT_EXCL_CMPR: u32 = 32;
 pub const BTRFS_QGROUP_INHERIT_SET_LIMITS: u32 = 1;
+pub const BTRFS_QGROUP_INHERIT_FLAGS_SUPP: u32 = 1;
 pub const BTRFS_DEVICE_REMOVE_ARGS_MASK: u32 = 8;
 pub const BTRFS_SUBVOL_CREATE_ARGS_MASK: u32 = 6;
 pub const BTRFS_SUBVOL_DELETE_ARGS_MASK: u32 = 16;
@@ -1589,14 +1636,6 @@ pub const BTRFS_SYSTEM_CHUNK_ARRAY_SIZE: u32 = 2048;
 pub const BTRFS_NUM_BACKUP_ROOTS: u32 = 4;
 pub const BTRFS_FREE_SPACE_EXTENT: u32 = 1;
 pub const BTRFS_FREE_SPACE_BITMAP: u32 = 2;
-pub const BTRFS_STRIPE_RAID0: u32 = 1;
-pub const BTRFS_STRIPE_RAID1: u32 = 2;
-pub const BTRFS_STRIPE_DUP: u32 = 3;
-pub const BTRFS_STRIPE_RAID10: u32 = 4;
-pub const BTRFS_STRIPE_RAID5: u32 = 5;
-pub const BTRFS_STRIPE_RAID6: u32 = 6;
-pub const BTRFS_STRIPE_RAID1C3: u32 = 7;
-pub const BTRFS_STRIPE_RAID1C4: u32 = 8;
 pub const BTRFS_HEADER_FLAG_WRITTEN: u32 = 1;
 pub const BTRFS_HEADER_FLAG_RELOC: u32 = 2;
 pub const BTRFS_SUPER_FLAG_ERROR: u32 = 4;
@@ -1605,6 +1644,9 @@ pub const BTRFS_SUPER_FLAG_METADUMP: u64 = 8589934592;
 pub const BTRFS_SUPER_FLAG_METADUMP_V2: u64 = 17179869184;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID: u64 = 34359738368;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID_V2: u64 = 68719476736;
+pub const BTRFS_SUPER_FLAG_CHANGING_BG_TREE: u64 = 274877906944;
+pub const BTRFS_SUPER_FLAG_CHANGING_DATA_CSUM: u64 = 549755813888;
+pub const BTRFS_SUPER_FLAG_CHANGING_META_CSUM: u64 = 1099511627776;
 pub const BTRFS_EXTENT_FLAG_DATA: u32 = 1;
 pub const BTRFS_EXTENT_FLAG_TREE_BLOCK: u32 = 2;
 pub const BTRFS_BLOCK_FLAG_FULL_BACKREF: u32 = 256;
@@ -1660,6 +1702,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/csky/general.rs
+++ b/src/csky/general.rs
@@ -160,6 +160,14 @@ pub data: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct epoll_params {
+pub busy_poll_usecs: __u32,
+pub busy_poll_budget: __u16,
+pub prefer_busy_poll: __u8,
+pub __pad: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct fscrypt_policy_v1 {
 pub version: __u8,
 pub contents_encryption_mode: __u8,
@@ -242,7 +250,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -260,7 +268,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -270,6 +279,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -285,6 +295,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -354,6 +376,25 @@ pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct futex_waitv {
 pub val: __u64,
 pub uaddr: __u64,
@@ -409,6 +450,14 @@ pub struct rand_pool_info {
 pub entropy_count: crate::ctypes::c_int,
 pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vgetrandom_opaque_params {
+pub size_of_opaque_state: __u32,
+pub mmap_prot: __u32,
+pub mmap_flags: __u32,
+pub reserved: [__u32; 13usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -642,7 +691,12 @@ pub stx_dev_minor: __u32,
 pub stx_mnt_id: __u64,
 pub stx_dio_mem_align: __u32,
 pub stx_dio_offset_align: __u32,
-pub __spare3: [__u64; 12usize],
+pub stx_subvol: __u64,
+pub stx_atomic_write_unit_min: __u32,
+pub stx_atomic_write_unit_max: __u32,
+pub stx_atomic_write_segments_max: __u32,
+pub __spare1: [__u32; 1usize],
+pub __spare3: [__u64; 9usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -965,9 +1019,9 @@ pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 395264;
+pub const LINUX_VERSION_CODE: u32 = 396032;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 11;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_NULL: u32 = 0;
 pub const AT_IGNORE: u32 = 1;
@@ -993,8 +1047,11 @@ pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_RSEQ_FEATURE_SIZE: u32 = 27;
 pub const AT_RSEQ_ALIGN: u32 = 28;
+pub const AT_HWCAP3: u32 = 29;
+pub const AT_HWCAP4: u32 = 30;
 pub const AT_EXECFN: u32 = 31;
 pub const AT_MINSIGSTKSZ: u32 = 51;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
 pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
@@ -1129,9 +1186,10 @@ pub const RESOLVE_IN_ROOT: u32 = 16;
 pub const RESOLVE_CACHED: u32 = 32;
 pub const F_SETLEASE: u32 = 1024;
 pub const F_GETLEASE: u32 = 1025;
+pub const F_NOTIFY: u32 = 1026;
+pub const F_DUPFD_QUERY: u32 = 1027;
 pub const F_CANCELLK: u32 = 1029;
 pub const F_DUPFD_CLOEXEC: u32 = 1030;
-pub const F_NOTIFY: u32 = 1026;
 pub const F_SETPIPE_SZ: u32 = 1031;
 pub const F_GETPIPE_SZ: u32 = 1032;
 pub const F_ADD_SEALS: u32 = 1033;
@@ -1177,6 +1235,7 @@ pub const EPOLL_CLOEXEC: u32 = 524288;
 pub const EPOLL_CTL_ADD: u32 = 1;
 pub const EPOLL_CTL_DEL: u32 = 2;
 pub const EPOLL_CTL_MOD: u32 = 3;
+pub const EPOLL_IOC_TYPE: u32 = 138;
 pub const POSIX_FADV_NORMAL: u32 = 0;
 pub const POSIX_FADV_RANDOM: u32 = 1;
 pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
@@ -1338,13 +1397,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1416,6 +1479,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1544,6 +1608,7 @@ pub const EFIVARFS_MAGIC: u32 = 3730735588;
 pub const HOSTFS_SUPER_MAGIC: u32 = 12648430;
 pub const OVERLAYFS_SUPER_MAGIC: u32 = 2035054128;
 pub const FUSE_SUPER_MAGIC: u32 = 1702057286;
+pub const BCACHEFS_SUPER_MAGIC: u32 = 3393526350;
 pub const MINIX_SUPER_MAGIC: u32 = 4991;
 pub const MINIX_SUPER_MAGIC2: u32 = 5007;
 pub const MINIX2_SUPER_MAGIC: u32 = 9320;
@@ -1593,6 +1658,7 @@ pub const UDF_SUPER_MAGIC: u32 = 352400198;
 pub const DMA_BUF_MAGIC: u32 = 1145913666;
 pub const DEVMEM_MAGIC: u32 = 1162691661;
 pub const SECRETMEM_MAGIC: u32 = 1397048141;
+pub const PID_FS_MAGIC: u32 = 1346978886;
 pub const PROT_READ: u32 = 1;
 pub const PROT_WRITE: u32 = 2;
 pub const PROT_EXEC: u32 = 4;
@@ -1675,6 +1741,7 @@ pub const OVERCOMMIT_NEVER: u32 = 2;
 pub const MAP_SHARED: u32 = 1;
 pub const MAP_PRIVATE: u32 = 2;
 pub const MAP_SHARED_VALIDATE: u32 = 3;
+pub const MAP_DROPPABLE: u32 = 8;
 pub const MAP_HUGE_SHIFT: u32 = 26;
 pub const MAP_HUGE_MASK: u32 = 63;
 pub const MAP_HUGE_16KB: u32 = 939524096;
@@ -1981,6 +2048,8 @@ pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
 pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
+pub const STATX_SUBVOL: u32 = 32768;
+pub const STATX_WRITE_ATOMIC: u32 = 65536;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -1992,6 +2061,7 @@ pub const STATX_ATTR_AUTOMOUNT: u32 = 4096;
 pub const STATX_ATTR_MOUNT_ROOT: u32 = 8192;
 pub const STATX_ATTR_VERITY: u32 = 1048576;
 pub const STATX_ATTR_DAX: u32 = 2097152;
+pub const STATX_ATTR_WRITE_ATOMIC: u32 = 4194304;
 pub const IGNBRK: u32 = 1;
 pub const BRKINT: u32 = 2;
 pub const IGNPAR: u32 = 4;
@@ -2204,7 +2274,7 @@ pub const __NR_epoll_ctl: u32 = 21;
 pub const __NR_epoll_pwait: u32 = 22;
 pub const __NR_dup: u32 = 23;
 pub const __NR_dup3: u32 = 24;
-pub const __NR3264_fcntl: u32 = 25;
+pub const __NR_fcntl64: u32 = 25;
 pub const __NR_inotify_init1: u32 = 26;
 pub const __NR_inotify_add_watch: u32 = 27;
 pub const __NR_inotify_rm_watch: u32 = 28;
@@ -2221,10 +2291,10 @@ pub const __NR_umount2: u32 = 39;
 pub const __NR_mount: u32 = 40;
 pub const __NR_pivot_root: u32 = 41;
 pub const __NR_nfsservctl: u32 = 42;
-pub const __NR3264_statfs: u32 = 43;
-pub const __NR3264_fstatfs: u32 = 44;
-pub const __NR3264_truncate: u32 = 45;
-pub const __NR3264_ftruncate: u32 = 46;
+pub const __NR_statfs64: u32 = 43;
+pub const __NR_fstatfs64: u32 = 44;
+pub const __NR_truncate64: u32 = 45;
+pub const __NR_ftruncate64: u32 = 46;
 pub const __NR_fallocate: u32 = 47;
 pub const __NR_faccessat: u32 = 48;
 pub const __NR_chdir: u32 = 49;
@@ -2240,7 +2310,7 @@ pub const __NR_vhangup: u32 = 58;
 pub const __NR_pipe2: u32 = 59;
 pub const __NR_quotactl: u32 = 60;
 pub const __NR_getdents64: u32 = 61;
-pub const __NR3264_lseek: u32 = 62;
+pub const __NR_llseek: u32 = 62;
 pub const __NR_read: u32 = 63;
 pub const __NR_write: u32 = 64;
 pub const __NR_readv: u32 = 65;
@@ -2249,7 +2319,7 @@ pub const __NR_pread64: u32 = 67;
 pub const __NR_pwrite64: u32 = 68;
 pub const __NR_preadv: u32 = 69;
 pub const __NR_pwritev: u32 = 70;
-pub const __NR3264_sendfile: u32 = 71;
+pub const __NR_sendfile64: u32 = 71;
 pub const __NR_pselect6: u32 = 72;
 pub const __NR_ppoll: u32 = 73;
 pub const __NR_signalfd4: u32 = 74;
@@ -2257,8 +2327,8 @@ pub const __NR_vmsplice: u32 = 75;
 pub const __NR_splice: u32 = 76;
 pub const __NR_tee: u32 = 77;
 pub const __NR_readlinkat: u32 = 78;
-pub const __NR3264_fstatat: u32 = 79;
-pub const __NR3264_fstat: u32 = 80;
+pub const __NR_fstatat64: u32 = 79;
+pub const __NR_fstat64: u32 = 80;
 pub const __NR_sync: u32 = 81;
 pub const __NR_fsync: u32 = 82;
 pub const __NR_fdatasync: u32 = 83;
@@ -2400,8 +2470,8 @@ pub const __NR_request_key: u32 = 218;
 pub const __NR_keyctl: u32 = 219;
 pub const __NR_clone: u32 = 220;
 pub const __NR_execve: u32 = 221;
-pub const __NR3264_mmap: u32 = 222;
-pub const __NR3264_fadvise64: u32 = 223;
+pub const __NR_mmap2: u32 = 222;
+pub const __NR_fadvise64_64: u32 = 223;
 pub const __NR_swapon: u32 = 224;
 pub const __NR_swapoff: u32 = 225;
 pub const __NR_mprotect: u32 = 226;
@@ -2422,7 +2492,8 @@ pub const __NR_rt_tgsigqueueinfo: u32 = 240;
 pub const __NR_perf_event_open: u32 = 241;
 pub const __NR_accept4: u32 = 242;
 pub const __NR_recvmmsg: u32 = 243;
-pub const __NR_arch_specific_syscall: u32 = 244;
+pub const __NR_set_thread_area: u32 = 244;
+pub const __NR_cacheflush: u32 = 245;
 pub const __NR_wait4: u32 = 260;
 pub const __NR_prlimit64: u32 = 261;
 pub const __NR_fanotify_init: u32 = 262;
@@ -2515,20 +2586,8 @@ pub const __NR_listmount: u32 = 458;
 pub const __NR_lsm_get_self_attr: u32 = 459;
 pub const __NR_lsm_set_self_attr: u32 = 460;
 pub const __NR_lsm_list_modules: u32 = 461;
-pub const __NR_syscalls: u32 = 462;
-pub const __NR_fcntl64: u32 = 25;
-pub const __NR_statfs64: u32 = 43;
-pub const __NR_fstatfs64: u32 = 44;
-pub const __NR_truncate64: u32 = 45;
-pub const __NR_ftruncate64: u32 = 46;
-pub const __NR_llseek: u32 = 62;
-pub const __NR_sendfile64: u32 = 71;
-pub const __NR_fstatat64: u32 = 79;
-pub const __NR_fstat64: u32 = 80;
-pub const __NR_mmap2: u32 = 222;
-pub const __NR_fadvise64_64: u32 = 223;
-pub const __NR_set_thread_area: u32 = 244;
-pub const __NR_cacheflush: u32 = 245;
+pub const __NR_mseal: u32 = 462;
+pub const __NR_sync_file_range2: u32 = 84;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
 pub const WSTOPPED: u32 = 2;
@@ -2713,6 +2772,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/csky/if_arp.rs
+++ b/src/csky/if_arp.rs
@@ -612,6 +612,7 @@ pub ar_hln: crate::ctypes::c_uchar,
 pub ar_pln: crate::ctypes::c_uchar,
 pub ar_op: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1381,6 +1382,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
@@ -1414,6 +1417,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1515,6 +1519,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
@@ -2281,7 +2286,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2319,7 +2326,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2495,7 +2503,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/csky/if_ether.rs
+++ b/src/csky/if_ether.rs
@@ -55,6 +55,7 @@ pub h_dest: [crate::ctypes::c_uchar; 6usize],
 pub h_source: [crate::ctypes::c_uchar; 6usize],
 pub h_proto: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const ETH_ALEN: u32 = 6;
 pub const ETH_TLEN: u32 = 2;
 pub const ETH_HLEN: u32 = 14;

--- a/src/csky/if_packet.rs
+++ b/src/csky/if_packet.rs
@@ -205,6 +205,7 @@ pub type_flags: __u16,
 pub max_num_members: __u32,
 }
 pub const __LITTLE_ENDIAN: u32 = 1234;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PACKET_HOST: u32 = 0;
 pub const PACKET_BROADCAST: u32 = 1;
 pub const PACKET_MULTICAST: u32 = 2;

--- a/src/csky/io_uring.rs
+++ b/src/csky/io_uring.rs
@@ -138,7 +138,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -156,7 +156,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -166,6 +167,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -181,6 +183,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -247,6 +261,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -494,6 +527,14 @@ pub resv: [__u32; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_napi {
+pub busy_poll_to: __u32,
+pub prefer_busy_poll: __u8,
+pub pad: [__u8; 3usize],
+pub resv: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -559,6 +600,7 @@ pub const IOC_OUT: u32 = 2147483648;
 pub const IOC_INOUT: u32 = 3221225472;
 pub const IOCSIZE_MASK: u32 = 1073676288;
 pub const IOCSIZE_SHIFT: u32 = 16;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const FSCRYPT_POLICY_FLAGS_PAD_4: u32 = 0;
 pub const FSCRYPT_POLICY_FLAGS_PAD_8: u32 = 1;
 pub const FSCRYPT_POLICY_FLAGS_PAD_16: u32 = 2;
@@ -673,13 +715,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -751,6 +797,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -806,15 +853,20 @@ pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
 pub const IORING_SEND_ZC_REPORT_USAGE: u32 = 8;
+pub const IORING_RECVSEND_BUNDLE: u32 = 16;
 pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
+pub const IORING_ACCEPT_DONTWAIT: u32 = 2;
+pub const IORING_ACCEPT_POLL_FIRST: u32 = 4;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
 pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
+pub const IORING_NOP_INJECT_RESULT: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
 pub const IORING_CQE_F_NOTIF: u32 = 8;
+pub const IORING_CQE_BUFFER_SHIFT: u32 = 16;
 pub const IORING_OFF_SQ_RING: u32 = 0;
 pub const IORING_OFF_CQ_RING: u32 = 134217728;
 pub const IORING_OFF_SQES: u32 = 268435456;
@@ -844,60 +896,10 @@ pub const IORING_FEAT_RSRC_TAGS: u32 = 1024;
 pub const IORING_FEAT_CQE_SKIP: u32 = 2048;
 pub const IORING_FEAT_LINKED_FILE: u32 = 4096;
 pub const IORING_FEAT_REG_REG_RING: u32 = 8192;
+pub const IORING_FEAT_RECVSEND_BUNDLE: u32 = 16384;
 pub const IORING_RSRC_REGISTER_SPARSE: u32 = 1;
 pub const IORING_REGISTER_FILES_SKIP: i32 = -2;
 pub const IO_URING_OP_SUPPORTED: u32 = 1;
-pub const IOSQE_FIXED_FILE_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_FIXED_FILE_BIT;
-pub const IOSQE_IO_DRAIN_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_DRAIN_BIT;
-pub const IOSQE_IO_LINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_LINK_BIT;
-pub const IOSQE_IO_HARDLINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_HARDLINK_BIT;
-pub const IOSQE_ASYNC_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_ASYNC_BIT;
-pub const IOSQE_BUFFER_SELECT_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_BUFFER_SELECT_BIT;
-pub const IOSQE_CQE_SKIP_SUCCESS_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_CQE_SKIP_SUCCESS_BIT;
-pub const IORING_MSG_DATA: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_DATA;
-pub const IORING_MSG_SEND_FD: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_SEND_FD;
-pub const IORING_CQE_BUFFER_SHIFT: _bindgen_ty_3 = _bindgen_ty_3::IORING_CQE_BUFFER_SHIFT;
-pub const IORING_REGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS;
-pub const IORING_UNREGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_BUFFERS;
-pub const IORING_REGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES;
-pub const IORING_UNREGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_FILES;
-pub const IORING_REGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD;
-pub const IORING_UNREGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_EVENTFD;
-pub const IORING_REGISTER_FILES_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE;
-pub const IORING_REGISTER_EVENTFD_ASYNC: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD_ASYNC;
-pub const IORING_REGISTER_PROBE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PROBE;
-pub const IORING_REGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PERSONALITY;
-pub const IORING_UNREGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PERSONALITY;
-pub const IORING_REGISTER_RESTRICTIONS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RESTRICTIONS;
-pub const IORING_REGISTER_ENABLE_RINGS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_ENABLE_RINGS;
-pub const IORING_REGISTER_FILES2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES2;
-pub const IORING_REGISTER_FILES_UPDATE2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE2;
-pub const IORING_REGISTER_BUFFERS2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS2;
-pub const IORING_REGISTER_BUFFERS_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS_UPDATE;
-pub const IORING_REGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_AFF;
-pub const IORING_UNREGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_IOWQ_AFF;
-pub const IORING_REGISTER_IOWQ_MAX_WORKERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_MAX_WORKERS;
-pub const IORING_REGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RING_FDS;
-pub const IORING_UNREGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_RING_FDS;
-pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_RING;
-pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
-pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
-pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
-pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
-pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
-pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
-pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
-pub const IO_WQ_UNBOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_UNBOUND;
-pub const IOU_PBUF_RING_MMAP: _bindgen_ty_6 = _bindgen_ty_6::IOU_PBUF_RING_MMAP;
-pub const IORING_RESTRICTION_REGISTER_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_REGISTER_OP;
-pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_OP;
-pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
-pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
-pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
-pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
-pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
-pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
-pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -915,7 +917,18 @@ FSCONFIG_CMD_CREATE_EXCL = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_1 {
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum io_uring_sqe_flags_bit {
 IOSQE_FIXED_FILE_BIT = 0,
 IOSQE_IO_DRAIN_BIT = 1,
 IOSQE_IO_LINK_BIT = 2,
@@ -983,25 +996,22 @@ IORING_OP_FUTEX_WAIT = 51,
 IORING_OP_FUTEX_WAKE = 52,
 IORING_OP_FUTEX_WAITV = 53,
 IORING_OP_FIXED_FD_INSTALL = 54,
-IORING_OP_LAST = 55,
+IORING_OP_FTRUNCATE = 55,
+IORING_OP_BIND = 56,
+IORING_OP_LISTEN = 57,
+IORING_OP_LAST = 58,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_2 {
+pub enum io_uring_msg_ring_flags {
 IORING_MSG_DATA = 0,
 IORING_MSG_SEND_FD = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_3 {
-IORING_CQE_BUFFER_SHIFT = 16,
-}
-#[repr(u32)]
-#[non_exhaustive]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_4 {
+pub enum io_uring_register_op {
 IORING_REGISTER_BUFFERS = 0,
 IORING_UNREGISTER_BUFFERS = 1,
 IORING_REGISTER_FILES = 2,
@@ -1029,26 +1039,28 @@ IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
 IORING_REGISTER_PBUF_STATUS = 26,
-IORING_REGISTER_LAST = 27,
+IORING_REGISTER_NAPI = 27,
+IORING_UNREGISTER_NAPI = 28,
+IORING_REGISTER_LAST = 29,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_5 {
+pub enum io_wq_type {
 IO_WQ_BOUND = 0,
 IO_WQ_UNBOUND = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_6 {
+pub enum io_uring_register_pbuf_ring_flags {
 IOU_PBUF_RING_MMAP = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_7 {
+pub enum io_uring_register_restriction_op {
 IORING_RESTRICTION_REGISTER_OP = 0,
 IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
@@ -1058,7 +1070,7 @@ IORING_RESTRICTION_LAST = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_8 {
+pub enum io_uring_socket_op {
 SOCKET_URING_OP_SIOCINQ = 0,
 SOCKET_URING_OP_SIOCOUTQ = 1,
 SOCKET_URING_OP_GETSOCKOPT = 2,
@@ -1117,6 +1129,7 @@ pub uring_cmd_flags: __u32,
 pub waitid_flags: __u32,
 pub futex_flags: __u32,
 pub install_fd_flags: __u32,
+pub nop_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]

--- a/src/csky/loop_device.rs
+++ b/src/csky/loop_device.rs
@@ -91,6 +91,7 @@ pub __reserved: [__u64; 8usize],
 }
 pub const LO_NAME_SIZE: u32 = 64;
 pub const LO_KEY_SIZE: u32 = 32;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const LO_CRYPT_NONE: u32 = 0;
 pub const LO_CRYPT_XOR: u32 = 1;
 pub const LO_CRYPT_DES: u32 = 2;

--- a/src/csky/mempolicy.rs
+++ b/src/csky/mempolicy.rs
@@ -158,6 +158,7 @@ pub const MPOL_BIND: _bindgen_ty_1 = _bindgen_ty_1::MPOL_BIND;
 pub const MPOL_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_INTERLEAVE;
 pub const MPOL_LOCAL: _bindgen_ty_1 = _bindgen_ty_1::MPOL_LOCAL;
 pub const MPOL_PREFERRED_MANY: _bindgen_ty_1 = _bindgen_ty_1::MPOL_PREFERRED_MANY;
+pub const MPOL_WEIGHTED_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_WEIGHTED_INTERLEAVE;
 pub const MPOL_MAX: _bindgen_ty_1 = _bindgen_ty_1::MPOL_MAX;
 #[repr(u32)]
 #[non_exhaustive]
@@ -169,5 +170,6 @@ MPOL_BIND = 2,
 MPOL_INTERLEAVE = 3,
 MPOL_LOCAL = 4,
 MPOL_PREFERRED_MANY = 5,
-MPOL_MAX = 6,
+MPOL_WEIGHTED_INTERLEAVE = 6,
+MPOL_MAX = 7,
 }

--- a/src/csky/net.rs
+++ b/src/csky/net.rs
@@ -856,6 +856,7 @@ pub _address: u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1261,6 +1262,7 @@ pub const TCP_AO_DEL_KEY: u32 = 39;
 pub const TCP_AO_INFO: u32 = 40;
 pub const TCP_AO_GET_KEYS: u32 = 41;
 pub const TCP_AO_REPAIR: u32 = 42;
+pub const TCP_IS_MPTCP: u32 = 43;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1547,6 +1549,7 @@ pub const IPPROTO_UDPLITE: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_UDPLITE;
 pub const IPPROTO_MPLS: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPLS;
 pub const IPPROTO_ETHERNET: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ETHERNET;
 pub const IPPROTO_RAW: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_RAW;
+pub const IPPROTO_SMC: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_SMC;
 pub const IPPROTO_MPTCP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPTCP;
 pub const IPPROTO_MAX: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MAX;
 pub const IPV4_DEVCONF_FORWARDING: _bindgen_ty_2 = _bindgen_ty_2::IPV4_DEVCONF_FORWARDING;
@@ -1735,6 +1738,7 @@ IPPROTO_UDPLITE = 136,
 IPPROTO_MPLS = 137,
 IPPROTO_ETHERNET = 143,
 IPPROTO_RAW = 255,
+IPPROTO_SMC = 256,
 IPPROTO_MPTCP = 262,
 IPPROTO_MAX = 263,
 }

--- a/src/csky/netlink.rs
+++ b/src/csky/netlink.rs
@@ -547,6 +547,7 @@ pub const SOCK_BUF_LOCK_MASK: u32 = 3;
 pub const SOCK_TXREHASH_DEFAULT: u32 = 255;
 pub const SOCK_TXREHASH_DISABLED: u32 = 0;
 pub const SOCK_TXREHASH_ENABLED: u32 = 1;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const NETLINK_ROUTE: u32 = 0;
 pub const NETLINK_UNUSED: u32 = 1;
 pub const NETLINK_USERSOCK: u32 = 2;
@@ -1094,6 +1095,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
@@ -1127,6 +1130,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1228,6 +1232,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
@@ -2142,7 +2147,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2180,7 +2187,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2356,7 +2364,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/csky/prctl.rs
+++ b/src/csky/prctl.rs
@@ -66,6 +66,7 @@ pub auxv: *mut __u64,
 pub auxv_size: __u32,
 pub exe_fd: __u32,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PR_SET_PDEATHSIG: u32 = 1;
 pub const PR_GET_PDEATHSIG: u32 = 2;
 pub const PR_GET_DUMPABLE: u32 = 3;
@@ -232,3 +233,20 @@ pub const PR_RISCV_V_VSTATE_CTRL_INHERIT: u32 = 16;
 pub const PR_RISCV_V_VSTATE_CTRL_CUR_MASK: u32 = 3;
 pub const PR_RISCV_V_VSTATE_CTRL_NEXT_MASK: u32 = 12;
 pub const PR_RISCV_V_VSTATE_CTRL_MASK: u32 = 31;
+pub const PR_RISCV_SET_ICACHE_FLUSH_CTX: u32 = 71;
+pub const PR_RISCV_CTX_SW_FENCEI_ON: u32 = 0;
+pub const PR_RISCV_CTX_SW_FENCEI_OFF: u32 = 1;
+pub const PR_RISCV_SCOPE_PER_PROCESS: u32 = 0;
+pub const PR_RISCV_SCOPE_PER_THREAD: u32 = 1;
+pub const PR_PPC_GET_DEXCR: u32 = 72;
+pub const PR_PPC_SET_DEXCR: u32 = 73;
+pub const PR_PPC_DEXCR_SBHE: u32 = 0;
+pub const PR_PPC_DEXCR_IBRTPD: u32 = 1;
+pub const PR_PPC_DEXCR_SRAPD: u32 = 2;
+pub const PR_PPC_DEXCR_NPHIE: u32 = 3;
+pub const PR_PPC_DEXCR_CTRL_EDITABLE: u32 = 1;
+pub const PR_PPC_DEXCR_CTRL_SET: u32 = 2;
+pub const PR_PPC_DEXCR_CTRL_CLEAR: u32 = 4;
+pub const PR_PPC_DEXCR_CTRL_SET_ONEXEC: u32 = 8;
+pub const PR_PPC_DEXCR_CTRL_CLEAR_ONEXEC: u32 = 16;
+pub const PR_PPC_DEXCR_CTRL_MASK: u32 = 31;

--- a/src/csky/system.rs
+++ b/src/csky/system.rs
@@ -94,6 +94,7 @@ pub version: [crate::ctypes::c_char; 65usize],
 pub machine: [crate::ctypes::c_char; 65usize],
 pub domainname: [crate::ctypes::c_char; 65usize],
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const SI_LOAD_SHIFT: u32 = 16;
 pub const __OLD_UTS_LEN: u32 = 8;
 pub const __NEW_UTS_LEN: u32 = 64;

--- a/src/csky/xdp.rs
+++ b/src/csky/xdp.rs
@@ -152,6 +152,7 @@ pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,
 pub tx_invalid_descs: __u64,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
@@ -159,6 +160,7 @@ pub const XDP_USE_NEED_WAKEUP: u32 = 8;
 pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
 pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
+pub const XDP_UMEM_TX_METADATA_LEN: u32 = 4;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;

--- a/src/loongarch64/btrfs.rs
+++ b/src/loongarch64/btrfs.rs
@@ -138,7 +138,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -156,7 +156,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -166,6 +167,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -181,6 +183,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -247,6 +261,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -857,10 +890,17 @@ pub physical: __le64,
 }
 #[repr(C, packed)]
 pub struct btrfs_stripe_extent {
-pub encoding: __u8,
-pub reserved: [__u8; 7usize],
+pub __bindgen_anon_1: btrfs_stripe_extent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct btrfs_stripe_extent__bindgen_ty_1 {
+pub __empty_strides: btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1,
 pub strides: __IncompleteArrayField<btrfs_raid_stride>,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct btrfs_extent_item {
@@ -1129,6 +1169,7 @@ pub encryption: __u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _IOC_NRBITS: u32 = 8;
 pub const _IOC_TYPEBITS: u32 = 8;
 pub const _IOC_SIZEBITS: u32 = 14;
@@ -1276,13 +1317,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1354,6 +1399,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1386,6 +1432,7 @@ pub const BTRFS_QGROUP_LIMIT_RSV_EXCL: u32 = 8;
 pub const BTRFS_QGROUP_LIMIT_RFER_CMPR: u32 = 16;
 pub const BTRFS_QGROUP_LIMIT_EXCL_CMPR: u32 = 32;
 pub const BTRFS_QGROUP_INHERIT_SET_LIMITS: u32 = 1;
+pub const BTRFS_QGROUP_INHERIT_FLAGS_SUPP: u32 = 1;
 pub const BTRFS_DEVICE_REMOVE_ARGS_MASK: u32 = 8;
 pub const BTRFS_SUBVOL_CREATE_ARGS_MASK: u32 = 6;
 pub const BTRFS_SUBVOL_DELETE_ARGS_MASK: u32 = 16;
@@ -1591,14 +1638,6 @@ pub const BTRFS_SYSTEM_CHUNK_ARRAY_SIZE: u32 = 2048;
 pub const BTRFS_NUM_BACKUP_ROOTS: u32 = 4;
 pub const BTRFS_FREE_SPACE_EXTENT: u32 = 1;
 pub const BTRFS_FREE_SPACE_BITMAP: u32 = 2;
-pub const BTRFS_STRIPE_RAID0: u32 = 1;
-pub const BTRFS_STRIPE_RAID1: u32 = 2;
-pub const BTRFS_STRIPE_DUP: u32 = 3;
-pub const BTRFS_STRIPE_RAID10: u32 = 4;
-pub const BTRFS_STRIPE_RAID5: u32 = 5;
-pub const BTRFS_STRIPE_RAID6: u32 = 6;
-pub const BTRFS_STRIPE_RAID1C3: u32 = 7;
-pub const BTRFS_STRIPE_RAID1C4: u32 = 8;
 pub const BTRFS_HEADER_FLAG_WRITTEN: u32 = 1;
 pub const BTRFS_HEADER_FLAG_RELOC: u32 = 2;
 pub const BTRFS_SUPER_FLAG_ERROR: u32 = 4;
@@ -1607,6 +1646,9 @@ pub const BTRFS_SUPER_FLAG_METADUMP: u64 = 8589934592;
 pub const BTRFS_SUPER_FLAG_METADUMP_V2: u64 = 17179869184;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID: u64 = 34359738368;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID_V2: u64 = 68719476736;
+pub const BTRFS_SUPER_FLAG_CHANGING_BG_TREE: u64 = 274877906944;
+pub const BTRFS_SUPER_FLAG_CHANGING_DATA_CSUM: u64 = 549755813888;
+pub const BTRFS_SUPER_FLAG_CHANGING_META_CSUM: u64 = 1099511627776;
 pub const BTRFS_EXTENT_FLAG_DATA: u32 = 1;
 pub const BTRFS_EXTENT_FLAG_TREE_BLOCK: u32 = 2;
 pub const BTRFS_BLOCK_FLAG_FULL_BACKREF: u32 = 256;
@@ -1662,6 +1704,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/loongarch64/general.rs
+++ b/src/loongarch64/general.rs
@@ -162,6 +162,14 @@ pub data: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct epoll_params {
+pub busy_poll_usecs: __u32,
+pub busy_poll_budget: __u16,
+pub prefer_busy_poll: __u8,
+pub __pad: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct fscrypt_policy_v1 {
 pub version: __u8,
 pub contents_encryption_mode: __u8,
@@ -244,7 +252,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -262,7 +270,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -272,6 +281,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -287,6 +297,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -356,6 +378,25 @@ pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct futex_waitv {
 pub val: __u64,
 pub uaddr: __u64,
@@ -411,6 +452,14 @@ pub struct rand_pool_info {
 pub entropy_count: crate::ctypes::c_int,
 pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vgetrandom_opaque_params {
+pub size_of_opaque_state: __u32,
+pub mmap_prot: __u32,
+pub mmap_flags: __u32,
+pub reserved: [__u32; 13usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -643,7 +692,12 @@ pub stx_dev_minor: __u32,
 pub stx_mnt_id: __u64,
 pub stx_dio_mem_align: __u32,
 pub stx_dio_offset_align: __u32,
-pub __spare3: [__u64; 12usize],
+pub stx_subvol: __u64,
+pub stx_atomic_write_unit_min: __u32,
+pub stx_atomic_write_unit_max: __u32,
+pub stx_atomic_write_segments_max: __u32,
+pub __spare1: [__u32; 1usize],
+pub __spare3: [__u64; 9usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -942,9 +996,9 @@ pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 395264;
+pub const LINUX_VERSION_CODE: u32 = 396032;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 11;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_VECTOR_SIZE_ARCH: u32 = 1;
@@ -972,8 +1026,11 @@ pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_RSEQ_FEATURE_SIZE: u32 = 27;
 pub const AT_RSEQ_ALIGN: u32 = 28;
+pub const AT_HWCAP3: u32 = 29;
+pub const AT_HWCAP4: u32 = 30;
 pub const AT_EXECFN: u32 = 31;
 pub const AT_MINSIGSTKSZ: u32 = 51;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
 pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
@@ -1105,9 +1162,10 @@ pub const RESOLVE_IN_ROOT: u32 = 16;
 pub const RESOLVE_CACHED: u32 = 32;
 pub const F_SETLEASE: u32 = 1024;
 pub const F_GETLEASE: u32 = 1025;
+pub const F_NOTIFY: u32 = 1026;
+pub const F_DUPFD_QUERY: u32 = 1027;
 pub const F_CANCELLK: u32 = 1029;
 pub const F_DUPFD_CLOEXEC: u32 = 1030;
-pub const F_NOTIFY: u32 = 1026;
 pub const F_SETPIPE_SZ: u32 = 1031;
 pub const F_GETPIPE_SZ: u32 = 1032;
 pub const F_ADD_SEALS: u32 = 1033;
@@ -1153,6 +1211,7 @@ pub const EPOLL_CLOEXEC: u32 = 524288;
 pub const EPOLL_CTL_ADD: u32 = 1;
 pub const EPOLL_CTL_DEL: u32 = 2;
 pub const EPOLL_CTL_MOD: u32 = 3;
+pub const EPOLL_IOC_TYPE: u32 = 138;
 pub const POSIX_FADV_NORMAL: u32 = 0;
 pub const POSIX_FADV_RANDOM: u32 = 1;
 pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
@@ -1314,13 +1373,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1392,6 +1455,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1520,6 +1584,7 @@ pub const EFIVARFS_MAGIC: u32 = 3730735588;
 pub const HOSTFS_SUPER_MAGIC: u32 = 12648430;
 pub const OVERLAYFS_SUPER_MAGIC: u32 = 2035054128;
 pub const FUSE_SUPER_MAGIC: u32 = 1702057286;
+pub const BCACHEFS_SUPER_MAGIC: u32 = 3393526350;
 pub const MINIX_SUPER_MAGIC: u32 = 4991;
 pub const MINIX_SUPER_MAGIC2: u32 = 5007;
 pub const MINIX2_SUPER_MAGIC: u32 = 9320;
@@ -1569,6 +1634,7 @@ pub const UDF_SUPER_MAGIC: u32 = 352400198;
 pub const DMA_BUF_MAGIC: u32 = 1145913666;
 pub const DEVMEM_MAGIC: u32 = 1162691661;
 pub const SECRETMEM_MAGIC: u32 = 1397048141;
+pub const PID_FS_MAGIC: u32 = 1346978886;
 pub const PROT_READ: u32 = 1;
 pub const PROT_WRITE: u32 = 2;
 pub const PROT_EXEC: u32 = 4;
@@ -1651,6 +1717,7 @@ pub const OVERCOMMIT_NEVER: u32 = 2;
 pub const MAP_SHARED: u32 = 1;
 pub const MAP_PRIVATE: u32 = 2;
 pub const MAP_SHARED_VALIDATE: u32 = 3;
+pub const MAP_DROPPABLE: u32 = 8;
 pub const MAP_HUGE_SHIFT: u32 = 26;
 pub const MAP_HUGE_MASK: u32 = 63;
 pub const MAP_HUGE_16KB: u32 = 939524096;
@@ -1957,6 +2024,8 @@ pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
 pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
+pub const STATX_SUBVOL: u32 = 32768;
+pub const STATX_WRITE_ATOMIC: u32 = 65536;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -1968,6 +2037,7 @@ pub const STATX_ATTR_AUTOMOUNT: u32 = 4096;
 pub const STATX_ATTR_MOUNT_ROOT: u32 = 8192;
 pub const STATX_ATTR_VERITY: u32 = 1048576;
 pub const STATX_ATTR_DAX: u32 = 2097152;
+pub const STATX_ATTR_WRITE_ATOMIC: u32 = 4194304;
 pub const IGNBRK: u32 = 1;
 pub const BRKINT: u32 = 2;
 pub const IGNPAR: u32 = 4;
@@ -2180,7 +2250,7 @@ pub const __NR_epoll_ctl: u32 = 21;
 pub const __NR_epoll_pwait: u32 = 22;
 pub const __NR_dup: u32 = 23;
 pub const __NR_dup3: u32 = 24;
-pub const __NR3264_fcntl: u32 = 25;
+pub const __NR_fcntl: u32 = 25;
 pub const __NR_inotify_init1: u32 = 26;
 pub const __NR_inotify_add_watch: u32 = 27;
 pub const __NR_inotify_rm_watch: u32 = 28;
@@ -2197,10 +2267,10 @@ pub const __NR_umount2: u32 = 39;
 pub const __NR_mount: u32 = 40;
 pub const __NR_pivot_root: u32 = 41;
 pub const __NR_nfsservctl: u32 = 42;
-pub const __NR3264_statfs: u32 = 43;
-pub const __NR3264_fstatfs: u32 = 44;
-pub const __NR3264_truncate: u32 = 45;
-pub const __NR3264_ftruncate: u32 = 46;
+pub const __NR_statfs: u32 = 43;
+pub const __NR_fstatfs: u32 = 44;
+pub const __NR_truncate: u32 = 45;
+pub const __NR_ftruncate: u32 = 46;
 pub const __NR_fallocate: u32 = 47;
 pub const __NR_faccessat: u32 = 48;
 pub const __NR_chdir: u32 = 49;
@@ -2216,7 +2286,7 @@ pub const __NR_vhangup: u32 = 58;
 pub const __NR_pipe2: u32 = 59;
 pub const __NR_quotactl: u32 = 60;
 pub const __NR_getdents64: u32 = 61;
-pub const __NR3264_lseek: u32 = 62;
+pub const __NR_lseek: u32 = 62;
 pub const __NR_read: u32 = 63;
 pub const __NR_write: u32 = 64;
 pub const __NR_readv: u32 = 65;
@@ -2225,7 +2295,7 @@ pub const __NR_pread64: u32 = 67;
 pub const __NR_pwrite64: u32 = 68;
 pub const __NR_preadv: u32 = 69;
 pub const __NR_pwritev: u32 = 70;
-pub const __NR3264_sendfile: u32 = 71;
+pub const __NR_sendfile: u32 = 71;
 pub const __NR_pselect6: u32 = 72;
 pub const __NR_ppoll: u32 = 73;
 pub const __NR_signalfd4: u32 = 74;
@@ -2233,6 +2303,8 @@ pub const __NR_vmsplice: u32 = 75;
 pub const __NR_splice: u32 = 76;
 pub const __NR_tee: u32 = 77;
 pub const __NR_readlinkat: u32 = 78;
+pub const __NR_newfstatat: u32 = 79;
+pub const __NR_fstat: u32 = 80;
 pub const __NR_sync: u32 = 81;
 pub const __NR_fsync: u32 = 82;
 pub const __NR_fdatasync: u32 = 83;
@@ -2372,8 +2444,8 @@ pub const __NR_request_key: u32 = 218;
 pub const __NR_keyctl: u32 = 219;
 pub const __NR_clone: u32 = 220;
 pub const __NR_execve: u32 = 221;
-pub const __NR3264_mmap: u32 = 222;
-pub const __NR3264_fadvise64: u32 = 223;
+pub const __NR_mmap: u32 = 222;
+pub const __NR_fadvise64: u32 = 223;
 pub const __NR_swapon: u32 = 224;
 pub const __NR_swapoff: u32 = 225;
 pub const __NR_mprotect: u32 = 226;
@@ -2394,7 +2466,6 @@ pub const __NR_rt_tgsigqueueinfo: u32 = 240;
 pub const __NR_perf_event_open: u32 = 241;
 pub const __NR_accept4: u32 = 242;
 pub const __NR_recvmmsg: u32 = 243;
-pub const __NR_arch_specific_syscall: u32 = 244;
 pub const __NR_wait4: u32 = 260;
 pub const __NR_prlimit64: u32 = 261;
 pub const __NR_fanotify_init: u32 = 262;
@@ -2467,16 +2538,7 @@ pub const __NR_listmount: u32 = 458;
 pub const __NR_lsm_get_self_attr: u32 = 459;
 pub const __NR_lsm_set_self_attr: u32 = 460;
 pub const __NR_lsm_list_modules: u32 = 461;
-pub const __NR_syscalls: u32 = 462;
-pub const __NR_fcntl: u32 = 25;
-pub const __NR_statfs: u32 = 43;
-pub const __NR_fstatfs: u32 = 44;
-pub const __NR_truncate: u32 = 45;
-pub const __NR_ftruncate: u32 = 46;
-pub const __NR_lseek: u32 = 62;
-pub const __NR_sendfile: u32 = 71;
-pub const __NR_mmap: u32 = 222;
-pub const __NR_fadvise64: u32 = 223;
+pub const __NR_mseal: u32 = 462;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
 pub const WSTOPPED: u32 = 2;
@@ -2661,6 +2723,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/loongarch64/if_arp.rs
+++ b/src/loongarch64/if_arp.rs
@@ -612,6 +612,7 @@ pub ar_hln: crate::ctypes::c_uchar,
 pub ar_pln: crate::ctypes::c_uchar,
 pub ar_op: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1381,6 +1382,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
@@ -1414,6 +1417,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1515,6 +1519,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
@@ -2281,7 +2286,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2319,7 +2326,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2495,7 +2503,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/loongarch64/if_ether.rs
+++ b/src/loongarch64/if_ether.rs
@@ -57,6 +57,7 @@ pub h_dest: [crate::ctypes::c_uchar; 6usize],
 pub h_source: [crate::ctypes::c_uchar; 6usize],
 pub h_proto: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const ETH_ALEN: u32 = 6;
 pub const ETH_TLEN: u32 = 2;
 pub const ETH_HLEN: u32 = 14;

--- a/src/loongarch64/if_packet.rs
+++ b/src/loongarch64/if_packet.rs
@@ -205,6 +205,7 @@ pub type_flags: __u16,
 pub max_num_members: __u32,
 }
 pub const __LITTLE_ENDIAN: u32 = 1234;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PACKET_HOST: u32 = 0;
 pub const PACKET_BROADCAST: u32 = 1;
 pub const PACKET_MULTICAST: u32 = 2;

--- a/src/loongarch64/io_uring.rs
+++ b/src/loongarch64/io_uring.rs
@@ -140,7 +140,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -158,7 +158,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -168,6 +169,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -183,6 +185,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -249,6 +263,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -492,6 +525,14 @@ pub resv: [__u32; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_napi {
+pub busy_poll_to: __u32,
+pub prefer_busy_poll: __u8,
+pub pad: [__u8; 3usize],
+pub resv: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -557,6 +598,7 @@ pub const IOC_OUT: u32 = 2147483648;
 pub const IOC_INOUT: u32 = 3221225472;
 pub const IOCSIZE_MASK: u32 = 1073676288;
 pub const IOCSIZE_SHIFT: u32 = 16;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const FSCRYPT_POLICY_FLAGS_PAD_4: u32 = 0;
 pub const FSCRYPT_POLICY_FLAGS_PAD_8: u32 = 1;
 pub const FSCRYPT_POLICY_FLAGS_PAD_16: u32 = 2;
@@ -671,13 +713,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -749,6 +795,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -804,15 +851,20 @@ pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
 pub const IORING_SEND_ZC_REPORT_USAGE: u32 = 8;
+pub const IORING_RECVSEND_BUNDLE: u32 = 16;
 pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
+pub const IORING_ACCEPT_DONTWAIT: u32 = 2;
+pub const IORING_ACCEPT_POLL_FIRST: u32 = 4;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
 pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
+pub const IORING_NOP_INJECT_RESULT: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
 pub const IORING_CQE_F_NOTIF: u32 = 8;
+pub const IORING_CQE_BUFFER_SHIFT: u32 = 16;
 pub const IORING_OFF_SQ_RING: u32 = 0;
 pub const IORING_OFF_CQ_RING: u32 = 134217728;
 pub const IORING_OFF_SQES: u32 = 268435456;
@@ -842,60 +894,10 @@ pub const IORING_FEAT_RSRC_TAGS: u32 = 1024;
 pub const IORING_FEAT_CQE_SKIP: u32 = 2048;
 pub const IORING_FEAT_LINKED_FILE: u32 = 4096;
 pub const IORING_FEAT_REG_REG_RING: u32 = 8192;
+pub const IORING_FEAT_RECVSEND_BUNDLE: u32 = 16384;
 pub const IORING_RSRC_REGISTER_SPARSE: u32 = 1;
 pub const IORING_REGISTER_FILES_SKIP: i32 = -2;
 pub const IO_URING_OP_SUPPORTED: u32 = 1;
-pub const IOSQE_FIXED_FILE_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_FIXED_FILE_BIT;
-pub const IOSQE_IO_DRAIN_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_DRAIN_BIT;
-pub const IOSQE_IO_LINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_LINK_BIT;
-pub const IOSQE_IO_HARDLINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_HARDLINK_BIT;
-pub const IOSQE_ASYNC_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_ASYNC_BIT;
-pub const IOSQE_BUFFER_SELECT_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_BUFFER_SELECT_BIT;
-pub const IOSQE_CQE_SKIP_SUCCESS_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_CQE_SKIP_SUCCESS_BIT;
-pub const IORING_MSG_DATA: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_DATA;
-pub const IORING_MSG_SEND_FD: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_SEND_FD;
-pub const IORING_CQE_BUFFER_SHIFT: _bindgen_ty_3 = _bindgen_ty_3::IORING_CQE_BUFFER_SHIFT;
-pub const IORING_REGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS;
-pub const IORING_UNREGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_BUFFERS;
-pub const IORING_REGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES;
-pub const IORING_UNREGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_FILES;
-pub const IORING_REGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD;
-pub const IORING_UNREGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_EVENTFD;
-pub const IORING_REGISTER_FILES_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE;
-pub const IORING_REGISTER_EVENTFD_ASYNC: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD_ASYNC;
-pub const IORING_REGISTER_PROBE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PROBE;
-pub const IORING_REGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PERSONALITY;
-pub const IORING_UNREGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PERSONALITY;
-pub const IORING_REGISTER_RESTRICTIONS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RESTRICTIONS;
-pub const IORING_REGISTER_ENABLE_RINGS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_ENABLE_RINGS;
-pub const IORING_REGISTER_FILES2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES2;
-pub const IORING_REGISTER_FILES_UPDATE2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE2;
-pub const IORING_REGISTER_BUFFERS2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS2;
-pub const IORING_REGISTER_BUFFERS_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS_UPDATE;
-pub const IORING_REGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_AFF;
-pub const IORING_UNREGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_IOWQ_AFF;
-pub const IORING_REGISTER_IOWQ_MAX_WORKERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_MAX_WORKERS;
-pub const IORING_REGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RING_FDS;
-pub const IORING_UNREGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_RING_FDS;
-pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_RING;
-pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
-pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
-pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
-pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
-pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
-pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
-pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
-pub const IO_WQ_UNBOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_UNBOUND;
-pub const IOU_PBUF_RING_MMAP: _bindgen_ty_6 = _bindgen_ty_6::IOU_PBUF_RING_MMAP;
-pub const IORING_RESTRICTION_REGISTER_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_REGISTER_OP;
-pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_OP;
-pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
-pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
-pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
-pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
-pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
-pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
-pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -913,7 +915,18 @@ FSCONFIG_CMD_CREATE_EXCL = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_1 {
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum io_uring_sqe_flags_bit {
 IOSQE_FIXED_FILE_BIT = 0,
 IOSQE_IO_DRAIN_BIT = 1,
 IOSQE_IO_LINK_BIT = 2,
@@ -981,25 +994,22 @@ IORING_OP_FUTEX_WAIT = 51,
 IORING_OP_FUTEX_WAKE = 52,
 IORING_OP_FUTEX_WAITV = 53,
 IORING_OP_FIXED_FD_INSTALL = 54,
-IORING_OP_LAST = 55,
+IORING_OP_FTRUNCATE = 55,
+IORING_OP_BIND = 56,
+IORING_OP_LISTEN = 57,
+IORING_OP_LAST = 58,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_2 {
+pub enum io_uring_msg_ring_flags {
 IORING_MSG_DATA = 0,
 IORING_MSG_SEND_FD = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_3 {
-IORING_CQE_BUFFER_SHIFT = 16,
-}
-#[repr(u32)]
-#[non_exhaustive]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_4 {
+pub enum io_uring_register_op {
 IORING_REGISTER_BUFFERS = 0,
 IORING_UNREGISTER_BUFFERS = 1,
 IORING_REGISTER_FILES = 2,
@@ -1027,26 +1037,28 @@ IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
 IORING_REGISTER_PBUF_STATUS = 26,
-IORING_REGISTER_LAST = 27,
+IORING_REGISTER_NAPI = 27,
+IORING_UNREGISTER_NAPI = 28,
+IORING_REGISTER_LAST = 29,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_5 {
+pub enum io_wq_type {
 IO_WQ_BOUND = 0,
 IO_WQ_UNBOUND = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_6 {
+pub enum io_uring_register_pbuf_ring_flags {
 IOU_PBUF_RING_MMAP = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_7 {
+pub enum io_uring_register_restriction_op {
 IORING_RESTRICTION_REGISTER_OP = 0,
 IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
@@ -1056,7 +1068,7 @@ IORING_RESTRICTION_LAST = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_8 {
+pub enum io_uring_socket_op {
 SOCKET_URING_OP_SIOCINQ = 0,
 SOCKET_URING_OP_SIOCOUTQ = 1,
 SOCKET_URING_OP_GETSOCKOPT = 2,
@@ -1115,6 +1127,7 @@ pub uring_cmd_flags: __u32,
 pub waitid_flags: __u32,
 pub futex_flags: __u32,
 pub install_fd_flags: __u32,
+pub nop_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]

--- a/src/loongarch64/loop_device.rs
+++ b/src/loongarch64/loop_device.rs
@@ -93,6 +93,7 @@ pub __reserved: [__u64; 8usize],
 }
 pub const LO_NAME_SIZE: u32 = 64;
 pub const LO_KEY_SIZE: u32 = 32;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const LO_CRYPT_NONE: u32 = 0;
 pub const LO_CRYPT_XOR: u32 = 1;
 pub const LO_CRYPT_DES: u32 = 2;

--- a/src/loongarch64/mempolicy.rs
+++ b/src/loongarch64/mempolicy.rs
@@ -158,6 +158,7 @@ pub const MPOL_BIND: _bindgen_ty_1 = _bindgen_ty_1::MPOL_BIND;
 pub const MPOL_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_INTERLEAVE;
 pub const MPOL_LOCAL: _bindgen_ty_1 = _bindgen_ty_1::MPOL_LOCAL;
 pub const MPOL_PREFERRED_MANY: _bindgen_ty_1 = _bindgen_ty_1::MPOL_PREFERRED_MANY;
+pub const MPOL_WEIGHTED_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_WEIGHTED_INTERLEAVE;
 pub const MPOL_MAX: _bindgen_ty_1 = _bindgen_ty_1::MPOL_MAX;
 #[repr(u32)]
 #[non_exhaustive]
@@ -169,5 +170,6 @@ MPOL_BIND = 2,
 MPOL_INTERLEAVE = 3,
 MPOL_LOCAL = 4,
 MPOL_PREFERRED_MANY = 5,
-MPOL_MAX = 6,
+MPOL_WEIGHTED_INTERLEAVE = 6,
+MPOL_MAX = 7,
 }

--- a/src/loongarch64/net.rs
+++ b/src/loongarch64/net.rs
@@ -854,6 +854,7 @@ pub _address: u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1267,6 +1268,7 @@ pub const TCP_AO_DEL_KEY: u32 = 39;
 pub const TCP_AO_INFO: u32 = 40;
 pub const TCP_AO_GET_KEYS: u32 = 41;
 pub const TCP_AO_REPAIR: u32 = 42;
+pub const TCP_IS_MPTCP: u32 = 43;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1553,6 +1555,7 @@ pub const IPPROTO_UDPLITE: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_UDPLITE;
 pub const IPPROTO_MPLS: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPLS;
 pub const IPPROTO_ETHERNET: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ETHERNET;
 pub const IPPROTO_RAW: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_RAW;
+pub const IPPROTO_SMC: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_SMC;
 pub const IPPROTO_MPTCP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPTCP;
 pub const IPPROTO_MAX: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MAX;
 pub const IPV4_DEVCONF_FORWARDING: _bindgen_ty_2 = _bindgen_ty_2::IPV4_DEVCONF_FORWARDING;
@@ -1741,6 +1744,7 @@ IPPROTO_UDPLITE = 136,
 IPPROTO_MPLS = 137,
 IPPROTO_ETHERNET = 143,
 IPPROTO_RAW = 255,
+IPPROTO_SMC = 256,
 IPPROTO_MPTCP = 262,
 IPPROTO_MAX = 263,
 }

--- a/src/loongarch64/netlink.rs
+++ b/src/loongarch64/netlink.rs
@@ -549,6 +549,7 @@ pub const SOCK_BUF_LOCK_MASK: u32 = 3;
 pub const SOCK_TXREHASH_DEFAULT: u32 = 255;
 pub const SOCK_TXREHASH_DISABLED: u32 = 0;
 pub const SOCK_TXREHASH_ENABLED: u32 = 1;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const NETLINK_ROUTE: u32 = 0;
 pub const NETLINK_UNUSED: u32 = 1;
 pub const NETLINK_USERSOCK: u32 = 2;
@@ -1096,6 +1097,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
@@ -1129,6 +1132,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1230,6 +1234,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
@@ -2144,7 +2149,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2182,7 +2189,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2358,7 +2366,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/loongarch64/prctl.rs
+++ b/src/loongarch64/prctl.rs
@@ -68,6 +68,7 @@ pub auxv: *mut __u64,
 pub auxv_size: __u32,
 pub exe_fd: __u32,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PR_SET_PDEATHSIG: u32 = 1;
 pub const PR_GET_PDEATHSIG: u32 = 2;
 pub const PR_GET_DUMPABLE: u32 = 3;
@@ -234,3 +235,20 @@ pub const PR_RISCV_V_VSTATE_CTRL_INHERIT: u32 = 16;
 pub const PR_RISCV_V_VSTATE_CTRL_CUR_MASK: u32 = 3;
 pub const PR_RISCV_V_VSTATE_CTRL_NEXT_MASK: u32 = 12;
 pub const PR_RISCV_V_VSTATE_CTRL_MASK: u32 = 31;
+pub const PR_RISCV_SET_ICACHE_FLUSH_CTX: u32 = 71;
+pub const PR_RISCV_CTX_SW_FENCEI_ON: u32 = 0;
+pub const PR_RISCV_CTX_SW_FENCEI_OFF: u32 = 1;
+pub const PR_RISCV_SCOPE_PER_PROCESS: u32 = 0;
+pub const PR_RISCV_SCOPE_PER_THREAD: u32 = 1;
+pub const PR_PPC_GET_DEXCR: u32 = 72;
+pub const PR_PPC_SET_DEXCR: u32 = 73;
+pub const PR_PPC_DEXCR_SBHE: u32 = 0;
+pub const PR_PPC_DEXCR_IBRTPD: u32 = 1;
+pub const PR_PPC_DEXCR_SRAPD: u32 = 2;
+pub const PR_PPC_DEXCR_NPHIE: u32 = 3;
+pub const PR_PPC_DEXCR_CTRL_EDITABLE: u32 = 1;
+pub const PR_PPC_DEXCR_CTRL_SET: u32 = 2;
+pub const PR_PPC_DEXCR_CTRL_CLEAR: u32 = 4;
+pub const PR_PPC_DEXCR_CTRL_SET_ONEXEC: u32 = 8;
+pub const PR_PPC_DEXCR_CTRL_CLEAR_ONEXEC: u32 = 16;
+pub const PR_PPC_DEXCR_CTRL_MASK: u32 = 31;

--- a/src/loongarch64/system.rs
+++ b/src/loongarch64/system.rs
@@ -99,6 +99,7 @@ pub version: [crate::ctypes::c_char; 65usize],
 pub machine: [crate::ctypes::c_char; 65usize],
 pub domainname: [crate::ctypes::c_char; 65usize],
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const SI_LOAD_SHIFT: u32 = 16;
 pub const __OLD_UTS_LEN: u32 = 8;
 pub const __NEW_UTS_LEN: u32 = 64;

--- a/src/loongarch64/xdp.rs
+++ b/src/loongarch64/xdp.rs
@@ -154,6 +154,7 @@ pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,
 pub tx_invalid_descs: __u64,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
@@ -161,6 +162,7 @@ pub const XDP_USE_NEED_WAKEUP: u32 = 8;
 pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
 pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
+pub const XDP_UMEM_TX_METADATA_LEN: u32 = 4;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;

--- a/src/mips/btrfs.rs
+++ b/src/mips/btrfs.rs
@@ -136,7 +136,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -154,7 +154,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -164,6 +165,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -179,6 +181,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -245,6 +259,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -855,10 +888,17 @@ pub physical: __le64,
 }
 #[repr(C, packed)]
 pub struct btrfs_stripe_extent {
-pub encoding: __u8,
-pub reserved: [__u8; 7usize],
+pub __bindgen_anon_1: btrfs_stripe_extent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct btrfs_stripe_extent__bindgen_ty_1 {
+pub __empty_strides: btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1,
 pub strides: __IncompleteArrayField<btrfs_raid_stride>,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct btrfs_extent_item {
@@ -1127,6 +1167,7 @@ pub encryption: __u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -1284,13 +1325,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1362,6 +1407,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1394,6 +1440,7 @@ pub const BTRFS_QGROUP_LIMIT_RSV_EXCL: u32 = 8;
 pub const BTRFS_QGROUP_LIMIT_RFER_CMPR: u32 = 16;
 pub const BTRFS_QGROUP_LIMIT_EXCL_CMPR: u32 = 32;
 pub const BTRFS_QGROUP_INHERIT_SET_LIMITS: u32 = 1;
+pub const BTRFS_QGROUP_INHERIT_FLAGS_SUPP: u32 = 1;
 pub const BTRFS_DEVICE_REMOVE_ARGS_MASK: u32 = 8;
 pub const BTRFS_SUBVOL_CREATE_ARGS_MASK: u32 = 6;
 pub const BTRFS_SUBVOL_DELETE_ARGS_MASK: u32 = 16;
@@ -1599,14 +1646,6 @@ pub const BTRFS_SYSTEM_CHUNK_ARRAY_SIZE: u32 = 2048;
 pub const BTRFS_NUM_BACKUP_ROOTS: u32 = 4;
 pub const BTRFS_FREE_SPACE_EXTENT: u32 = 1;
 pub const BTRFS_FREE_SPACE_BITMAP: u32 = 2;
-pub const BTRFS_STRIPE_RAID0: u32 = 1;
-pub const BTRFS_STRIPE_RAID1: u32 = 2;
-pub const BTRFS_STRIPE_DUP: u32 = 3;
-pub const BTRFS_STRIPE_RAID10: u32 = 4;
-pub const BTRFS_STRIPE_RAID5: u32 = 5;
-pub const BTRFS_STRIPE_RAID6: u32 = 6;
-pub const BTRFS_STRIPE_RAID1C3: u32 = 7;
-pub const BTRFS_STRIPE_RAID1C4: u32 = 8;
 pub const BTRFS_HEADER_FLAG_WRITTEN: u32 = 1;
 pub const BTRFS_HEADER_FLAG_RELOC: u32 = 2;
 pub const BTRFS_SUPER_FLAG_ERROR: u32 = 4;
@@ -1615,6 +1654,9 @@ pub const BTRFS_SUPER_FLAG_METADUMP: u64 = 8589934592;
 pub const BTRFS_SUPER_FLAG_METADUMP_V2: u64 = 17179869184;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID: u64 = 34359738368;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID_V2: u64 = 68719476736;
+pub const BTRFS_SUPER_FLAG_CHANGING_BG_TREE: u64 = 274877906944;
+pub const BTRFS_SUPER_FLAG_CHANGING_DATA_CSUM: u64 = 549755813888;
+pub const BTRFS_SUPER_FLAG_CHANGING_META_CSUM: u64 = 1099511627776;
 pub const BTRFS_EXTENT_FLAG_DATA: u32 = 1;
 pub const BTRFS_EXTENT_FLAG_TREE_BLOCK: u32 = 2;
 pub const BTRFS_BLOCK_FLAG_FULL_BACKREF: u32 = 256;
@@ -1670,6 +1712,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/mips/general.rs
+++ b/src/mips/general.rs
@@ -163,6 +163,14 @@ pub data: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct epoll_params {
+pub busy_poll_usecs: __u32,
+pub busy_poll_budget: __u16,
+pub prefer_busy_poll: __u8,
+pub __pad: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct fscrypt_policy_v1 {
 pub version: __u8,
 pub contents_encryption_mode: __u8,
@@ -245,7 +253,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -263,7 +271,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -273,6 +282,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -288,6 +298,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -357,6 +379,25 @@ pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct futex_waitv {
 pub val: __u64,
 pub uaddr: __u64,
@@ -412,6 +453,14 @@ pub struct rand_pool_info {
 pub entropy_count: crate::ctypes::c_int,
 pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vgetrandom_opaque_params {
+pub size_of_opaque_state: __u32,
+pub mmap_prot: __u32,
+pub mmap_flags: __u32,
+pub reserved: [__u32; 13usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -644,7 +693,12 @@ pub stx_dev_minor: __u32,
 pub stx_mnt_id: __u64,
 pub stx_dio_mem_align: __u32,
 pub stx_dio_offset_align: __u32,
-pub __spare3: [__u64; 12usize],
+pub stx_subvol: __u64,
+pub stx_atomic_write_unit_min: __u32,
+pub stx_atomic_write_unit_max: __u32,
+pub stx_atomic_write_segments_max: __u32,
+pub __spare1: [__u32; 1usize],
+pub __spare3: [__u64; 9usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -980,9 +1034,9 @@ pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 395264;
+pub const LINUX_VERSION_CODE: u32 = 396032;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 11;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_VECTOR_SIZE_ARCH: u32 = 1;
@@ -1010,8 +1064,11 @@ pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_RSEQ_FEATURE_SIZE: u32 = 27;
 pub const AT_RSEQ_ALIGN: u32 = 28;
+pub const AT_HWCAP3: u32 = 29;
+pub const AT_HWCAP4: u32 = 30;
 pub const AT_EXECFN: u32 = 31;
 pub const AT_MINSIGSTKSZ: u32 = 51;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
@@ -1156,9 +1213,10 @@ pub const RESOLVE_IN_ROOT: u32 = 16;
 pub const RESOLVE_CACHED: u32 = 32;
 pub const F_SETLEASE: u32 = 1024;
 pub const F_GETLEASE: u32 = 1025;
+pub const F_NOTIFY: u32 = 1026;
+pub const F_DUPFD_QUERY: u32 = 1027;
 pub const F_CANCELLK: u32 = 1029;
 pub const F_DUPFD_CLOEXEC: u32 = 1030;
-pub const F_NOTIFY: u32 = 1026;
 pub const F_SETPIPE_SZ: u32 = 1031;
 pub const F_GETPIPE_SZ: u32 = 1032;
 pub const F_ADD_SEALS: u32 = 1033;
@@ -1204,6 +1262,7 @@ pub const EPOLL_CLOEXEC: u32 = 524288;
 pub const EPOLL_CTL_ADD: u32 = 1;
 pub const EPOLL_CTL_DEL: u32 = 2;
 pub const EPOLL_CTL_MOD: u32 = 3;
+pub const EPOLL_IOC_TYPE: u32 = 138;
 pub const POSIX_FADV_NORMAL: u32 = 0;
 pub const POSIX_FADV_RANDOM: u32 = 1;
 pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
@@ -1365,13 +1424,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1443,6 +1506,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1571,6 +1635,7 @@ pub const EFIVARFS_MAGIC: u32 = 3730735588;
 pub const HOSTFS_SUPER_MAGIC: u32 = 12648430;
 pub const OVERLAYFS_SUPER_MAGIC: u32 = 2035054128;
 pub const FUSE_SUPER_MAGIC: u32 = 1702057286;
+pub const BCACHEFS_SUPER_MAGIC: u32 = 3393526350;
 pub const MINIX_SUPER_MAGIC: u32 = 4991;
 pub const MINIX_SUPER_MAGIC2: u32 = 5007;
 pub const MINIX2_SUPER_MAGIC: u32 = 9320;
@@ -1620,6 +1685,7 @@ pub const UDF_SUPER_MAGIC: u32 = 352400198;
 pub const DMA_BUF_MAGIC: u32 = 1145913666;
 pub const DEVMEM_MAGIC: u32 = 1162691661;
 pub const SECRETMEM_MAGIC: u32 = 1397048141;
+pub const PID_FS_MAGIC: u32 = 1346978886;
 pub const PROT_NONE: u32 = 0;
 pub const PROT_READ: u32 = 1;
 pub const PROT_WRITE: u32 = 2;
@@ -1703,6 +1769,7 @@ pub const OVERCOMMIT_NEVER: u32 = 2;
 pub const MAP_SHARED: u32 = 1;
 pub const MAP_PRIVATE: u32 = 2;
 pub const MAP_SHARED_VALIDATE: u32 = 3;
+pub const MAP_DROPPABLE: u32 = 8;
 pub const MAP_HUGE_SHIFT: u32 = 26;
 pub const MAP_HUGE_MASK: u32 = 63;
 pub const MAP_HUGE_16KB: u32 = 939524096;
@@ -2008,6 +2075,8 @@ pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
 pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
+pub const STATX_SUBVOL: u32 = 32768;
+pub const STATX_WRITE_ATOMIC: u32 = 65536;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2019,6 +2088,7 @@ pub const STATX_ATTR_AUTOMOUNT: u32 = 4096;
 pub const STATX_ATTR_MOUNT_ROOT: u32 = 8192;
 pub const STATX_ATTR_VERITY: u32 = 1048576;
 pub const STATX_ATTR_DAX: u32 = 2097152;
+pub const STATX_ATTR_WRITE_ATOMIC: u32 = 4194304;
 pub const EPERM: u32 = 1;
 pub const ENOENT: u32 = 2;
 pub const ESRCH: u32 = 3;
@@ -2781,6 +2851,7 @@ pub const __NR_listmount: u32 = 4458;
 pub const __NR_lsm_get_self_attr: u32 = 4459;
 pub const __NR_lsm_set_self_attr: u32 = 4460;
 pub const __NR_lsm_list_modules: u32 = 4461;
+pub const __NR_mseal: u32 = 4462;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
 pub const WSTOPPED: u32 = 2;
@@ -2969,6 +3040,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/mips/if_arp.rs
+++ b/src/mips/if_arp.rs
@@ -610,6 +610,7 @@ pub ar_hln: crate::ctypes::c_uchar,
 pub ar_pln: crate::ctypes::c_uchar,
 pub ar_op: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -1389,6 +1390,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
@@ -1422,6 +1425,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1523,6 +1527,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
@@ -2289,7 +2294,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2327,7 +2334,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2503,7 +2511,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/mips/if_ether.rs
+++ b/src/mips/if_ether.rs
@@ -55,6 +55,7 @@ pub h_dest: [crate::ctypes::c_uchar; 6usize],
 pub h_source: [crate::ctypes::c_uchar; 6usize],
 pub h_proto: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;

--- a/src/mips/if_packet.rs
+++ b/src/mips/if_packet.rs
@@ -203,6 +203,7 @@ pub id: __u16,
 pub max_num_members: __u32,
 }
 pub const __BIG_ENDIAN: u32 = 4321;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;

--- a/src/mips/io_uring.rs
+++ b/src/mips/io_uring.rs
@@ -138,7 +138,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -156,7 +156,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -166,6 +167,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -181,6 +183,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -247,6 +261,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -490,6 +523,14 @@ pub resv: [__u32; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_napi {
+pub busy_poll_to: __u32,
+pub prefer_busy_poll: __u8,
+pub pad: [__u8; 3usize],
+pub resv: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -555,6 +596,7 @@ pub const IOC_OUT: u32 = 1073741824;
 pub const IOC_INOUT: u32 = 3221225472;
 pub const IOCSIZE_MASK: u32 = 536805376;
 pub const IOCSIZE_SHIFT: u32 = 16;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -679,13 +721,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -757,6 +803,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -812,15 +859,20 @@ pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
 pub const IORING_SEND_ZC_REPORT_USAGE: u32 = 8;
+pub const IORING_RECVSEND_BUNDLE: u32 = 16;
 pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
+pub const IORING_ACCEPT_DONTWAIT: u32 = 2;
+pub const IORING_ACCEPT_POLL_FIRST: u32 = 4;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
 pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
+pub const IORING_NOP_INJECT_RESULT: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
 pub const IORING_CQE_F_NOTIF: u32 = 8;
+pub const IORING_CQE_BUFFER_SHIFT: u32 = 16;
 pub const IORING_OFF_SQ_RING: u32 = 0;
 pub const IORING_OFF_CQ_RING: u32 = 134217728;
 pub const IORING_OFF_SQES: u32 = 268435456;
@@ -850,60 +902,10 @@ pub const IORING_FEAT_RSRC_TAGS: u32 = 1024;
 pub const IORING_FEAT_CQE_SKIP: u32 = 2048;
 pub const IORING_FEAT_LINKED_FILE: u32 = 4096;
 pub const IORING_FEAT_REG_REG_RING: u32 = 8192;
+pub const IORING_FEAT_RECVSEND_BUNDLE: u32 = 16384;
 pub const IORING_RSRC_REGISTER_SPARSE: u32 = 1;
 pub const IORING_REGISTER_FILES_SKIP: i32 = -2;
 pub const IO_URING_OP_SUPPORTED: u32 = 1;
-pub const IOSQE_FIXED_FILE_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_FIXED_FILE_BIT;
-pub const IOSQE_IO_DRAIN_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_DRAIN_BIT;
-pub const IOSQE_IO_LINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_LINK_BIT;
-pub const IOSQE_IO_HARDLINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_HARDLINK_BIT;
-pub const IOSQE_ASYNC_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_ASYNC_BIT;
-pub const IOSQE_BUFFER_SELECT_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_BUFFER_SELECT_BIT;
-pub const IOSQE_CQE_SKIP_SUCCESS_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_CQE_SKIP_SUCCESS_BIT;
-pub const IORING_MSG_DATA: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_DATA;
-pub const IORING_MSG_SEND_FD: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_SEND_FD;
-pub const IORING_CQE_BUFFER_SHIFT: _bindgen_ty_3 = _bindgen_ty_3::IORING_CQE_BUFFER_SHIFT;
-pub const IORING_REGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS;
-pub const IORING_UNREGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_BUFFERS;
-pub const IORING_REGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES;
-pub const IORING_UNREGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_FILES;
-pub const IORING_REGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD;
-pub const IORING_UNREGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_EVENTFD;
-pub const IORING_REGISTER_FILES_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE;
-pub const IORING_REGISTER_EVENTFD_ASYNC: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD_ASYNC;
-pub const IORING_REGISTER_PROBE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PROBE;
-pub const IORING_REGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PERSONALITY;
-pub const IORING_UNREGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PERSONALITY;
-pub const IORING_REGISTER_RESTRICTIONS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RESTRICTIONS;
-pub const IORING_REGISTER_ENABLE_RINGS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_ENABLE_RINGS;
-pub const IORING_REGISTER_FILES2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES2;
-pub const IORING_REGISTER_FILES_UPDATE2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE2;
-pub const IORING_REGISTER_BUFFERS2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS2;
-pub const IORING_REGISTER_BUFFERS_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS_UPDATE;
-pub const IORING_REGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_AFF;
-pub const IORING_UNREGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_IOWQ_AFF;
-pub const IORING_REGISTER_IOWQ_MAX_WORKERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_MAX_WORKERS;
-pub const IORING_REGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RING_FDS;
-pub const IORING_UNREGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_RING_FDS;
-pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_RING;
-pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
-pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
-pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
-pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
-pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
-pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
-pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
-pub const IO_WQ_UNBOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_UNBOUND;
-pub const IOU_PBUF_RING_MMAP: _bindgen_ty_6 = _bindgen_ty_6::IOU_PBUF_RING_MMAP;
-pub const IORING_RESTRICTION_REGISTER_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_REGISTER_OP;
-pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_OP;
-pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
-pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
-pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
-pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
-pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
-pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
-pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -921,7 +923,18 @@ FSCONFIG_CMD_CREATE_EXCL = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_1 {
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum io_uring_sqe_flags_bit {
 IOSQE_FIXED_FILE_BIT = 0,
 IOSQE_IO_DRAIN_BIT = 1,
 IOSQE_IO_LINK_BIT = 2,
@@ -989,25 +1002,22 @@ IORING_OP_FUTEX_WAIT = 51,
 IORING_OP_FUTEX_WAKE = 52,
 IORING_OP_FUTEX_WAITV = 53,
 IORING_OP_FIXED_FD_INSTALL = 54,
-IORING_OP_LAST = 55,
+IORING_OP_FTRUNCATE = 55,
+IORING_OP_BIND = 56,
+IORING_OP_LISTEN = 57,
+IORING_OP_LAST = 58,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_2 {
+pub enum io_uring_msg_ring_flags {
 IORING_MSG_DATA = 0,
 IORING_MSG_SEND_FD = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_3 {
-IORING_CQE_BUFFER_SHIFT = 16,
-}
-#[repr(u32)]
-#[non_exhaustive]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_4 {
+pub enum io_uring_register_op {
 IORING_REGISTER_BUFFERS = 0,
 IORING_UNREGISTER_BUFFERS = 1,
 IORING_REGISTER_FILES = 2,
@@ -1035,26 +1045,28 @@ IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
 IORING_REGISTER_PBUF_STATUS = 26,
-IORING_REGISTER_LAST = 27,
+IORING_REGISTER_NAPI = 27,
+IORING_UNREGISTER_NAPI = 28,
+IORING_REGISTER_LAST = 29,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_5 {
+pub enum io_wq_type {
 IO_WQ_BOUND = 0,
 IO_WQ_UNBOUND = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_6 {
+pub enum io_uring_register_pbuf_ring_flags {
 IOU_PBUF_RING_MMAP = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_7 {
+pub enum io_uring_register_restriction_op {
 IORING_RESTRICTION_REGISTER_OP = 0,
 IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
@@ -1064,7 +1076,7 @@ IORING_RESTRICTION_LAST = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_8 {
+pub enum io_uring_socket_op {
 SOCKET_URING_OP_SIOCINQ = 0,
 SOCKET_URING_OP_SIOCOUTQ = 1,
 SOCKET_URING_OP_GETSOCKOPT = 2,
@@ -1123,6 +1135,7 @@ pub uring_cmd_flags: __u32,
 pub waitid_flags: __u32,
 pub futex_flags: __u32,
 pub install_fd_flags: __u32,
+pub nop_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]

--- a/src/mips/loop_device.rs
+++ b/src/mips/loop_device.rs
@@ -101,6 +101,7 @@ pub const _MIPS_ISA_MIPS64: u32 = 7;
 pub const _MIPS_SIM_ABI32: u32 = 1;
 pub const _MIPS_SIM_NABI32: u32 = 2;
 pub const _MIPS_SIM_ABI64: u32 = 3;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const LO_CRYPT_NONE: u32 = 0;
 pub const LO_CRYPT_XOR: u32 = 1;
 pub const LO_CRYPT_DES: u32 = 2;

--- a/src/mips/mempolicy.rs
+++ b/src/mips/mempolicy.rs
@@ -160,6 +160,7 @@ pub const MPOL_BIND: _bindgen_ty_1 = _bindgen_ty_1::MPOL_BIND;
 pub const MPOL_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_INTERLEAVE;
 pub const MPOL_LOCAL: _bindgen_ty_1 = _bindgen_ty_1::MPOL_LOCAL;
 pub const MPOL_PREFERRED_MANY: _bindgen_ty_1 = _bindgen_ty_1::MPOL_PREFERRED_MANY;
+pub const MPOL_WEIGHTED_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_WEIGHTED_INTERLEAVE;
 pub const MPOL_MAX: _bindgen_ty_1 = _bindgen_ty_1::MPOL_MAX;
 #[repr(u32)]
 #[non_exhaustive]
@@ -171,5 +172,6 @@ MPOL_BIND = 2,
 MPOL_INTERLEAVE = 3,
 MPOL_LOCAL = 4,
 MPOL_PREFERRED_MANY = 5,
-MPOL_MAX = 6,
+MPOL_WEIGHTED_INTERLEAVE = 6,
+MPOL_MAX = 7,
 }

--- a/src/mips/net.rs
+++ b/src/mips/net.rs
@@ -854,6 +854,7 @@ pub _address: u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -1290,6 +1291,7 @@ pub const TCP_AO_DEL_KEY: u32 = 39;
 pub const TCP_AO_INFO: u32 = 40;
 pub const TCP_AO_GET_KEYS: u32 = 41;
 pub const TCP_AO_REPAIR: u32 = 42;
+pub const TCP_IS_MPTCP: u32 = 43;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1576,6 +1578,7 @@ pub const IPPROTO_UDPLITE: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_UDPLITE;
 pub const IPPROTO_MPLS: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPLS;
 pub const IPPROTO_ETHERNET: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ETHERNET;
 pub const IPPROTO_RAW: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_RAW;
+pub const IPPROTO_SMC: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_SMC;
 pub const IPPROTO_MPTCP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPTCP;
 pub const IPPROTO_MAX: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MAX;
 pub const IPV4_DEVCONF_FORWARDING: _bindgen_ty_2 = _bindgen_ty_2::IPV4_DEVCONF_FORWARDING;
@@ -1764,6 +1767,7 @@ IPPROTO_UDPLITE = 136,
 IPPROTO_MPLS = 137,
 IPPROTO_ETHERNET = 143,
 IPPROTO_RAW = 255,
+IPPROTO_SMC = 256,
 IPPROTO_MPTCP = 262,
 IPPROTO_MAX = 263,
 }

--- a/src/mips/netlink.rs
+++ b/src/mips/netlink.rs
@@ -547,6 +547,7 @@ pub const SOCK_BUF_LOCK_MASK: u32 = 3;
 pub const SOCK_TXREHASH_DEFAULT: u32 = 255;
 pub const SOCK_TXREHASH_DISABLED: u32 = 0;
 pub const SOCK_TXREHASH_ENABLED: u32 = 1;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -1104,6 +1105,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
@@ -1137,6 +1140,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1238,6 +1242,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
@@ -2152,7 +2157,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2190,7 +2197,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2366,7 +2374,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/mips/prctl.rs
+++ b/src/mips/prctl.rs
@@ -66,6 +66,7 @@ pub auxv: *mut __u64,
 pub auxv_size: __u32,
 pub exe_fd: __u32,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -242,3 +243,20 @@ pub const PR_RISCV_V_VSTATE_CTRL_INHERIT: u32 = 16;
 pub const PR_RISCV_V_VSTATE_CTRL_CUR_MASK: u32 = 3;
 pub const PR_RISCV_V_VSTATE_CTRL_NEXT_MASK: u32 = 12;
 pub const PR_RISCV_V_VSTATE_CTRL_MASK: u32 = 31;
+pub const PR_RISCV_SET_ICACHE_FLUSH_CTX: u32 = 71;
+pub const PR_RISCV_CTX_SW_FENCEI_ON: u32 = 0;
+pub const PR_RISCV_CTX_SW_FENCEI_OFF: u32 = 1;
+pub const PR_RISCV_SCOPE_PER_PROCESS: u32 = 0;
+pub const PR_RISCV_SCOPE_PER_THREAD: u32 = 1;
+pub const PR_PPC_GET_DEXCR: u32 = 72;
+pub const PR_PPC_SET_DEXCR: u32 = 73;
+pub const PR_PPC_DEXCR_SBHE: u32 = 0;
+pub const PR_PPC_DEXCR_IBRTPD: u32 = 1;
+pub const PR_PPC_DEXCR_SRAPD: u32 = 2;
+pub const PR_PPC_DEXCR_NPHIE: u32 = 3;
+pub const PR_PPC_DEXCR_CTRL_EDITABLE: u32 = 1;
+pub const PR_PPC_DEXCR_CTRL_SET: u32 = 2;
+pub const PR_PPC_DEXCR_CTRL_CLEAR: u32 = 4;
+pub const PR_PPC_DEXCR_CTRL_SET_ONEXEC: u32 = 8;
+pub const PR_PPC_DEXCR_CTRL_CLEAR_ONEXEC: u32 = 16;
+pub const PR_PPC_DEXCR_CTRL_MASK: u32 = 31;

--- a/src/mips/system.rs
+++ b/src/mips/system.rs
@@ -94,6 +94,7 @@ pub version: [crate::ctypes::c_char; 65usize],
 pub machine: [crate::ctypes::c_char; 65usize],
 pub domainname: [crate::ctypes::c_char; 65usize],
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;

--- a/src/mips/xdp.rs
+++ b/src/mips/xdp.rs
@@ -152,6 +152,7 @@ pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,
 pub tx_invalid_descs: __u64,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -169,6 +170,7 @@ pub const XDP_USE_NEED_WAKEUP: u32 = 8;
 pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
 pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
+pub const XDP_UMEM_TX_METADATA_LEN: u32 = 4;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;

--- a/src/mips32r6/btrfs.rs
+++ b/src/mips32r6/btrfs.rs
@@ -136,7 +136,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -154,7 +154,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -164,6 +165,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -179,6 +181,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -245,6 +259,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -855,10 +888,17 @@ pub physical: __le64,
 }
 #[repr(C, packed)]
 pub struct btrfs_stripe_extent {
-pub encoding: __u8,
-pub reserved: [__u8; 7usize],
+pub __bindgen_anon_1: btrfs_stripe_extent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct btrfs_stripe_extent__bindgen_ty_1 {
+pub __empty_strides: btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1,
 pub strides: __IncompleteArrayField<btrfs_raid_stride>,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct btrfs_extent_item {
@@ -1127,6 +1167,7 @@ pub encryption: __u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -1284,13 +1325,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1362,6 +1407,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1394,6 +1440,7 @@ pub const BTRFS_QGROUP_LIMIT_RSV_EXCL: u32 = 8;
 pub const BTRFS_QGROUP_LIMIT_RFER_CMPR: u32 = 16;
 pub const BTRFS_QGROUP_LIMIT_EXCL_CMPR: u32 = 32;
 pub const BTRFS_QGROUP_INHERIT_SET_LIMITS: u32 = 1;
+pub const BTRFS_QGROUP_INHERIT_FLAGS_SUPP: u32 = 1;
 pub const BTRFS_DEVICE_REMOVE_ARGS_MASK: u32 = 8;
 pub const BTRFS_SUBVOL_CREATE_ARGS_MASK: u32 = 6;
 pub const BTRFS_SUBVOL_DELETE_ARGS_MASK: u32 = 16;
@@ -1599,14 +1646,6 @@ pub const BTRFS_SYSTEM_CHUNK_ARRAY_SIZE: u32 = 2048;
 pub const BTRFS_NUM_BACKUP_ROOTS: u32 = 4;
 pub const BTRFS_FREE_SPACE_EXTENT: u32 = 1;
 pub const BTRFS_FREE_SPACE_BITMAP: u32 = 2;
-pub const BTRFS_STRIPE_RAID0: u32 = 1;
-pub const BTRFS_STRIPE_RAID1: u32 = 2;
-pub const BTRFS_STRIPE_DUP: u32 = 3;
-pub const BTRFS_STRIPE_RAID10: u32 = 4;
-pub const BTRFS_STRIPE_RAID5: u32 = 5;
-pub const BTRFS_STRIPE_RAID6: u32 = 6;
-pub const BTRFS_STRIPE_RAID1C3: u32 = 7;
-pub const BTRFS_STRIPE_RAID1C4: u32 = 8;
 pub const BTRFS_HEADER_FLAG_WRITTEN: u32 = 1;
 pub const BTRFS_HEADER_FLAG_RELOC: u32 = 2;
 pub const BTRFS_SUPER_FLAG_ERROR: u32 = 4;
@@ -1615,6 +1654,9 @@ pub const BTRFS_SUPER_FLAG_METADUMP: u64 = 8589934592;
 pub const BTRFS_SUPER_FLAG_METADUMP_V2: u64 = 17179869184;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID: u64 = 34359738368;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID_V2: u64 = 68719476736;
+pub const BTRFS_SUPER_FLAG_CHANGING_BG_TREE: u64 = 274877906944;
+pub const BTRFS_SUPER_FLAG_CHANGING_DATA_CSUM: u64 = 549755813888;
+pub const BTRFS_SUPER_FLAG_CHANGING_META_CSUM: u64 = 1099511627776;
 pub const BTRFS_EXTENT_FLAG_DATA: u32 = 1;
 pub const BTRFS_EXTENT_FLAG_TREE_BLOCK: u32 = 2;
 pub const BTRFS_BLOCK_FLAG_FULL_BACKREF: u32 = 256;
@@ -1670,6 +1712,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/mips32r6/general.rs
+++ b/src/mips32r6/general.rs
@@ -163,6 +163,14 @@ pub data: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct epoll_params {
+pub busy_poll_usecs: __u32,
+pub busy_poll_budget: __u16,
+pub prefer_busy_poll: __u8,
+pub __pad: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct fscrypt_policy_v1 {
 pub version: __u8,
 pub contents_encryption_mode: __u8,
@@ -245,7 +253,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -263,7 +271,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -273,6 +282,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -288,6 +298,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -357,6 +379,25 @@ pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct futex_waitv {
 pub val: __u64,
 pub uaddr: __u64,
@@ -412,6 +453,14 @@ pub struct rand_pool_info {
 pub entropy_count: crate::ctypes::c_int,
 pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vgetrandom_opaque_params {
+pub size_of_opaque_state: __u32,
+pub mmap_prot: __u32,
+pub mmap_flags: __u32,
+pub reserved: [__u32; 13usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -644,7 +693,12 @@ pub stx_dev_minor: __u32,
 pub stx_mnt_id: __u64,
 pub stx_dio_mem_align: __u32,
 pub stx_dio_offset_align: __u32,
-pub __spare3: [__u64; 12usize],
+pub stx_subvol: __u64,
+pub stx_atomic_write_unit_min: __u32,
+pub stx_atomic_write_unit_max: __u32,
+pub stx_atomic_write_segments_max: __u32,
+pub __spare1: [__u32; 1usize],
+pub __spare3: [__u64; 9usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -980,9 +1034,9 @@ pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 395264;
+pub const LINUX_VERSION_CODE: u32 = 396032;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 11;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_VECTOR_SIZE_ARCH: u32 = 1;
@@ -1010,8 +1064,11 @@ pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_RSEQ_FEATURE_SIZE: u32 = 27;
 pub const AT_RSEQ_ALIGN: u32 = 28;
+pub const AT_HWCAP3: u32 = 29;
+pub const AT_HWCAP4: u32 = 30;
 pub const AT_EXECFN: u32 = 31;
 pub const AT_MINSIGSTKSZ: u32 = 51;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
@@ -1156,9 +1213,10 @@ pub const RESOLVE_IN_ROOT: u32 = 16;
 pub const RESOLVE_CACHED: u32 = 32;
 pub const F_SETLEASE: u32 = 1024;
 pub const F_GETLEASE: u32 = 1025;
+pub const F_NOTIFY: u32 = 1026;
+pub const F_DUPFD_QUERY: u32 = 1027;
 pub const F_CANCELLK: u32 = 1029;
 pub const F_DUPFD_CLOEXEC: u32 = 1030;
-pub const F_NOTIFY: u32 = 1026;
 pub const F_SETPIPE_SZ: u32 = 1031;
 pub const F_GETPIPE_SZ: u32 = 1032;
 pub const F_ADD_SEALS: u32 = 1033;
@@ -1204,6 +1262,7 @@ pub const EPOLL_CLOEXEC: u32 = 524288;
 pub const EPOLL_CTL_ADD: u32 = 1;
 pub const EPOLL_CTL_DEL: u32 = 2;
 pub const EPOLL_CTL_MOD: u32 = 3;
+pub const EPOLL_IOC_TYPE: u32 = 138;
 pub const POSIX_FADV_NORMAL: u32 = 0;
 pub const POSIX_FADV_RANDOM: u32 = 1;
 pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
@@ -1365,13 +1424,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1443,6 +1506,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1571,6 +1635,7 @@ pub const EFIVARFS_MAGIC: u32 = 3730735588;
 pub const HOSTFS_SUPER_MAGIC: u32 = 12648430;
 pub const OVERLAYFS_SUPER_MAGIC: u32 = 2035054128;
 pub const FUSE_SUPER_MAGIC: u32 = 1702057286;
+pub const BCACHEFS_SUPER_MAGIC: u32 = 3393526350;
 pub const MINIX_SUPER_MAGIC: u32 = 4991;
 pub const MINIX_SUPER_MAGIC2: u32 = 5007;
 pub const MINIX2_SUPER_MAGIC: u32 = 9320;
@@ -1620,6 +1685,7 @@ pub const UDF_SUPER_MAGIC: u32 = 352400198;
 pub const DMA_BUF_MAGIC: u32 = 1145913666;
 pub const DEVMEM_MAGIC: u32 = 1162691661;
 pub const SECRETMEM_MAGIC: u32 = 1397048141;
+pub const PID_FS_MAGIC: u32 = 1346978886;
 pub const PROT_NONE: u32 = 0;
 pub const PROT_READ: u32 = 1;
 pub const PROT_WRITE: u32 = 2;
@@ -1703,6 +1769,7 @@ pub const OVERCOMMIT_NEVER: u32 = 2;
 pub const MAP_SHARED: u32 = 1;
 pub const MAP_PRIVATE: u32 = 2;
 pub const MAP_SHARED_VALIDATE: u32 = 3;
+pub const MAP_DROPPABLE: u32 = 8;
 pub const MAP_HUGE_SHIFT: u32 = 26;
 pub const MAP_HUGE_MASK: u32 = 63;
 pub const MAP_HUGE_16KB: u32 = 939524096;
@@ -2008,6 +2075,8 @@ pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
 pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
+pub const STATX_SUBVOL: u32 = 32768;
+pub const STATX_WRITE_ATOMIC: u32 = 65536;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2019,6 +2088,7 @@ pub const STATX_ATTR_AUTOMOUNT: u32 = 4096;
 pub const STATX_ATTR_MOUNT_ROOT: u32 = 8192;
 pub const STATX_ATTR_VERITY: u32 = 1048576;
 pub const STATX_ATTR_DAX: u32 = 2097152;
+pub const STATX_ATTR_WRITE_ATOMIC: u32 = 4194304;
 pub const EPERM: u32 = 1;
 pub const ENOENT: u32 = 2;
 pub const ESRCH: u32 = 3;
@@ -2781,6 +2851,7 @@ pub const __NR_listmount: u32 = 4458;
 pub const __NR_lsm_get_self_attr: u32 = 4459;
 pub const __NR_lsm_set_self_attr: u32 = 4460;
 pub const __NR_lsm_list_modules: u32 = 4461;
+pub const __NR_mseal: u32 = 4462;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
 pub const WSTOPPED: u32 = 2;
@@ -2969,6 +3040,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/mips32r6/if_arp.rs
+++ b/src/mips32r6/if_arp.rs
@@ -610,6 +610,7 @@ pub ar_hln: crate::ctypes::c_uchar,
 pub ar_pln: crate::ctypes::c_uchar,
 pub ar_op: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -1389,6 +1390,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
@@ -1422,6 +1425,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1523,6 +1527,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
@@ -2289,7 +2294,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2327,7 +2334,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2503,7 +2511,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/mips32r6/if_ether.rs
+++ b/src/mips32r6/if_ether.rs
@@ -55,6 +55,7 @@ pub h_dest: [crate::ctypes::c_uchar; 6usize],
 pub h_source: [crate::ctypes::c_uchar; 6usize],
 pub h_proto: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;

--- a/src/mips32r6/if_packet.rs
+++ b/src/mips32r6/if_packet.rs
@@ -203,6 +203,7 @@ pub id: __u16,
 pub max_num_members: __u32,
 }
 pub const __BIG_ENDIAN: u32 = 4321;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;

--- a/src/mips32r6/io_uring.rs
+++ b/src/mips32r6/io_uring.rs
@@ -138,7 +138,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -156,7 +156,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -166,6 +167,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -181,6 +183,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -247,6 +261,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -490,6 +523,14 @@ pub resv: [__u32; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_napi {
+pub busy_poll_to: __u32,
+pub prefer_busy_poll: __u8,
+pub pad: [__u8; 3usize],
+pub resv: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -555,6 +596,7 @@ pub const IOC_OUT: u32 = 1073741824;
 pub const IOC_INOUT: u32 = 3221225472;
 pub const IOCSIZE_MASK: u32 = 536805376;
 pub const IOCSIZE_SHIFT: u32 = 16;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -679,13 +721,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -757,6 +803,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -812,15 +859,20 @@ pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
 pub const IORING_SEND_ZC_REPORT_USAGE: u32 = 8;
+pub const IORING_RECVSEND_BUNDLE: u32 = 16;
 pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
+pub const IORING_ACCEPT_DONTWAIT: u32 = 2;
+pub const IORING_ACCEPT_POLL_FIRST: u32 = 4;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
 pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
+pub const IORING_NOP_INJECT_RESULT: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
 pub const IORING_CQE_F_NOTIF: u32 = 8;
+pub const IORING_CQE_BUFFER_SHIFT: u32 = 16;
 pub const IORING_OFF_SQ_RING: u32 = 0;
 pub const IORING_OFF_CQ_RING: u32 = 134217728;
 pub const IORING_OFF_SQES: u32 = 268435456;
@@ -850,60 +902,10 @@ pub const IORING_FEAT_RSRC_TAGS: u32 = 1024;
 pub const IORING_FEAT_CQE_SKIP: u32 = 2048;
 pub const IORING_FEAT_LINKED_FILE: u32 = 4096;
 pub const IORING_FEAT_REG_REG_RING: u32 = 8192;
+pub const IORING_FEAT_RECVSEND_BUNDLE: u32 = 16384;
 pub const IORING_RSRC_REGISTER_SPARSE: u32 = 1;
 pub const IORING_REGISTER_FILES_SKIP: i32 = -2;
 pub const IO_URING_OP_SUPPORTED: u32 = 1;
-pub const IOSQE_FIXED_FILE_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_FIXED_FILE_BIT;
-pub const IOSQE_IO_DRAIN_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_DRAIN_BIT;
-pub const IOSQE_IO_LINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_LINK_BIT;
-pub const IOSQE_IO_HARDLINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_HARDLINK_BIT;
-pub const IOSQE_ASYNC_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_ASYNC_BIT;
-pub const IOSQE_BUFFER_SELECT_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_BUFFER_SELECT_BIT;
-pub const IOSQE_CQE_SKIP_SUCCESS_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_CQE_SKIP_SUCCESS_BIT;
-pub const IORING_MSG_DATA: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_DATA;
-pub const IORING_MSG_SEND_FD: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_SEND_FD;
-pub const IORING_CQE_BUFFER_SHIFT: _bindgen_ty_3 = _bindgen_ty_3::IORING_CQE_BUFFER_SHIFT;
-pub const IORING_REGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS;
-pub const IORING_UNREGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_BUFFERS;
-pub const IORING_REGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES;
-pub const IORING_UNREGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_FILES;
-pub const IORING_REGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD;
-pub const IORING_UNREGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_EVENTFD;
-pub const IORING_REGISTER_FILES_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE;
-pub const IORING_REGISTER_EVENTFD_ASYNC: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD_ASYNC;
-pub const IORING_REGISTER_PROBE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PROBE;
-pub const IORING_REGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PERSONALITY;
-pub const IORING_UNREGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PERSONALITY;
-pub const IORING_REGISTER_RESTRICTIONS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RESTRICTIONS;
-pub const IORING_REGISTER_ENABLE_RINGS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_ENABLE_RINGS;
-pub const IORING_REGISTER_FILES2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES2;
-pub const IORING_REGISTER_FILES_UPDATE2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE2;
-pub const IORING_REGISTER_BUFFERS2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS2;
-pub const IORING_REGISTER_BUFFERS_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS_UPDATE;
-pub const IORING_REGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_AFF;
-pub const IORING_UNREGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_IOWQ_AFF;
-pub const IORING_REGISTER_IOWQ_MAX_WORKERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_MAX_WORKERS;
-pub const IORING_REGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RING_FDS;
-pub const IORING_UNREGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_RING_FDS;
-pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_RING;
-pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
-pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
-pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
-pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
-pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
-pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
-pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
-pub const IO_WQ_UNBOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_UNBOUND;
-pub const IOU_PBUF_RING_MMAP: _bindgen_ty_6 = _bindgen_ty_6::IOU_PBUF_RING_MMAP;
-pub const IORING_RESTRICTION_REGISTER_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_REGISTER_OP;
-pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_OP;
-pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
-pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
-pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
-pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
-pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
-pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
-pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -921,7 +923,18 @@ FSCONFIG_CMD_CREATE_EXCL = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_1 {
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum io_uring_sqe_flags_bit {
 IOSQE_FIXED_FILE_BIT = 0,
 IOSQE_IO_DRAIN_BIT = 1,
 IOSQE_IO_LINK_BIT = 2,
@@ -989,25 +1002,22 @@ IORING_OP_FUTEX_WAIT = 51,
 IORING_OP_FUTEX_WAKE = 52,
 IORING_OP_FUTEX_WAITV = 53,
 IORING_OP_FIXED_FD_INSTALL = 54,
-IORING_OP_LAST = 55,
+IORING_OP_FTRUNCATE = 55,
+IORING_OP_BIND = 56,
+IORING_OP_LISTEN = 57,
+IORING_OP_LAST = 58,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_2 {
+pub enum io_uring_msg_ring_flags {
 IORING_MSG_DATA = 0,
 IORING_MSG_SEND_FD = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_3 {
-IORING_CQE_BUFFER_SHIFT = 16,
-}
-#[repr(u32)]
-#[non_exhaustive]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_4 {
+pub enum io_uring_register_op {
 IORING_REGISTER_BUFFERS = 0,
 IORING_UNREGISTER_BUFFERS = 1,
 IORING_REGISTER_FILES = 2,
@@ -1035,26 +1045,28 @@ IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
 IORING_REGISTER_PBUF_STATUS = 26,
-IORING_REGISTER_LAST = 27,
+IORING_REGISTER_NAPI = 27,
+IORING_UNREGISTER_NAPI = 28,
+IORING_REGISTER_LAST = 29,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_5 {
+pub enum io_wq_type {
 IO_WQ_BOUND = 0,
 IO_WQ_UNBOUND = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_6 {
+pub enum io_uring_register_pbuf_ring_flags {
 IOU_PBUF_RING_MMAP = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_7 {
+pub enum io_uring_register_restriction_op {
 IORING_RESTRICTION_REGISTER_OP = 0,
 IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
@@ -1064,7 +1076,7 @@ IORING_RESTRICTION_LAST = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_8 {
+pub enum io_uring_socket_op {
 SOCKET_URING_OP_SIOCINQ = 0,
 SOCKET_URING_OP_SIOCOUTQ = 1,
 SOCKET_URING_OP_GETSOCKOPT = 2,
@@ -1123,6 +1135,7 @@ pub uring_cmd_flags: __u32,
 pub waitid_flags: __u32,
 pub futex_flags: __u32,
 pub install_fd_flags: __u32,
+pub nop_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]

--- a/src/mips32r6/loop_device.rs
+++ b/src/mips32r6/loop_device.rs
@@ -101,6 +101,7 @@ pub const _MIPS_ISA_MIPS64: u32 = 7;
 pub const _MIPS_SIM_ABI32: u32 = 1;
 pub const _MIPS_SIM_NABI32: u32 = 2;
 pub const _MIPS_SIM_ABI64: u32 = 3;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const LO_CRYPT_NONE: u32 = 0;
 pub const LO_CRYPT_XOR: u32 = 1;
 pub const LO_CRYPT_DES: u32 = 2;

--- a/src/mips32r6/mempolicy.rs
+++ b/src/mips32r6/mempolicy.rs
@@ -160,6 +160,7 @@ pub const MPOL_BIND: _bindgen_ty_1 = _bindgen_ty_1::MPOL_BIND;
 pub const MPOL_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_INTERLEAVE;
 pub const MPOL_LOCAL: _bindgen_ty_1 = _bindgen_ty_1::MPOL_LOCAL;
 pub const MPOL_PREFERRED_MANY: _bindgen_ty_1 = _bindgen_ty_1::MPOL_PREFERRED_MANY;
+pub const MPOL_WEIGHTED_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_WEIGHTED_INTERLEAVE;
 pub const MPOL_MAX: _bindgen_ty_1 = _bindgen_ty_1::MPOL_MAX;
 #[repr(u32)]
 #[non_exhaustive]
@@ -171,5 +172,6 @@ MPOL_BIND = 2,
 MPOL_INTERLEAVE = 3,
 MPOL_LOCAL = 4,
 MPOL_PREFERRED_MANY = 5,
-MPOL_MAX = 6,
+MPOL_WEIGHTED_INTERLEAVE = 6,
+MPOL_MAX = 7,
 }

--- a/src/mips32r6/net.rs
+++ b/src/mips32r6/net.rs
@@ -854,6 +854,7 @@ pub _address: u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -1290,6 +1291,7 @@ pub const TCP_AO_DEL_KEY: u32 = 39;
 pub const TCP_AO_INFO: u32 = 40;
 pub const TCP_AO_GET_KEYS: u32 = 41;
 pub const TCP_AO_REPAIR: u32 = 42;
+pub const TCP_IS_MPTCP: u32 = 43;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1576,6 +1578,7 @@ pub const IPPROTO_UDPLITE: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_UDPLITE;
 pub const IPPROTO_MPLS: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPLS;
 pub const IPPROTO_ETHERNET: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ETHERNET;
 pub const IPPROTO_RAW: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_RAW;
+pub const IPPROTO_SMC: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_SMC;
 pub const IPPROTO_MPTCP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPTCP;
 pub const IPPROTO_MAX: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MAX;
 pub const IPV4_DEVCONF_FORWARDING: _bindgen_ty_2 = _bindgen_ty_2::IPV4_DEVCONF_FORWARDING;
@@ -1764,6 +1767,7 @@ IPPROTO_UDPLITE = 136,
 IPPROTO_MPLS = 137,
 IPPROTO_ETHERNET = 143,
 IPPROTO_RAW = 255,
+IPPROTO_SMC = 256,
 IPPROTO_MPTCP = 262,
 IPPROTO_MAX = 263,
 }

--- a/src/mips32r6/netlink.rs
+++ b/src/mips32r6/netlink.rs
@@ -547,6 +547,7 @@ pub const SOCK_BUF_LOCK_MASK: u32 = 3;
 pub const SOCK_TXREHASH_DEFAULT: u32 = 255;
 pub const SOCK_TXREHASH_DISABLED: u32 = 0;
 pub const SOCK_TXREHASH_ENABLED: u32 = 1;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -1104,6 +1105,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
@@ -1137,6 +1140,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1238,6 +1242,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
@@ -2152,7 +2157,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2190,7 +2197,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2366,7 +2374,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/mips32r6/prctl.rs
+++ b/src/mips32r6/prctl.rs
@@ -66,6 +66,7 @@ pub auxv: *mut __u64,
 pub auxv_size: __u32,
 pub exe_fd: __u32,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -242,3 +243,20 @@ pub const PR_RISCV_V_VSTATE_CTRL_INHERIT: u32 = 16;
 pub const PR_RISCV_V_VSTATE_CTRL_CUR_MASK: u32 = 3;
 pub const PR_RISCV_V_VSTATE_CTRL_NEXT_MASK: u32 = 12;
 pub const PR_RISCV_V_VSTATE_CTRL_MASK: u32 = 31;
+pub const PR_RISCV_SET_ICACHE_FLUSH_CTX: u32 = 71;
+pub const PR_RISCV_CTX_SW_FENCEI_ON: u32 = 0;
+pub const PR_RISCV_CTX_SW_FENCEI_OFF: u32 = 1;
+pub const PR_RISCV_SCOPE_PER_PROCESS: u32 = 0;
+pub const PR_RISCV_SCOPE_PER_THREAD: u32 = 1;
+pub const PR_PPC_GET_DEXCR: u32 = 72;
+pub const PR_PPC_SET_DEXCR: u32 = 73;
+pub const PR_PPC_DEXCR_SBHE: u32 = 0;
+pub const PR_PPC_DEXCR_IBRTPD: u32 = 1;
+pub const PR_PPC_DEXCR_SRAPD: u32 = 2;
+pub const PR_PPC_DEXCR_NPHIE: u32 = 3;
+pub const PR_PPC_DEXCR_CTRL_EDITABLE: u32 = 1;
+pub const PR_PPC_DEXCR_CTRL_SET: u32 = 2;
+pub const PR_PPC_DEXCR_CTRL_CLEAR: u32 = 4;
+pub const PR_PPC_DEXCR_CTRL_SET_ONEXEC: u32 = 8;
+pub const PR_PPC_DEXCR_CTRL_CLEAR_ONEXEC: u32 = 16;
+pub const PR_PPC_DEXCR_CTRL_MASK: u32 = 31;

--- a/src/mips32r6/system.rs
+++ b/src/mips32r6/system.rs
@@ -94,6 +94,7 @@ pub version: [crate::ctypes::c_char; 65usize],
 pub machine: [crate::ctypes::c_char; 65usize],
 pub domainname: [crate::ctypes::c_char; 65usize],
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;

--- a/src/mips32r6/xdp.rs
+++ b/src/mips32r6/xdp.rs
@@ -152,6 +152,7 @@ pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,
 pub tx_invalid_descs: __u64,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -169,6 +170,7 @@ pub const XDP_USE_NEED_WAKEUP: u32 = 8;
 pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
 pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
+pub const XDP_UMEM_TX_METADATA_LEN: u32 = 4;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;

--- a/src/mips64/btrfs.rs
+++ b/src/mips64/btrfs.rs
@@ -138,7 +138,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -156,7 +156,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -166,6 +167,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -181,6 +183,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -247,6 +261,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -857,10 +890,17 @@ pub physical: __le64,
 }
 #[repr(C, packed)]
 pub struct btrfs_stripe_extent {
-pub encoding: __u8,
-pub reserved: [__u8; 7usize],
+pub __bindgen_anon_1: btrfs_stripe_extent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct btrfs_stripe_extent__bindgen_ty_1 {
+pub __empty_strides: btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1,
 pub strides: __IncompleteArrayField<btrfs_raid_stride>,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct btrfs_extent_item {
@@ -1129,6 +1169,7 @@ pub encryption: __u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -1286,13 +1327,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1364,6 +1409,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1396,6 +1442,7 @@ pub const BTRFS_QGROUP_LIMIT_RSV_EXCL: u32 = 8;
 pub const BTRFS_QGROUP_LIMIT_RFER_CMPR: u32 = 16;
 pub const BTRFS_QGROUP_LIMIT_EXCL_CMPR: u32 = 32;
 pub const BTRFS_QGROUP_INHERIT_SET_LIMITS: u32 = 1;
+pub const BTRFS_QGROUP_INHERIT_FLAGS_SUPP: u32 = 1;
 pub const BTRFS_DEVICE_REMOVE_ARGS_MASK: u32 = 8;
 pub const BTRFS_SUBVOL_CREATE_ARGS_MASK: u32 = 6;
 pub const BTRFS_SUBVOL_DELETE_ARGS_MASK: u32 = 16;
@@ -1601,14 +1648,6 @@ pub const BTRFS_SYSTEM_CHUNK_ARRAY_SIZE: u32 = 2048;
 pub const BTRFS_NUM_BACKUP_ROOTS: u32 = 4;
 pub const BTRFS_FREE_SPACE_EXTENT: u32 = 1;
 pub const BTRFS_FREE_SPACE_BITMAP: u32 = 2;
-pub const BTRFS_STRIPE_RAID0: u32 = 1;
-pub const BTRFS_STRIPE_RAID1: u32 = 2;
-pub const BTRFS_STRIPE_DUP: u32 = 3;
-pub const BTRFS_STRIPE_RAID10: u32 = 4;
-pub const BTRFS_STRIPE_RAID5: u32 = 5;
-pub const BTRFS_STRIPE_RAID6: u32 = 6;
-pub const BTRFS_STRIPE_RAID1C3: u32 = 7;
-pub const BTRFS_STRIPE_RAID1C4: u32 = 8;
 pub const BTRFS_HEADER_FLAG_WRITTEN: u32 = 1;
 pub const BTRFS_HEADER_FLAG_RELOC: u32 = 2;
 pub const BTRFS_SUPER_FLAG_ERROR: u32 = 4;
@@ -1617,6 +1656,9 @@ pub const BTRFS_SUPER_FLAG_METADUMP: u64 = 8589934592;
 pub const BTRFS_SUPER_FLAG_METADUMP_V2: u64 = 17179869184;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID: u64 = 34359738368;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID_V2: u64 = 68719476736;
+pub const BTRFS_SUPER_FLAG_CHANGING_BG_TREE: u64 = 274877906944;
+pub const BTRFS_SUPER_FLAG_CHANGING_DATA_CSUM: u64 = 549755813888;
+pub const BTRFS_SUPER_FLAG_CHANGING_META_CSUM: u64 = 1099511627776;
 pub const BTRFS_EXTENT_FLAG_DATA: u32 = 1;
 pub const BTRFS_EXTENT_FLAG_TREE_BLOCK: u32 = 2;
 pub const BTRFS_BLOCK_FLAG_FULL_BACKREF: u32 = 256;
@@ -1672,6 +1714,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/mips64/general.rs
+++ b/src/mips64/general.rs
@@ -163,6 +163,14 @@ pub data: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct epoll_params {
+pub busy_poll_usecs: __u32,
+pub busy_poll_budget: __u16,
+pub prefer_busy_poll: __u8,
+pub __pad: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct fscrypt_policy_v1 {
 pub version: __u8,
 pub contents_encryption_mode: __u8,
@@ -245,7 +253,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -263,7 +271,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -273,6 +282,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -288,6 +298,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -357,6 +379,25 @@ pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct futex_waitv {
 pub val: __u64,
 pub uaddr: __u64,
@@ -412,6 +453,14 @@ pub struct rand_pool_info {
 pub entropy_count: crate::ctypes::c_int,
 pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vgetrandom_opaque_params {
+pub size_of_opaque_state: __u32,
+pub mmap_prot: __u32,
+pub mmap_flags: __u32,
+pub reserved: [__u32; 13usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -644,7 +693,12 @@ pub stx_dev_minor: __u32,
 pub stx_mnt_id: __u64,
 pub stx_dio_mem_align: __u32,
 pub stx_dio_offset_align: __u32,
-pub __spare3: [__u64; 12usize],
+pub stx_subvol: __u64,
+pub stx_atomic_write_unit_min: __u32,
+pub stx_atomic_write_unit_max: __u32,
+pub stx_atomic_write_segments_max: __u32,
+pub __spare1: [__u32; 1usize],
+pub __spare3: [__u64; 9usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -972,9 +1026,9 @@ pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 395264;
+pub const LINUX_VERSION_CODE: u32 = 396032;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 11;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_VECTOR_SIZE_ARCH: u32 = 1;
@@ -1002,8 +1056,11 @@ pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_RSEQ_FEATURE_SIZE: u32 = 27;
 pub const AT_RSEQ_ALIGN: u32 = 28;
+pub const AT_HWCAP3: u32 = 29;
+pub const AT_HWCAP4: u32 = 30;
 pub const AT_EXECFN: u32 = 31;
 pub const AT_MINSIGSTKSZ: u32 = 51;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
@@ -1145,9 +1202,10 @@ pub const RESOLVE_IN_ROOT: u32 = 16;
 pub const RESOLVE_CACHED: u32 = 32;
 pub const F_SETLEASE: u32 = 1024;
 pub const F_GETLEASE: u32 = 1025;
+pub const F_NOTIFY: u32 = 1026;
+pub const F_DUPFD_QUERY: u32 = 1027;
 pub const F_CANCELLK: u32 = 1029;
 pub const F_DUPFD_CLOEXEC: u32 = 1030;
-pub const F_NOTIFY: u32 = 1026;
 pub const F_SETPIPE_SZ: u32 = 1031;
 pub const F_GETPIPE_SZ: u32 = 1032;
 pub const F_ADD_SEALS: u32 = 1033;
@@ -1193,6 +1251,7 @@ pub const EPOLL_CLOEXEC: u32 = 524288;
 pub const EPOLL_CTL_ADD: u32 = 1;
 pub const EPOLL_CTL_DEL: u32 = 2;
 pub const EPOLL_CTL_MOD: u32 = 3;
+pub const EPOLL_IOC_TYPE: u32 = 138;
 pub const POSIX_FADV_NORMAL: u32 = 0;
 pub const POSIX_FADV_RANDOM: u32 = 1;
 pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
@@ -1354,13 +1413,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1432,6 +1495,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1560,6 +1624,7 @@ pub const EFIVARFS_MAGIC: u32 = 3730735588;
 pub const HOSTFS_SUPER_MAGIC: u32 = 12648430;
 pub const OVERLAYFS_SUPER_MAGIC: u32 = 2035054128;
 pub const FUSE_SUPER_MAGIC: u32 = 1702057286;
+pub const BCACHEFS_SUPER_MAGIC: u32 = 3393526350;
 pub const MINIX_SUPER_MAGIC: u32 = 4991;
 pub const MINIX_SUPER_MAGIC2: u32 = 5007;
 pub const MINIX2_SUPER_MAGIC: u32 = 9320;
@@ -1609,6 +1674,7 @@ pub const UDF_SUPER_MAGIC: u32 = 352400198;
 pub const DMA_BUF_MAGIC: u32 = 1145913666;
 pub const DEVMEM_MAGIC: u32 = 1162691661;
 pub const SECRETMEM_MAGIC: u32 = 1397048141;
+pub const PID_FS_MAGIC: u32 = 1346978886;
 pub const PROT_NONE: u32 = 0;
 pub const PROT_READ: u32 = 1;
 pub const PROT_WRITE: u32 = 2;
@@ -1692,6 +1758,7 @@ pub const OVERCOMMIT_NEVER: u32 = 2;
 pub const MAP_SHARED: u32 = 1;
 pub const MAP_PRIVATE: u32 = 2;
 pub const MAP_SHARED_VALIDATE: u32 = 3;
+pub const MAP_DROPPABLE: u32 = 8;
 pub const MAP_HUGE_SHIFT: u32 = 26;
 pub const MAP_HUGE_MASK: u32 = 63;
 pub const MAP_HUGE_16KB: u32 = 939524096;
@@ -1997,6 +2064,8 @@ pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
 pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
+pub const STATX_SUBVOL: u32 = 32768;
+pub const STATX_WRITE_ATOMIC: u32 = 65536;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2008,6 +2077,7 @@ pub const STATX_ATTR_AUTOMOUNT: u32 = 4096;
 pub const STATX_ATTR_MOUNT_ROOT: u32 = 8192;
 pub const STATX_ATTR_VERITY: u32 = 1048576;
 pub const STATX_ATTR_DAX: u32 = 2097152;
+pub const STATX_ATTR_WRITE_ATOMIC: u32 = 4194304;
 pub const EPERM: u32 = 1;
 pub const ENOENT: u32 = 2;
 pub const ESRCH: u32 = 3;
@@ -2700,6 +2770,7 @@ pub const __NR_listmount: u32 = 5458;
 pub const __NR_lsm_get_self_attr: u32 = 5459;
 pub const __NR_lsm_set_self_attr: u32 = 5460;
 pub const __NR_lsm_list_modules: u32 = 5461;
+pub const __NR_mseal: u32 = 5462;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
 pub const WSTOPPED: u32 = 2;
@@ -2888,6 +2959,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/mips64/if_arp.rs
+++ b/src/mips64/if_arp.rs
@@ -612,6 +612,7 @@ pub ar_hln: crate::ctypes::c_uchar,
 pub ar_pln: crate::ctypes::c_uchar,
 pub ar_op: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -1391,6 +1392,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
@@ -1424,6 +1427,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1525,6 +1529,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
@@ -2291,7 +2296,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2329,7 +2336,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2505,7 +2513,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/mips64/if_ether.rs
+++ b/src/mips64/if_ether.rs
@@ -57,6 +57,7 @@ pub h_dest: [crate::ctypes::c_uchar; 6usize],
 pub h_source: [crate::ctypes::c_uchar; 6usize],
 pub h_proto: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;

--- a/src/mips64/if_packet.rs
+++ b/src/mips64/if_packet.rs
@@ -205,6 +205,7 @@ pub id: __u16,
 pub max_num_members: __u32,
 }
 pub const __BIG_ENDIAN: u32 = 4321;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;

--- a/src/mips64/io_uring.rs
+++ b/src/mips64/io_uring.rs
@@ -140,7 +140,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -158,7 +158,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -168,6 +169,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -183,6 +185,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -249,6 +263,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -492,6 +525,14 @@ pub resv: [__u32; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_napi {
+pub busy_poll_to: __u32,
+pub prefer_busy_poll: __u8,
+pub pad: [__u8; 3usize],
+pub resv: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -557,6 +598,7 @@ pub const IOC_OUT: u32 = 1073741824;
 pub const IOC_INOUT: u32 = 3221225472;
 pub const IOCSIZE_MASK: u32 = 536805376;
 pub const IOCSIZE_SHIFT: u32 = 16;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -681,13 +723,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -759,6 +805,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -814,15 +861,20 @@ pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
 pub const IORING_SEND_ZC_REPORT_USAGE: u32 = 8;
+pub const IORING_RECVSEND_BUNDLE: u32 = 16;
 pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
+pub const IORING_ACCEPT_DONTWAIT: u32 = 2;
+pub const IORING_ACCEPT_POLL_FIRST: u32 = 4;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
 pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
+pub const IORING_NOP_INJECT_RESULT: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
 pub const IORING_CQE_F_NOTIF: u32 = 8;
+pub const IORING_CQE_BUFFER_SHIFT: u32 = 16;
 pub const IORING_OFF_SQ_RING: u32 = 0;
 pub const IORING_OFF_CQ_RING: u32 = 134217728;
 pub const IORING_OFF_SQES: u32 = 268435456;
@@ -852,60 +904,10 @@ pub const IORING_FEAT_RSRC_TAGS: u32 = 1024;
 pub const IORING_FEAT_CQE_SKIP: u32 = 2048;
 pub const IORING_FEAT_LINKED_FILE: u32 = 4096;
 pub const IORING_FEAT_REG_REG_RING: u32 = 8192;
+pub const IORING_FEAT_RECVSEND_BUNDLE: u32 = 16384;
 pub const IORING_RSRC_REGISTER_SPARSE: u32 = 1;
 pub const IORING_REGISTER_FILES_SKIP: i32 = -2;
 pub const IO_URING_OP_SUPPORTED: u32 = 1;
-pub const IOSQE_FIXED_FILE_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_FIXED_FILE_BIT;
-pub const IOSQE_IO_DRAIN_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_DRAIN_BIT;
-pub const IOSQE_IO_LINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_LINK_BIT;
-pub const IOSQE_IO_HARDLINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_HARDLINK_BIT;
-pub const IOSQE_ASYNC_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_ASYNC_BIT;
-pub const IOSQE_BUFFER_SELECT_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_BUFFER_SELECT_BIT;
-pub const IOSQE_CQE_SKIP_SUCCESS_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_CQE_SKIP_SUCCESS_BIT;
-pub const IORING_MSG_DATA: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_DATA;
-pub const IORING_MSG_SEND_FD: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_SEND_FD;
-pub const IORING_CQE_BUFFER_SHIFT: _bindgen_ty_3 = _bindgen_ty_3::IORING_CQE_BUFFER_SHIFT;
-pub const IORING_REGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS;
-pub const IORING_UNREGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_BUFFERS;
-pub const IORING_REGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES;
-pub const IORING_UNREGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_FILES;
-pub const IORING_REGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD;
-pub const IORING_UNREGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_EVENTFD;
-pub const IORING_REGISTER_FILES_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE;
-pub const IORING_REGISTER_EVENTFD_ASYNC: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD_ASYNC;
-pub const IORING_REGISTER_PROBE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PROBE;
-pub const IORING_REGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PERSONALITY;
-pub const IORING_UNREGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PERSONALITY;
-pub const IORING_REGISTER_RESTRICTIONS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RESTRICTIONS;
-pub const IORING_REGISTER_ENABLE_RINGS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_ENABLE_RINGS;
-pub const IORING_REGISTER_FILES2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES2;
-pub const IORING_REGISTER_FILES_UPDATE2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE2;
-pub const IORING_REGISTER_BUFFERS2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS2;
-pub const IORING_REGISTER_BUFFERS_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS_UPDATE;
-pub const IORING_REGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_AFF;
-pub const IORING_UNREGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_IOWQ_AFF;
-pub const IORING_REGISTER_IOWQ_MAX_WORKERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_MAX_WORKERS;
-pub const IORING_REGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RING_FDS;
-pub const IORING_UNREGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_RING_FDS;
-pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_RING;
-pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
-pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
-pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
-pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
-pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
-pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
-pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
-pub const IO_WQ_UNBOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_UNBOUND;
-pub const IOU_PBUF_RING_MMAP: _bindgen_ty_6 = _bindgen_ty_6::IOU_PBUF_RING_MMAP;
-pub const IORING_RESTRICTION_REGISTER_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_REGISTER_OP;
-pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_OP;
-pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
-pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
-pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
-pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
-pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
-pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
-pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -923,7 +925,18 @@ FSCONFIG_CMD_CREATE_EXCL = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_1 {
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum io_uring_sqe_flags_bit {
 IOSQE_FIXED_FILE_BIT = 0,
 IOSQE_IO_DRAIN_BIT = 1,
 IOSQE_IO_LINK_BIT = 2,
@@ -991,25 +1004,22 @@ IORING_OP_FUTEX_WAIT = 51,
 IORING_OP_FUTEX_WAKE = 52,
 IORING_OP_FUTEX_WAITV = 53,
 IORING_OP_FIXED_FD_INSTALL = 54,
-IORING_OP_LAST = 55,
+IORING_OP_FTRUNCATE = 55,
+IORING_OP_BIND = 56,
+IORING_OP_LISTEN = 57,
+IORING_OP_LAST = 58,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_2 {
+pub enum io_uring_msg_ring_flags {
 IORING_MSG_DATA = 0,
 IORING_MSG_SEND_FD = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_3 {
-IORING_CQE_BUFFER_SHIFT = 16,
-}
-#[repr(u32)]
-#[non_exhaustive]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_4 {
+pub enum io_uring_register_op {
 IORING_REGISTER_BUFFERS = 0,
 IORING_UNREGISTER_BUFFERS = 1,
 IORING_REGISTER_FILES = 2,
@@ -1037,26 +1047,28 @@ IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
 IORING_REGISTER_PBUF_STATUS = 26,
-IORING_REGISTER_LAST = 27,
+IORING_REGISTER_NAPI = 27,
+IORING_UNREGISTER_NAPI = 28,
+IORING_REGISTER_LAST = 29,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_5 {
+pub enum io_wq_type {
 IO_WQ_BOUND = 0,
 IO_WQ_UNBOUND = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_6 {
+pub enum io_uring_register_pbuf_ring_flags {
 IOU_PBUF_RING_MMAP = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_7 {
+pub enum io_uring_register_restriction_op {
 IORING_RESTRICTION_REGISTER_OP = 0,
 IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
@@ -1066,7 +1078,7 @@ IORING_RESTRICTION_LAST = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_8 {
+pub enum io_uring_socket_op {
 SOCKET_URING_OP_SIOCINQ = 0,
 SOCKET_URING_OP_SIOCOUTQ = 1,
 SOCKET_URING_OP_GETSOCKOPT = 2,
@@ -1125,6 +1137,7 @@ pub uring_cmd_flags: __u32,
 pub waitid_flags: __u32,
 pub futex_flags: __u32,
 pub install_fd_flags: __u32,
+pub nop_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]

--- a/src/mips64/loop_device.rs
+++ b/src/mips64/loop_device.rs
@@ -103,6 +103,7 @@ pub const _MIPS_ISA_MIPS64: u32 = 7;
 pub const _MIPS_SIM_ABI32: u32 = 1;
 pub const _MIPS_SIM_NABI32: u32 = 2;
 pub const _MIPS_SIM_ABI64: u32 = 3;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const LO_CRYPT_NONE: u32 = 0;
 pub const LO_CRYPT_XOR: u32 = 1;
 pub const LO_CRYPT_DES: u32 = 2;

--- a/src/mips64/mempolicy.rs
+++ b/src/mips64/mempolicy.rs
@@ -160,6 +160,7 @@ pub const MPOL_BIND: _bindgen_ty_1 = _bindgen_ty_1::MPOL_BIND;
 pub const MPOL_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_INTERLEAVE;
 pub const MPOL_LOCAL: _bindgen_ty_1 = _bindgen_ty_1::MPOL_LOCAL;
 pub const MPOL_PREFERRED_MANY: _bindgen_ty_1 = _bindgen_ty_1::MPOL_PREFERRED_MANY;
+pub const MPOL_WEIGHTED_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_WEIGHTED_INTERLEAVE;
 pub const MPOL_MAX: _bindgen_ty_1 = _bindgen_ty_1::MPOL_MAX;
 #[repr(u32)]
 #[non_exhaustive]
@@ -171,5 +172,6 @@ MPOL_BIND = 2,
 MPOL_INTERLEAVE = 3,
 MPOL_LOCAL = 4,
 MPOL_PREFERRED_MANY = 5,
-MPOL_MAX = 6,
+MPOL_WEIGHTED_INTERLEAVE = 6,
+MPOL_MAX = 7,
 }

--- a/src/mips64/net.rs
+++ b/src/mips64/net.rs
@@ -854,6 +854,7 @@ pub _address: u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -1298,6 +1299,7 @@ pub const TCP_AO_DEL_KEY: u32 = 39;
 pub const TCP_AO_INFO: u32 = 40;
 pub const TCP_AO_GET_KEYS: u32 = 41;
 pub const TCP_AO_REPAIR: u32 = 42;
+pub const TCP_IS_MPTCP: u32 = 43;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1584,6 +1586,7 @@ pub const IPPROTO_UDPLITE: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_UDPLITE;
 pub const IPPROTO_MPLS: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPLS;
 pub const IPPROTO_ETHERNET: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ETHERNET;
 pub const IPPROTO_RAW: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_RAW;
+pub const IPPROTO_SMC: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_SMC;
 pub const IPPROTO_MPTCP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPTCP;
 pub const IPPROTO_MAX: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MAX;
 pub const IPV4_DEVCONF_FORWARDING: _bindgen_ty_2 = _bindgen_ty_2::IPV4_DEVCONF_FORWARDING;
@@ -1772,6 +1775,7 @@ IPPROTO_UDPLITE = 136,
 IPPROTO_MPLS = 137,
 IPPROTO_ETHERNET = 143,
 IPPROTO_RAW = 255,
+IPPROTO_SMC = 256,
 IPPROTO_MPTCP = 262,
 IPPROTO_MAX = 263,
 }

--- a/src/mips64/netlink.rs
+++ b/src/mips64/netlink.rs
@@ -549,6 +549,7 @@ pub const SOCK_BUF_LOCK_MASK: u32 = 3;
 pub const SOCK_TXREHASH_DEFAULT: u32 = 255;
 pub const SOCK_TXREHASH_DISABLED: u32 = 0;
 pub const SOCK_TXREHASH_ENABLED: u32 = 1;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -1106,6 +1107,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
@@ -1139,6 +1142,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1240,6 +1244,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
@@ -2154,7 +2159,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2192,7 +2199,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2368,7 +2376,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/mips64/prctl.rs
+++ b/src/mips64/prctl.rs
@@ -68,6 +68,7 @@ pub auxv: *mut __u64,
 pub auxv_size: __u32,
 pub exe_fd: __u32,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -244,3 +245,20 @@ pub const PR_RISCV_V_VSTATE_CTRL_INHERIT: u32 = 16;
 pub const PR_RISCV_V_VSTATE_CTRL_CUR_MASK: u32 = 3;
 pub const PR_RISCV_V_VSTATE_CTRL_NEXT_MASK: u32 = 12;
 pub const PR_RISCV_V_VSTATE_CTRL_MASK: u32 = 31;
+pub const PR_RISCV_SET_ICACHE_FLUSH_CTX: u32 = 71;
+pub const PR_RISCV_CTX_SW_FENCEI_ON: u32 = 0;
+pub const PR_RISCV_CTX_SW_FENCEI_OFF: u32 = 1;
+pub const PR_RISCV_SCOPE_PER_PROCESS: u32 = 0;
+pub const PR_RISCV_SCOPE_PER_THREAD: u32 = 1;
+pub const PR_PPC_GET_DEXCR: u32 = 72;
+pub const PR_PPC_SET_DEXCR: u32 = 73;
+pub const PR_PPC_DEXCR_SBHE: u32 = 0;
+pub const PR_PPC_DEXCR_IBRTPD: u32 = 1;
+pub const PR_PPC_DEXCR_SRAPD: u32 = 2;
+pub const PR_PPC_DEXCR_NPHIE: u32 = 3;
+pub const PR_PPC_DEXCR_CTRL_EDITABLE: u32 = 1;
+pub const PR_PPC_DEXCR_CTRL_SET: u32 = 2;
+pub const PR_PPC_DEXCR_CTRL_CLEAR: u32 = 4;
+pub const PR_PPC_DEXCR_CTRL_SET_ONEXEC: u32 = 8;
+pub const PR_PPC_DEXCR_CTRL_CLEAR_ONEXEC: u32 = 16;
+pub const PR_PPC_DEXCR_CTRL_MASK: u32 = 31;

--- a/src/mips64/system.rs
+++ b/src/mips64/system.rs
@@ -99,6 +99,7 @@ pub version: [crate::ctypes::c_char; 65usize],
 pub machine: [crate::ctypes::c_char; 65usize],
 pub domainname: [crate::ctypes::c_char; 65usize],
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;

--- a/src/mips64/xdp.rs
+++ b/src/mips64/xdp.rs
@@ -154,6 +154,7 @@ pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,
 pub tx_invalid_descs: __u64,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -171,6 +172,7 @@ pub const XDP_USE_NEED_WAKEUP: u32 = 8;
 pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
 pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
+pub const XDP_UMEM_TX_METADATA_LEN: u32 = 4;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;

--- a/src/mips64r6/btrfs.rs
+++ b/src/mips64r6/btrfs.rs
@@ -138,7 +138,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -156,7 +156,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -166,6 +167,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -181,6 +183,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -247,6 +261,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -857,10 +890,17 @@ pub physical: __le64,
 }
 #[repr(C, packed)]
 pub struct btrfs_stripe_extent {
-pub encoding: __u8,
-pub reserved: [__u8; 7usize],
+pub __bindgen_anon_1: btrfs_stripe_extent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct btrfs_stripe_extent__bindgen_ty_1 {
+pub __empty_strides: btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1,
 pub strides: __IncompleteArrayField<btrfs_raid_stride>,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct btrfs_extent_item {
@@ -1129,6 +1169,7 @@ pub encryption: __u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -1286,13 +1327,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1364,6 +1409,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1396,6 +1442,7 @@ pub const BTRFS_QGROUP_LIMIT_RSV_EXCL: u32 = 8;
 pub const BTRFS_QGROUP_LIMIT_RFER_CMPR: u32 = 16;
 pub const BTRFS_QGROUP_LIMIT_EXCL_CMPR: u32 = 32;
 pub const BTRFS_QGROUP_INHERIT_SET_LIMITS: u32 = 1;
+pub const BTRFS_QGROUP_INHERIT_FLAGS_SUPP: u32 = 1;
 pub const BTRFS_DEVICE_REMOVE_ARGS_MASK: u32 = 8;
 pub const BTRFS_SUBVOL_CREATE_ARGS_MASK: u32 = 6;
 pub const BTRFS_SUBVOL_DELETE_ARGS_MASK: u32 = 16;
@@ -1601,14 +1648,6 @@ pub const BTRFS_SYSTEM_CHUNK_ARRAY_SIZE: u32 = 2048;
 pub const BTRFS_NUM_BACKUP_ROOTS: u32 = 4;
 pub const BTRFS_FREE_SPACE_EXTENT: u32 = 1;
 pub const BTRFS_FREE_SPACE_BITMAP: u32 = 2;
-pub const BTRFS_STRIPE_RAID0: u32 = 1;
-pub const BTRFS_STRIPE_RAID1: u32 = 2;
-pub const BTRFS_STRIPE_DUP: u32 = 3;
-pub const BTRFS_STRIPE_RAID10: u32 = 4;
-pub const BTRFS_STRIPE_RAID5: u32 = 5;
-pub const BTRFS_STRIPE_RAID6: u32 = 6;
-pub const BTRFS_STRIPE_RAID1C3: u32 = 7;
-pub const BTRFS_STRIPE_RAID1C4: u32 = 8;
 pub const BTRFS_HEADER_FLAG_WRITTEN: u32 = 1;
 pub const BTRFS_HEADER_FLAG_RELOC: u32 = 2;
 pub const BTRFS_SUPER_FLAG_ERROR: u32 = 4;
@@ -1617,6 +1656,9 @@ pub const BTRFS_SUPER_FLAG_METADUMP: u64 = 8589934592;
 pub const BTRFS_SUPER_FLAG_METADUMP_V2: u64 = 17179869184;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID: u64 = 34359738368;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID_V2: u64 = 68719476736;
+pub const BTRFS_SUPER_FLAG_CHANGING_BG_TREE: u64 = 274877906944;
+pub const BTRFS_SUPER_FLAG_CHANGING_DATA_CSUM: u64 = 549755813888;
+pub const BTRFS_SUPER_FLAG_CHANGING_META_CSUM: u64 = 1099511627776;
 pub const BTRFS_EXTENT_FLAG_DATA: u32 = 1;
 pub const BTRFS_EXTENT_FLAG_TREE_BLOCK: u32 = 2;
 pub const BTRFS_BLOCK_FLAG_FULL_BACKREF: u32 = 256;
@@ -1672,6 +1714,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/mips64r6/general.rs
+++ b/src/mips64r6/general.rs
@@ -163,6 +163,14 @@ pub data: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct epoll_params {
+pub busy_poll_usecs: __u32,
+pub busy_poll_budget: __u16,
+pub prefer_busy_poll: __u8,
+pub __pad: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct fscrypt_policy_v1 {
 pub version: __u8,
 pub contents_encryption_mode: __u8,
@@ -245,7 +253,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -263,7 +271,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -273,6 +282,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -288,6 +298,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -357,6 +379,25 @@ pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct futex_waitv {
 pub val: __u64,
 pub uaddr: __u64,
@@ -412,6 +453,14 @@ pub struct rand_pool_info {
 pub entropy_count: crate::ctypes::c_int,
 pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vgetrandom_opaque_params {
+pub size_of_opaque_state: __u32,
+pub mmap_prot: __u32,
+pub mmap_flags: __u32,
+pub reserved: [__u32; 13usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -644,7 +693,12 @@ pub stx_dev_minor: __u32,
 pub stx_mnt_id: __u64,
 pub stx_dio_mem_align: __u32,
 pub stx_dio_offset_align: __u32,
-pub __spare3: [__u64; 12usize],
+pub stx_subvol: __u64,
+pub stx_atomic_write_unit_min: __u32,
+pub stx_atomic_write_unit_max: __u32,
+pub stx_atomic_write_segments_max: __u32,
+pub __spare1: [__u32; 1usize],
+pub __spare3: [__u64; 9usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -972,9 +1026,9 @@ pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 395264;
+pub const LINUX_VERSION_CODE: u32 = 396032;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 11;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_VECTOR_SIZE_ARCH: u32 = 1;
@@ -1002,8 +1056,11 @@ pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_RSEQ_FEATURE_SIZE: u32 = 27;
 pub const AT_RSEQ_ALIGN: u32 = 28;
+pub const AT_HWCAP3: u32 = 29;
+pub const AT_HWCAP4: u32 = 30;
 pub const AT_EXECFN: u32 = 31;
 pub const AT_MINSIGSTKSZ: u32 = 51;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
@@ -1145,9 +1202,10 @@ pub const RESOLVE_IN_ROOT: u32 = 16;
 pub const RESOLVE_CACHED: u32 = 32;
 pub const F_SETLEASE: u32 = 1024;
 pub const F_GETLEASE: u32 = 1025;
+pub const F_NOTIFY: u32 = 1026;
+pub const F_DUPFD_QUERY: u32 = 1027;
 pub const F_CANCELLK: u32 = 1029;
 pub const F_DUPFD_CLOEXEC: u32 = 1030;
-pub const F_NOTIFY: u32 = 1026;
 pub const F_SETPIPE_SZ: u32 = 1031;
 pub const F_GETPIPE_SZ: u32 = 1032;
 pub const F_ADD_SEALS: u32 = 1033;
@@ -1193,6 +1251,7 @@ pub const EPOLL_CLOEXEC: u32 = 524288;
 pub const EPOLL_CTL_ADD: u32 = 1;
 pub const EPOLL_CTL_DEL: u32 = 2;
 pub const EPOLL_CTL_MOD: u32 = 3;
+pub const EPOLL_IOC_TYPE: u32 = 138;
 pub const POSIX_FADV_NORMAL: u32 = 0;
 pub const POSIX_FADV_RANDOM: u32 = 1;
 pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
@@ -1354,13 +1413,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1432,6 +1495,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1560,6 +1624,7 @@ pub const EFIVARFS_MAGIC: u32 = 3730735588;
 pub const HOSTFS_SUPER_MAGIC: u32 = 12648430;
 pub const OVERLAYFS_SUPER_MAGIC: u32 = 2035054128;
 pub const FUSE_SUPER_MAGIC: u32 = 1702057286;
+pub const BCACHEFS_SUPER_MAGIC: u32 = 3393526350;
 pub const MINIX_SUPER_MAGIC: u32 = 4991;
 pub const MINIX_SUPER_MAGIC2: u32 = 5007;
 pub const MINIX2_SUPER_MAGIC: u32 = 9320;
@@ -1609,6 +1674,7 @@ pub const UDF_SUPER_MAGIC: u32 = 352400198;
 pub const DMA_BUF_MAGIC: u32 = 1145913666;
 pub const DEVMEM_MAGIC: u32 = 1162691661;
 pub const SECRETMEM_MAGIC: u32 = 1397048141;
+pub const PID_FS_MAGIC: u32 = 1346978886;
 pub const PROT_NONE: u32 = 0;
 pub const PROT_READ: u32 = 1;
 pub const PROT_WRITE: u32 = 2;
@@ -1692,6 +1758,7 @@ pub const OVERCOMMIT_NEVER: u32 = 2;
 pub const MAP_SHARED: u32 = 1;
 pub const MAP_PRIVATE: u32 = 2;
 pub const MAP_SHARED_VALIDATE: u32 = 3;
+pub const MAP_DROPPABLE: u32 = 8;
 pub const MAP_HUGE_SHIFT: u32 = 26;
 pub const MAP_HUGE_MASK: u32 = 63;
 pub const MAP_HUGE_16KB: u32 = 939524096;
@@ -1997,6 +2064,8 @@ pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
 pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
+pub const STATX_SUBVOL: u32 = 32768;
+pub const STATX_WRITE_ATOMIC: u32 = 65536;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2008,6 +2077,7 @@ pub const STATX_ATTR_AUTOMOUNT: u32 = 4096;
 pub const STATX_ATTR_MOUNT_ROOT: u32 = 8192;
 pub const STATX_ATTR_VERITY: u32 = 1048576;
 pub const STATX_ATTR_DAX: u32 = 2097152;
+pub const STATX_ATTR_WRITE_ATOMIC: u32 = 4194304;
 pub const EPERM: u32 = 1;
 pub const ENOENT: u32 = 2;
 pub const ESRCH: u32 = 3;
@@ -2700,6 +2770,7 @@ pub const __NR_listmount: u32 = 5458;
 pub const __NR_lsm_get_self_attr: u32 = 5459;
 pub const __NR_lsm_set_self_attr: u32 = 5460;
 pub const __NR_lsm_list_modules: u32 = 5461;
+pub const __NR_mseal: u32 = 5462;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
 pub const WSTOPPED: u32 = 2;
@@ -2888,6 +2959,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/mips64r6/if_arp.rs
+++ b/src/mips64r6/if_arp.rs
@@ -612,6 +612,7 @@ pub ar_hln: crate::ctypes::c_uchar,
 pub ar_pln: crate::ctypes::c_uchar,
 pub ar_op: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -1391,6 +1392,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
@@ -1424,6 +1427,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1525,6 +1529,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
@@ -2291,7 +2296,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2329,7 +2336,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2505,7 +2513,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/mips64r6/if_ether.rs
+++ b/src/mips64r6/if_ether.rs
@@ -57,6 +57,7 @@ pub h_dest: [crate::ctypes::c_uchar; 6usize],
 pub h_source: [crate::ctypes::c_uchar; 6usize],
 pub h_proto: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;

--- a/src/mips64r6/if_packet.rs
+++ b/src/mips64r6/if_packet.rs
@@ -205,6 +205,7 @@ pub id: __u16,
 pub max_num_members: __u32,
 }
 pub const __BIG_ENDIAN: u32 = 4321;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;

--- a/src/mips64r6/io_uring.rs
+++ b/src/mips64r6/io_uring.rs
@@ -140,7 +140,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -158,7 +158,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -168,6 +169,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -183,6 +185,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -249,6 +263,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -492,6 +525,14 @@ pub resv: [__u32; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_napi {
+pub busy_poll_to: __u32,
+pub prefer_busy_poll: __u8,
+pub pad: [__u8; 3usize],
+pub resv: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -557,6 +598,7 @@ pub const IOC_OUT: u32 = 1073741824;
 pub const IOC_INOUT: u32 = 3221225472;
 pub const IOCSIZE_MASK: u32 = 536805376;
 pub const IOCSIZE_SHIFT: u32 = 16;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -681,13 +723,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -759,6 +805,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -814,15 +861,20 @@ pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
 pub const IORING_SEND_ZC_REPORT_USAGE: u32 = 8;
+pub const IORING_RECVSEND_BUNDLE: u32 = 16;
 pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
+pub const IORING_ACCEPT_DONTWAIT: u32 = 2;
+pub const IORING_ACCEPT_POLL_FIRST: u32 = 4;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
 pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
+pub const IORING_NOP_INJECT_RESULT: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
 pub const IORING_CQE_F_NOTIF: u32 = 8;
+pub const IORING_CQE_BUFFER_SHIFT: u32 = 16;
 pub const IORING_OFF_SQ_RING: u32 = 0;
 pub const IORING_OFF_CQ_RING: u32 = 134217728;
 pub const IORING_OFF_SQES: u32 = 268435456;
@@ -852,60 +904,10 @@ pub const IORING_FEAT_RSRC_TAGS: u32 = 1024;
 pub const IORING_FEAT_CQE_SKIP: u32 = 2048;
 pub const IORING_FEAT_LINKED_FILE: u32 = 4096;
 pub const IORING_FEAT_REG_REG_RING: u32 = 8192;
+pub const IORING_FEAT_RECVSEND_BUNDLE: u32 = 16384;
 pub const IORING_RSRC_REGISTER_SPARSE: u32 = 1;
 pub const IORING_REGISTER_FILES_SKIP: i32 = -2;
 pub const IO_URING_OP_SUPPORTED: u32 = 1;
-pub const IOSQE_FIXED_FILE_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_FIXED_FILE_BIT;
-pub const IOSQE_IO_DRAIN_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_DRAIN_BIT;
-pub const IOSQE_IO_LINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_LINK_BIT;
-pub const IOSQE_IO_HARDLINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_HARDLINK_BIT;
-pub const IOSQE_ASYNC_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_ASYNC_BIT;
-pub const IOSQE_BUFFER_SELECT_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_BUFFER_SELECT_BIT;
-pub const IOSQE_CQE_SKIP_SUCCESS_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_CQE_SKIP_SUCCESS_BIT;
-pub const IORING_MSG_DATA: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_DATA;
-pub const IORING_MSG_SEND_FD: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_SEND_FD;
-pub const IORING_CQE_BUFFER_SHIFT: _bindgen_ty_3 = _bindgen_ty_3::IORING_CQE_BUFFER_SHIFT;
-pub const IORING_REGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS;
-pub const IORING_UNREGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_BUFFERS;
-pub const IORING_REGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES;
-pub const IORING_UNREGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_FILES;
-pub const IORING_REGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD;
-pub const IORING_UNREGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_EVENTFD;
-pub const IORING_REGISTER_FILES_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE;
-pub const IORING_REGISTER_EVENTFD_ASYNC: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD_ASYNC;
-pub const IORING_REGISTER_PROBE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PROBE;
-pub const IORING_REGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PERSONALITY;
-pub const IORING_UNREGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PERSONALITY;
-pub const IORING_REGISTER_RESTRICTIONS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RESTRICTIONS;
-pub const IORING_REGISTER_ENABLE_RINGS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_ENABLE_RINGS;
-pub const IORING_REGISTER_FILES2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES2;
-pub const IORING_REGISTER_FILES_UPDATE2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE2;
-pub const IORING_REGISTER_BUFFERS2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS2;
-pub const IORING_REGISTER_BUFFERS_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS_UPDATE;
-pub const IORING_REGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_AFF;
-pub const IORING_UNREGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_IOWQ_AFF;
-pub const IORING_REGISTER_IOWQ_MAX_WORKERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_MAX_WORKERS;
-pub const IORING_REGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RING_FDS;
-pub const IORING_UNREGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_RING_FDS;
-pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_RING;
-pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
-pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
-pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
-pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
-pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
-pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
-pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
-pub const IO_WQ_UNBOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_UNBOUND;
-pub const IOU_PBUF_RING_MMAP: _bindgen_ty_6 = _bindgen_ty_6::IOU_PBUF_RING_MMAP;
-pub const IORING_RESTRICTION_REGISTER_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_REGISTER_OP;
-pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_OP;
-pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
-pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
-pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
-pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
-pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
-pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
-pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -923,7 +925,18 @@ FSCONFIG_CMD_CREATE_EXCL = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_1 {
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum io_uring_sqe_flags_bit {
 IOSQE_FIXED_FILE_BIT = 0,
 IOSQE_IO_DRAIN_BIT = 1,
 IOSQE_IO_LINK_BIT = 2,
@@ -991,25 +1004,22 @@ IORING_OP_FUTEX_WAIT = 51,
 IORING_OP_FUTEX_WAKE = 52,
 IORING_OP_FUTEX_WAITV = 53,
 IORING_OP_FIXED_FD_INSTALL = 54,
-IORING_OP_LAST = 55,
+IORING_OP_FTRUNCATE = 55,
+IORING_OP_BIND = 56,
+IORING_OP_LISTEN = 57,
+IORING_OP_LAST = 58,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_2 {
+pub enum io_uring_msg_ring_flags {
 IORING_MSG_DATA = 0,
 IORING_MSG_SEND_FD = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_3 {
-IORING_CQE_BUFFER_SHIFT = 16,
-}
-#[repr(u32)]
-#[non_exhaustive]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_4 {
+pub enum io_uring_register_op {
 IORING_REGISTER_BUFFERS = 0,
 IORING_UNREGISTER_BUFFERS = 1,
 IORING_REGISTER_FILES = 2,
@@ -1037,26 +1047,28 @@ IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
 IORING_REGISTER_PBUF_STATUS = 26,
-IORING_REGISTER_LAST = 27,
+IORING_REGISTER_NAPI = 27,
+IORING_UNREGISTER_NAPI = 28,
+IORING_REGISTER_LAST = 29,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_5 {
+pub enum io_wq_type {
 IO_WQ_BOUND = 0,
 IO_WQ_UNBOUND = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_6 {
+pub enum io_uring_register_pbuf_ring_flags {
 IOU_PBUF_RING_MMAP = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_7 {
+pub enum io_uring_register_restriction_op {
 IORING_RESTRICTION_REGISTER_OP = 0,
 IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
@@ -1066,7 +1078,7 @@ IORING_RESTRICTION_LAST = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_8 {
+pub enum io_uring_socket_op {
 SOCKET_URING_OP_SIOCINQ = 0,
 SOCKET_URING_OP_SIOCOUTQ = 1,
 SOCKET_URING_OP_GETSOCKOPT = 2,
@@ -1125,6 +1137,7 @@ pub uring_cmd_flags: __u32,
 pub waitid_flags: __u32,
 pub futex_flags: __u32,
 pub install_fd_flags: __u32,
+pub nop_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]

--- a/src/mips64r6/loop_device.rs
+++ b/src/mips64r6/loop_device.rs
@@ -103,6 +103,7 @@ pub const _MIPS_ISA_MIPS64: u32 = 7;
 pub const _MIPS_SIM_ABI32: u32 = 1;
 pub const _MIPS_SIM_NABI32: u32 = 2;
 pub const _MIPS_SIM_ABI64: u32 = 3;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const LO_CRYPT_NONE: u32 = 0;
 pub const LO_CRYPT_XOR: u32 = 1;
 pub const LO_CRYPT_DES: u32 = 2;

--- a/src/mips64r6/mempolicy.rs
+++ b/src/mips64r6/mempolicy.rs
@@ -160,6 +160,7 @@ pub const MPOL_BIND: _bindgen_ty_1 = _bindgen_ty_1::MPOL_BIND;
 pub const MPOL_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_INTERLEAVE;
 pub const MPOL_LOCAL: _bindgen_ty_1 = _bindgen_ty_1::MPOL_LOCAL;
 pub const MPOL_PREFERRED_MANY: _bindgen_ty_1 = _bindgen_ty_1::MPOL_PREFERRED_MANY;
+pub const MPOL_WEIGHTED_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_WEIGHTED_INTERLEAVE;
 pub const MPOL_MAX: _bindgen_ty_1 = _bindgen_ty_1::MPOL_MAX;
 #[repr(u32)]
 #[non_exhaustive]
@@ -171,5 +172,6 @@ MPOL_BIND = 2,
 MPOL_INTERLEAVE = 3,
 MPOL_LOCAL = 4,
 MPOL_PREFERRED_MANY = 5,
-MPOL_MAX = 6,
+MPOL_WEIGHTED_INTERLEAVE = 6,
+MPOL_MAX = 7,
 }

--- a/src/mips64r6/net.rs
+++ b/src/mips64r6/net.rs
@@ -854,6 +854,7 @@ pub _address: u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -1298,6 +1299,7 @@ pub const TCP_AO_DEL_KEY: u32 = 39;
 pub const TCP_AO_INFO: u32 = 40;
 pub const TCP_AO_GET_KEYS: u32 = 41;
 pub const TCP_AO_REPAIR: u32 = 42;
+pub const TCP_IS_MPTCP: u32 = 43;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1584,6 +1586,7 @@ pub const IPPROTO_UDPLITE: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_UDPLITE;
 pub const IPPROTO_MPLS: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPLS;
 pub const IPPROTO_ETHERNET: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ETHERNET;
 pub const IPPROTO_RAW: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_RAW;
+pub const IPPROTO_SMC: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_SMC;
 pub const IPPROTO_MPTCP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPTCP;
 pub const IPPROTO_MAX: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MAX;
 pub const IPV4_DEVCONF_FORWARDING: _bindgen_ty_2 = _bindgen_ty_2::IPV4_DEVCONF_FORWARDING;
@@ -1772,6 +1775,7 @@ IPPROTO_UDPLITE = 136,
 IPPROTO_MPLS = 137,
 IPPROTO_ETHERNET = 143,
 IPPROTO_RAW = 255,
+IPPROTO_SMC = 256,
 IPPROTO_MPTCP = 262,
 IPPROTO_MAX = 263,
 }

--- a/src/mips64r6/netlink.rs
+++ b/src/mips64r6/netlink.rs
@@ -549,6 +549,7 @@ pub const SOCK_BUF_LOCK_MASK: u32 = 3;
 pub const SOCK_TXREHASH_DEFAULT: u32 = 255;
 pub const SOCK_TXREHASH_DISABLED: u32 = 0;
 pub const SOCK_TXREHASH_ENABLED: u32 = 1;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -1106,6 +1107,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
@@ -1139,6 +1142,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1240,6 +1244,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
@@ -2154,7 +2159,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2192,7 +2199,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2368,7 +2376,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/mips64r6/prctl.rs
+++ b/src/mips64r6/prctl.rs
@@ -68,6 +68,7 @@ pub auxv: *mut __u64,
 pub auxv_size: __u32,
 pub exe_fd: __u32,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -244,3 +245,20 @@ pub const PR_RISCV_V_VSTATE_CTRL_INHERIT: u32 = 16;
 pub const PR_RISCV_V_VSTATE_CTRL_CUR_MASK: u32 = 3;
 pub const PR_RISCV_V_VSTATE_CTRL_NEXT_MASK: u32 = 12;
 pub const PR_RISCV_V_VSTATE_CTRL_MASK: u32 = 31;
+pub const PR_RISCV_SET_ICACHE_FLUSH_CTX: u32 = 71;
+pub const PR_RISCV_CTX_SW_FENCEI_ON: u32 = 0;
+pub const PR_RISCV_CTX_SW_FENCEI_OFF: u32 = 1;
+pub const PR_RISCV_SCOPE_PER_PROCESS: u32 = 0;
+pub const PR_RISCV_SCOPE_PER_THREAD: u32 = 1;
+pub const PR_PPC_GET_DEXCR: u32 = 72;
+pub const PR_PPC_SET_DEXCR: u32 = 73;
+pub const PR_PPC_DEXCR_SBHE: u32 = 0;
+pub const PR_PPC_DEXCR_IBRTPD: u32 = 1;
+pub const PR_PPC_DEXCR_SRAPD: u32 = 2;
+pub const PR_PPC_DEXCR_NPHIE: u32 = 3;
+pub const PR_PPC_DEXCR_CTRL_EDITABLE: u32 = 1;
+pub const PR_PPC_DEXCR_CTRL_SET: u32 = 2;
+pub const PR_PPC_DEXCR_CTRL_CLEAR: u32 = 4;
+pub const PR_PPC_DEXCR_CTRL_SET_ONEXEC: u32 = 8;
+pub const PR_PPC_DEXCR_CTRL_CLEAR_ONEXEC: u32 = 16;
+pub const PR_PPC_DEXCR_CTRL_MASK: u32 = 31;

--- a/src/mips64r6/system.rs
+++ b/src/mips64r6/system.rs
@@ -99,6 +99,7 @@ pub version: [crate::ctypes::c_char; 65usize],
 pub machine: [crate::ctypes::c_char; 65usize],
 pub domainname: [crate::ctypes::c_char; 65usize],
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;

--- a/src/mips64r6/xdp.rs
+++ b/src/mips64r6/xdp.rs
@@ -154,6 +154,7 @@ pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,
 pub tx_invalid_descs: __u64,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _MIPS_ISA_MIPS1: u32 = 1;
 pub const _MIPS_ISA_MIPS2: u32 = 2;
 pub const _MIPS_ISA_MIPS3: u32 = 3;
@@ -171,6 +172,7 @@ pub const XDP_USE_NEED_WAKEUP: u32 = 8;
 pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
 pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
+pub const XDP_UMEM_TX_METADATA_LEN: u32 = 4;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;

--- a/src/powerpc/btrfs.rs
+++ b/src/powerpc/btrfs.rs
@@ -142,7 +142,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -160,7 +160,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -170,6 +171,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -185,6 +187,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -251,6 +265,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -861,10 +894,17 @@ pub physical: __le64,
 }
 #[repr(C, packed)]
 pub struct btrfs_stripe_extent {
-pub encoding: __u8,
-pub reserved: [__u8; 7usize],
+pub __bindgen_anon_1: btrfs_stripe_extent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct btrfs_stripe_extent__bindgen_ty_1 {
+pub __empty_strides: btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1,
 pub strides: __IncompleteArrayField<btrfs_raid_stride>,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct btrfs_extent_item {
@@ -1133,6 +1173,7 @@ pub encryption: __u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _IOC_SIZEBITS: u32 = 13;
 pub const _IOC_DIRBITS: u32 = 3;
 pub const _IOC_NONE: u32 = 1;
@@ -1280,13 +1321,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1358,6 +1403,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1390,6 +1436,7 @@ pub const BTRFS_QGROUP_LIMIT_RSV_EXCL: u32 = 8;
 pub const BTRFS_QGROUP_LIMIT_RFER_CMPR: u32 = 16;
 pub const BTRFS_QGROUP_LIMIT_EXCL_CMPR: u32 = 32;
 pub const BTRFS_QGROUP_INHERIT_SET_LIMITS: u32 = 1;
+pub const BTRFS_QGROUP_INHERIT_FLAGS_SUPP: u32 = 1;
 pub const BTRFS_DEVICE_REMOVE_ARGS_MASK: u32 = 8;
 pub const BTRFS_SUBVOL_CREATE_ARGS_MASK: u32 = 6;
 pub const BTRFS_SUBVOL_DELETE_ARGS_MASK: u32 = 16;
@@ -1595,14 +1642,6 @@ pub const BTRFS_SYSTEM_CHUNK_ARRAY_SIZE: u32 = 2048;
 pub const BTRFS_NUM_BACKUP_ROOTS: u32 = 4;
 pub const BTRFS_FREE_SPACE_EXTENT: u32 = 1;
 pub const BTRFS_FREE_SPACE_BITMAP: u32 = 2;
-pub const BTRFS_STRIPE_RAID0: u32 = 1;
-pub const BTRFS_STRIPE_RAID1: u32 = 2;
-pub const BTRFS_STRIPE_DUP: u32 = 3;
-pub const BTRFS_STRIPE_RAID10: u32 = 4;
-pub const BTRFS_STRIPE_RAID5: u32 = 5;
-pub const BTRFS_STRIPE_RAID6: u32 = 6;
-pub const BTRFS_STRIPE_RAID1C3: u32 = 7;
-pub const BTRFS_STRIPE_RAID1C4: u32 = 8;
 pub const BTRFS_HEADER_FLAG_WRITTEN: u32 = 1;
 pub const BTRFS_HEADER_FLAG_RELOC: u32 = 2;
 pub const BTRFS_SUPER_FLAG_ERROR: u32 = 4;
@@ -1611,6 +1650,9 @@ pub const BTRFS_SUPER_FLAG_METADUMP: u64 = 8589934592;
 pub const BTRFS_SUPER_FLAG_METADUMP_V2: u64 = 17179869184;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID: u64 = 34359738368;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID_V2: u64 = 68719476736;
+pub const BTRFS_SUPER_FLAG_CHANGING_BG_TREE: u64 = 274877906944;
+pub const BTRFS_SUPER_FLAG_CHANGING_DATA_CSUM: u64 = 549755813888;
+pub const BTRFS_SUPER_FLAG_CHANGING_META_CSUM: u64 = 1099511627776;
 pub const BTRFS_EXTENT_FLAG_DATA: u32 = 1;
 pub const BTRFS_EXTENT_FLAG_TREE_BLOCK: u32 = 2;
 pub const BTRFS_BLOCK_FLAG_FULL_BACKREF: u32 = 256;
@@ -1666,6 +1708,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/powerpc/general.rs
+++ b/src/powerpc/general.rs
@@ -167,6 +167,14 @@ pub data: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct epoll_params {
+pub busy_poll_usecs: __u32,
+pub busy_poll_budget: __u16,
+pub prefer_busy_poll: __u8,
+pub __pad: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct fscrypt_policy_v1 {
 pub version: __u8,
 pub contents_encryption_mode: __u8,
@@ -249,7 +257,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -267,7 +275,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -277,6 +286,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -292,6 +302,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -361,6 +383,25 @@ pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct futex_waitv {
 pub val: __u64,
 pub uaddr: __u64,
@@ -416,6 +457,14 @@ pub struct rand_pool_info {
 pub entropy_count: crate::ctypes::c_int,
 pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vgetrandom_opaque_params {
+pub size_of_opaque_state: __u32,
+pub mmap_prot: __u32,
+pub mmap_flags: __u32,
+pub reserved: [__u32; 13usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -663,7 +712,12 @@ pub stx_dev_minor: __u32,
 pub stx_mnt_id: __u64,
 pub stx_dio_mem_align: __u32,
 pub stx_dio_offset_align: __u32,
-pub __spare3: [__u64; 12usize],
+pub stx_subvol: __u64,
+pub stx_atomic_write_unit_min: __u32,
+pub stx_atomic_write_unit_max: __u32,
+pub stx_atomic_write_segments_max: __u32,
+pub __spare1: [__u32; 1usize],
+pub __spare3: [__u64; 9usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1018,9 +1072,9 @@ pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 395264;
+pub const LINUX_VERSION_CODE: u32 = 396032;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 11;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_DCACHEBSIZE: u32 = 19;
 pub const AT_ICACHEBSIZE: u32 = 20;
@@ -1061,7 +1115,10 @@ pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_RSEQ_FEATURE_SIZE: u32 = 27;
 pub const AT_RSEQ_ALIGN: u32 = 28;
+pub const AT_HWCAP3: u32 = 29;
+pub const AT_HWCAP4: u32 = 30;
 pub const AT_EXECFN: u32 = 31;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
 pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
@@ -1196,9 +1253,10 @@ pub const RESOLVE_IN_ROOT: u32 = 16;
 pub const RESOLVE_CACHED: u32 = 32;
 pub const F_SETLEASE: u32 = 1024;
 pub const F_GETLEASE: u32 = 1025;
+pub const F_NOTIFY: u32 = 1026;
+pub const F_DUPFD_QUERY: u32 = 1027;
 pub const F_CANCELLK: u32 = 1029;
 pub const F_DUPFD_CLOEXEC: u32 = 1030;
-pub const F_NOTIFY: u32 = 1026;
 pub const F_SETPIPE_SZ: u32 = 1031;
 pub const F_GETPIPE_SZ: u32 = 1032;
 pub const F_ADD_SEALS: u32 = 1033;
@@ -1244,6 +1302,7 @@ pub const EPOLL_CLOEXEC: u32 = 524288;
 pub const EPOLL_CTL_ADD: u32 = 1;
 pub const EPOLL_CTL_DEL: u32 = 2;
 pub const EPOLL_CTL_MOD: u32 = 3;
+pub const EPOLL_IOC_TYPE: u32 = 138;
 pub const POSIX_FADV_NORMAL: u32 = 0;
 pub const POSIX_FADV_RANDOM: u32 = 1;
 pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
@@ -1405,13 +1464,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1483,6 +1546,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1611,6 +1675,7 @@ pub const EFIVARFS_MAGIC: u32 = 3730735588;
 pub const HOSTFS_SUPER_MAGIC: u32 = 12648430;
 pub const OVERLAYFS_SUPER_MAGIC: u32 = 2035054128;
 pub const FUSE_SUPER_MAGIC: u32 = 1702057286;
+pub const BCACHEFS_SUPER_MAGIC: u32 = 3393526350;
 pub const MINIX_SUPER_MAGIC: u32 = 4991;
 pub const MINIX_SUPER_MAGIC2: u32 = 5007;
 pub const MINIX2_SUPER_MAGIC: u32 = 9320;
@@ -1660,6 +1725,7 @@ pub const UDF_SUPER_MAGIC: u32 = 352400198;
 pub const DMA_BUF_MAGIC: u32 = 1145913666;
 pub const DEVMEM_MAGIC: u32 = 1162691661;
 pub const SECRETMEM_MAGIC: u32 = 1397048141;
+pub const PID_FS_MAGIC: u32 = 1346978886;
 pub const PROT_READ: u32 = 1;
 pub const PROT_WRITE: u32 = 2;
 pub const PROT_EXEC: u32 = 4;
@@ -1745,6 +1811,7 @@ pub const OVERCOMMIT_NEVER: u32 = 2;
 pub const MAP_SHARED: u32 = 1;
 pub const MAP_PRIVATE: u32 = 2;
 pub const MAP_SHARED_VALIDATE: u32 = 3;
+pub const MAP_DROPPABLE: u32 = 8;
 pub const MAP_HUGE_SHIFT: u32 = 26;
 pub const MAP_HUGE_MASK: u32 = 63;
 pub const MAP_HUGE_16KB: u32 = 939524096;
@@ -2056,6 +2123,8 @@ pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
 pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
+pub const STATX_SUBVOL: u32 = 32768;
+pub const STATX_WRITE_ATOMIC: u32 = 65536;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2067,6 +2136,7 @@ pub const STATX_ATTR_AUTOMOUNT: u32 = 4096;
 pub const STATX_ATTR_MOUNT_ROOT: u32 = 8192;
 pub const STATX_ATTR_VERITY: u32 = 1048576;
 pub const STATX_ATTR_DAX: u32 = 2097152;
+pub const STATX_ATTR_WRITE_ATOMIC: u32 = 4194304;
 pub const TIOCM_LE: u32 = 1;
 pub const TIOCM_DTR: u32 = 2;
 pub const TIOCM_RTS: u32 = 4;
@@ -2708,6 +2778,7 @@ pub const __NR_listmount: u32 = 458;
 pub const __NR_lsm_get_self_attr: u32 = 459;
 pub const __NR_lsm_set_self_attr: u32 = 460;
 pub const __NR_lsm_list_modules: u32 = 461;
+pub const __NR_mseal: u32 = 462;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
 pub const WSTOPPED: u32 = 2;
@@ -2892,6 +2963,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/powerpc/if_arp.rs
+++ b/src/powerpc/if_arp.rs
@@ -616,6 +616,7 @@ pub ar_hln: crate::ctypes::c_uchar,
 pub ar_pln: crate::ctypes::c_uchar,
 pub ar_op: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1385,6 +1386,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
@@ -1418,6 +1421,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1519,6 +1523,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
@@ -2285,7 +2290,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2323,7 +2330,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2499,7 +2507,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/powerpc/if_ether.rs
+++ b/src/powerpc/if_ether.rs
@@ -61,6 +61,7 @@ pub h_dest: [crate::ctypes::c_uchar; 6usize],
 pub h_source: [crate::ctypes::c_uchar; 6usize],
 pub h_proto: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const ETH_ALEN: u32 = 6;
 pub const ETH_TLEN: u32 = 2;
 pub const ETH_HLEN: u32 = 14;

--- a/src/powerpc/if_packet.rs
+++ b/src/powerpc/if_packet.rs
@@ -209,6 +209,7 @@ pub id: __u16,
 pub max_num_members: __u32,
 }
 pub const __BIG_ENDIAN: u32 = 4321;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PACKET_HOST: u32 = 0;
 pub const PACKET_BROADCAST: u32 = 1;
 pub const PACKET_MULTICAST: u32 = 2;

--- a/src/powerpc/io_uring.rs
+++ b/src/powerpc/io_uring.rs
@@ -144,7 +144,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -162,7 +162,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -172,6 +173,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -187,6 +189,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -253,6 +267,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -496,6 +529,14 @@ pub resv: [__u32; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_napi {
+pub busy_poll_to: __u32,
+pub prefer_busy_poll: __u8,
+pub pad: [__u8; 3usize],
+pub resv: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -561,6 +602,7 @@ pub const IOC_OUT: u32 = 1073741824;
 pub const IOC_INOUT: u32 = 3221225472;
 pub const IOCSIZE_MASK: u32 = 536805376;
 pub const IOCSIZE_SHIFT: u32 = 16;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const FSCRYPT_POLICY_FLAGS_PAD_4: u32 = 0;
 pub const FSCRYPT_POLICY_FLAGS_PAD_8: u32 = 1;
 pub const FSCRYPT_POLICY_FLAGS_PAD_16: u32 = 2;
@@ -675,13 +717,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -753,6 +799,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -808,15 +855,20 @@ pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
 pub const IORING_SEND_ZC_REPORT_USAGE: u32 = 8;
+pub const IORING_RECVSEND_BUNDLE: u32 = 16;
 pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
+pub const IORING_ACCEPT_DONTWAIT: u32 = 2;
+pub const IORING_ACCEPT_POLL_FIRST: u32 = 4;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
 pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
+pub const IORING_NOP_INJECT_RESULT: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
 pub const IORING_CQE_F_NOTIF: u32 = 8;
+pub const IORING_CQE_BUFFER_SHIFT: u32 = 16;
 pub const IORING_OFF_SQ_RING: u32 = 0;
 pub const IORING_OFF_CQ_RING: u32 = 134217728;
 pub const IORING_OFF_SQES: u32 = 268435456;
@@ -846,60 +898,10 @@ pub const IORING_FEAT_RSRC_TAGS: u32 = 1024;
 pub const IORING_FEAT_CQE_SKIP: u32 = 2048;
 pub const IORING_FEAT_LINKED_FILE: u32 = 4096;
 pub const IORING_FEAT_REG_REG_RING: u32 = 8192;
+pub const IORING_FEAT_RECVSEND_BUNDLE: u32 = 16384;
 pub const IORING_RSRC_REGISTER_SPARSE: u32 = 1;
 pub const IORING_REGISTER_FILES_SKIP: i32 = -2;
 pub const IO_URING_OP_SUPPORTED: u32 = 1;
-pub const IOSQE_FIXED_FILE_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_FIXED_FILE_BIT;
-pub const IOSQE_IO_DRAIN_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_DRAIN_BIT;
-pub const IOSQE_IO_LINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_LINK_BIT;
-pub const IOSQE_IO_HARDLINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_HARDLINK_BIT;
-pub const IOSQE_ASYNC_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_ASYNC_BIT;
-pub const IOSQE_BUFFER_SELECT_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_BUFFER_SELECT_BIT;
-pub const IOSQE_CQE_SKIP_SUCCESS_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_CQE_SKIP_SUCCESS_BIT;
-pub const IORING_MSG_DATA: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_DATA;
-pub const IORING_MSG_SEND_FD: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_SEND_FD;
-pub const IORING_CQE_BUFFER_SHIFT: _bindgen_ty_3 = _bindgen_ty_3::IORING_CQE_BUFFER_SHIFT;
-pub const IORING_REGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS;
-pub const IORING_UNREGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_BUFFERS;
-pub const IORING_REGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES;
-pub const IORING_UNREGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_FILES;
-pub const IORING_REGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD;
-pub const IORING_UNREGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_EVENTFD;
-pub const IORING_REGISTER_FILES_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE;
-pub const IORING_REGISTER_EVENTFD_ASYNC: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD_ASYNC;
-pub const IORING_REGISTER_PROBE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PROBE;
-pub const IORING_REGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PERSONALITY;
-pub const IORING_UNREGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PERSONALITY;
-pub const IORING_REGISTER_RESTRICTIONS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RESTRICTIONS;
-pub const IORING_REGISTER_ENABLE_RINGS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_ENABLE_RINGS;
-pub const IORING_REGISTER_FILES2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES2;
-pub const IORING_REGISTER_FILES_UPDATE2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE2;
-pub const IORING_REGISTER_BUFFERS2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS2;
-pub const IORING_REGISTER_BUFFERS_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS_UPDATE;
-pub const IORING_REGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_AFF;
-pub const IORING_UNREGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_IOWQ_AFF;
-pub const IORING_REGISTER_IOWQ_MAX_WORKERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_MAX_WORKERS;
-pub const IORING_REGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RING_FDS;
-pub const IORING_UNREGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_RING_FDS;
-pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_RING;
-pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
-pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
-pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
-pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
-pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
-pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
-pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
-pub const IO_WQ_UNBOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_UNBOUND;
-pub const IOU_PBUF_RING_MMAP: _bindgen_ty_6 = _bindgen_ty_6::IOU_PBUF_RING_MMAP;
-pub const IORING_RESTRICTION_REGISTER_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_REGISTER_OP;
-pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_OP;
-pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
-pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
-pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
-pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
-pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
-pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
-pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -917,7 +919,18 @@ FSCONFIG_CMD_CREATE_EXCL = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_1 {
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum io_uring_sqe_flags_bit {
 IOSQE_FIXED_FILE_BIT = 0,
 IOSQE_IO_DRAIN_BIT = 1,
 IOSQE_IO_LINK_BIT = 2,
@@ -985,25 +998,22 @@ IORING_OP_FUTEX_WAIT = 51,
 IORING_OP_FUTEX_WAKE = 52,
 IORING_OP_FUTEX_WAITV = 53,
 IORING_OP_FIXED_FD_INSTALL = 54,
-IORING_OP_LAST = 55,
+IORING_OP_FTRUNCATE = 55,
+IORING_OP_BIND = 56,
+IORING_OP_LISTEN = 57,
+IORING_OP_LAST = 58,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_2 {
+pub enum io_uring_msg_ring_flags {
 IORING_MSG_DATA = 0,
 IORING_MSG_SEND_FD = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_3 {
-IORING_CQE_BUFFER_SHIFT = 16,
-}
-#[repr(u32)]
-#[non_exhaustive]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_4 {
+pub enum io_uring_register_op {
 IORING_REGISTER_BUFFERS = 0,
 IORING_UNREGISTER_BUFFERS = 1,
 IORING_REGISTER_FILES = 2,
@@ -1031,26 +1041,28 @@ IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
 IORING_REGISTER_PBUF_STATUS = 26,
-IORING_REGISTER_LAST = 27,
+IORING_REGISTER_NAPI = 27,
+IORING_UNREGISTER_NAPI = 28,
+IORING_REGISTER_LAST = 29,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_5 {
+pub enum io_wq_type {
 IO_WQ_BOUND = 0,
 IO_WQ_UNBOUND = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_6 {
+pub enum io_uring_register_pbuf_ring_flags {
 IOU_PBUF_RING_MMAP = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_7 {
+pub enum io_uring_register_restriction_op {
 IORING_RESTRICTION_REGISTER_OP = 0,
 IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
@@ -1060,7 +1072,7 @@ IORING_RESTRICTION_LAST = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_8 {
+pub enum io_uring_socket_op {
 SOCKET_URING_OP_SIOCINQ = 0,
 SOCKET_URING_OP_SIOCOUTQ = 1,
 SOCKET_URING_OP_GETSOCKOPT = 2,
@@ -1119,6 +1131,7 @@ pub uring_cmd_flags: __u32,
 pub waitid_flags: __u32,
 pub futex_flags: __u32,
 pub install_fd_flags: __u32,
+pub nop_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]

--- a/src/powerpc/loop_device.rs
+++ b/src/powerpc/loop_device.rs
@@ -97,6 +97,7 @@ pub __reserved: [__u64; 8usize],
 }
 pub const LO_NAME_SIZE: u32 = 64;
 pub const LO_KEY_SIZE: u32 = 32;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const LO_CRYPT_NONE: u32 = 0;
 pub const LO_CRYPT_XOR: u32 = 1;
 pub const LO_CRYPT_DES: u32 = 2;

--- a/src/powerpc/mempolicy.rs
+++ b/src/powerpc/mempolicy.rs
@@ -158,6 +158,7 @@ pub const MPOL_BIND: _bindgen_ty_1 = _bindgen_ty_1::MPOL_BIND;
 pub const MPOL_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_INTERLEAVE;
 pub const MPOL_LOCAL: _bindgen_ty_1 = _bindgen_ty_1::MPOL_LOCAL;
 pub const MPOL_PREFERRED_MANY: _bindgen_ty_1 = _bindgen_ty_1::MPOL_PREFERRED_MANY;
+pub const MPOL_WEIGHTED_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_WEIGHTED_INTERLEAVE;
 pub const MPOL_MAX: _bindgen_ty_1 = _bindgen_ty_1::MPOL_MAX;
 #[repr(u32)]
 #[non_exhaustive]
@@ -169,5 +170,6 @@ MPOL_BIND = 2,
 MPOL_INTERLEAVE = 3,
 MPOL_LOCAL = 4,
 MPOL_PREFERRED_MANY = 5,
-MPOL_MAX = 6,
+MPOL_WEIGHTED_INTERLEAVE = 6,
+MPOL_MAX = 7,
 }

--- a/src/powerpc/net.rs
+++ b/src/powerpc/net.rs
@@ -860,6 +860,7 @@ pub _address: u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1265,6 +1266,7 @@ pub const TCP_AO_DEL_KEY: u32 = 39;
 pub const TCP_AO_INFO: u32 = 40;
 pub const TCP_AO_GET_KEYS: u32 = 41;
 pub const TCP_AO_REPAIR: u32 = 42;
+pub const TCP_IS_MPTCP: u32 = 43;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1551,6 +1553,7 @@ pub const IPPROTO_UDPLITE: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_UDPLITE;
 pub const IPPROTO_MPLS: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPLS;
 pub const IPPROTO_ETHERNET: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ETHERNET;
 pub const IPPROTO_RAW: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_RAW;
+pub const IPPROTO_SMC: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_SMC;
 pub const IPPROTO_MPTCP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPTCP;
 pub const IPPROTO_MAX: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MAX;
 pub const IPV4_DEVCONF_FORWARDING: _bindgen_ty_2 = _bindgen_ty_2::IPV4_DEVCONF_FORWARDING;
@@ -1739,6 +1742,7 @@ IPPROTO_UDPLITE = 136,
 IPPROTO_MPLS = 137,
 IPPROTO_ETHERNET = 143,
 IPPROTO_RAW = 255,
+IPPROTO_SMC = 256,
 IPPROTO_MPTCP = 262,
 IPPROTO_MAX = 263,
 }

--- a/src/powerpc/netlink.rs
+++ b/src/powerpc/netlink.rs
@@ -553,6 +553,7 @@ pub const SOCK_BUF_LOCK_MASK: u32 = 3;
 pub const SOCK_TXREHASH_DEFAULT: u32 = 255;
 pub const SOCK_TXREHASH_DISABLED: u32 = 0;
 pub const SOCK_TXREHASH_ENABLED: u32 = 1;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const NETLINK_ROUTE: u32 = 0;
 pub const NETLINK_UNUSED: u32 = 1;
 pub const NETLINK_USERSOCK: u32 = 2;
@@ -1100,6 +1101,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
@@ -1133,6 +1136,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1234,6 +1238,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
@@ -2148,7 +2153,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2186,7 +2193,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2362,7 +2370,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/powerpc/prctl.rs
+++ b/src/powerpc/prctl.rs
@@ -72,6 +72,7 @@ pub auxv: *mut __u64,
 pub auxv_size: __u32,
 pub exe_fd: __u32,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PR_SET_PDEATHSIG: u32 = 1;
 pub const PR_GET_PDEATHSIG: u32 = 2;
 pub const PR_GET_DUMPABLE: u32 = 3;
@@ -238,3 +239,20 @@ pub const PR_RISCV_V_VSTATE_CTRL_INHERIT: u32 = 16;
 pub const PR_RISCV_V_VSTATE_CTRL_CUR_MASK: u32 = 3;
 pub const PR_RISCV_V_VSTATE_CTRL_NEXT_MASK: u32 = 12;
 pub const PR_RISCV_V_VSTATE_CTRL_MASK: u32 = 31;
+pub const PR_RISCV_SET_ICACHE_FLUSH_CTX: u32 = 71;
+pub const PR_RISCV_CTX_SW_FENCEI_ON: u32 = 0;
+pub const PR_RISCV_CTX_SW_FENCEI_OFF: u32 = 1;
+pub const PR_RISCV_SCOPE_PER_PROCESS: u32 = 0;
+pub const PR_RISCV_SCOPE_PER_THREAD: u32 = 1;
+pub const PR_PPC_GET_DEXCR: u32 = 72;
+pub const PR_PPC_SET_DEXCR: u32 = 73;
+pub const PR_PPC_DEXCR_SBHE: u32 = 0;
+pub const PR_PPC_DEXCR_IBRTPD: u32 = 1;
+pub const PR_PPC_DEXCR_SRAPD: u32 = 2;
+pub const PR_PPC_DEXCR_NPHIE: u32 = 3;
+pub const PR_PPC_DEXCR_CTRL_EDITABLE: u32 = 1;
+pub const PR_PPC_DEXCR_CTRL_SET: u32 = 2;
+pub const PR_PPC_DEXCR_CTRL_CLEAR: u32 = 4;
+pub const PR_PPC_DEXCR_CTRL_SET_ONEXEC: u32 = 8;
+pub const PR_PPC_DEXCR_CTRL_CLEAR_ONEXEC: u32 = 16;
+pub const PR_PPC_DEXCR_CTRL_MASK: u32 = 31;

--- a/src/powerpc/system.rs
+++ b/src/powerpc/system.rs
@@ -100,6 +100,7 @@ pub version: [crate::ctypes::c_char; 65usize],
 pub machine: [crate::ctypes::c_char; 65usize],
 pub domainname: [crate::ctypes::c_char; 65usize],
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const SI_LOAD_SHIFT: u32 = 16;
 pub const __OLD_UTS_LEN: u32 = 8;
 pub const __NEW_UTS_LEN: u32 = 64;

--- a/src/powerpc/xdp.rs
+++ b/src/powerpc/xdp.rs
@@ -158,6 +158,7 @@ pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,
 pub tx_invalid_descs: __u64,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
@@ -165,6 +166,7 @@ pub const XDP_USE_NEED_WAKEUP: u32 = 8;
 pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
 pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
+pub const XDP_UMEM_TX_METADATA_LEN: u32 = 4;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;

--- a/src/powerpc64/btrfs.rs
+++ b/src/powerpc64/btrfs.rs
@@ -144,7 +144,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -162,7 +162,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -172,6 +173,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -187,6 +189,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -253,6 +267,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -863,10 +896,17 @@ pub physical: __le64,
 }
 #[repr(C, packed)]
 pub struct btrfs_stripe_extent {
-pub encoding: __u8,
-pub reserved: [__u8; 7usize],
+pub __bindgen_anon_1: btrfs_stripe_extent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct btrfs_stripe_extent__bindgen_ty_1 {
+pub __empty_strides: btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1,
 pub strides: __IncompleteArrayField<btrfs_raid_stride>,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct btrfs_extent_item {
@@ -1135,6 +1175,7 @@ pub encryption: __u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _IOC_SIZEBITS: u32 = 13;
 pub const _IOC_DIRBITS: u32 = 3;
 pub const _IOC_NONE: u32 = 1;
@@ -1282,13 +1323,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1360,6 +1405,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1392,6 +1438,7 @@ pub const BTRFS_QGROUP_LIMIT_RSV_EXCL: u32 = 8;
 pub const BTRFS_QGROUP_LIMIT_RFER_CMPR: u32 = 16;
 pub const BTRFS_QGROUP_LIMIT_EXCL_CMPR: u32 = 32;
 pub const BTRFS_QGROUP_INHERIT_SET_LIMITS: u32 = 1;
+pub const BTRFS_QGROUP_INHERIT_FLAGS_SUPP: u32 = 1;
 pub const BTRFS_DEVICE_REMOVE_ARGS_MASK: u32 = 8;
 pub const BTRFS_SUBVOL_CREATE_ARGS_MASK: u32 = 6;
 pub const BTRFS_SUBVOL_DELETE_ARGS_MASK: u32 = 16;
@@ -1597,14 +1644,6 @@ pub const BTRFS_SYSTEM_CHUNK_ARRAY_SIZE: u32 = 2048;
 pub const BTRFS_NUM_BACKUP_ROOTS: u32 = 4;
 pub const BTRFS_FREE_SPACE_EXTENT: u32 = 1;
 pub const BTRFS_FREE_SPACE_BITMAP: u32 = 2;
-pub const BTRFS_STRIPE_RAID0: u32 = 1;
-pub const BTRFS_STRIPE_RAID1: u32 = 2;
-pub const BTRFS_STRIPE_DUP: u32 = 3;
-pub const BTRFS_STRIPE_RAID10: u32 = 4;
-pub const BTRFS_STRIPE_RAID5: u32 = 5;
-pub const BTRFS_STRIPE_RAID6: u32 = 6;
-pub const BTRFS_STRIPE_RAID1C3: u32 = 7;
-pub const BTRFS_STRIPE_RAID1C4: u32 = 8;
 pub const BTRFS_HEADER_FLAG_WRITTEN: u32 = 1;
 pub const BTRFS_HEADER_FLAG_RELOC: u32 = 2;
 pub const BTRFS_SUPER_FLAG_ERROR: u32 = 4;
@@ -1613,6 +1652,9 @@ pub const BTRFS_SUPER_FLAG_METADUMP: u64 = 8589934592;
 pub const BTRFS_SUPER_FLAG_METADUMP_V2: u64 = 17179869184;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID: u64 = 34359738368;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID_V2: u64 = 68719476736;
+pub const BTRFS_SUPER_FLAG_CHANGING_BG_TREE: u64 = 274877906944;
+pub const BTRFS_SUPER_FLAG_CHANGING_DATA_CSUM: u64 = 549755813888;
+pub const BTRFS_SUPER_FLAG_CHANGING_META_CSUM: u64 = 1099511627776;
 pub const BTRFS_EXTENT_FLAG_DATA: u32 = 1;
 pub const BTRFS_EXTENT_FLAG_TREE_BLOCK: u32 = 2;
 pub const BTRFS_BLOCK_FLAG_FULL_BACKREF: u32 = 256;
@@ -1668,6 +1710,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/powerpc64/general.rs
+++ b/src/powerpc64/general.rs
@@ -169,6 +169,14 @@ pub data: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct epoll_params {
+pub busy_poll_usecs: __u32,
+pub busy_poll_budget: __u16,
+pub prefer_busy_poll: __u8,
+pub __pad: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct fscrypt_policy_v1 {
 pub version: __u8,
 pub contents_encryption_mode: __u8,
@@ -251,7 +259,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -269,7 +277,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -279,6 +288,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -294,6 +304,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -363,6 +385,25 @@ pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct futex_waitv {
 pub val: __u64,
 pub uaddr: __u64,
@@ -418,6 +459,14 @@ pub struct rand_pool_info {
 pub entropy_count: crate::ctypes::c_int,
 pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vgetrandom_opaque_params {
+pub size_of_opaque_state: __u32,
+pub mmap_prot: __u32,
+pub mmap_flags: __u32,
+pub reserved: [__u32; 13usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -659,7 +708,12 @@ pub stx_dev_minor: __u32,
 pub stx_mnt_id: __u64,
 pub stx_dio_mem_align: __u32,
 pub stx_dio_offset_align: __u32,
-pub __spare3: [__u64; 12usize],
+pub stx_subvol: __u64,
+pub stx_atomic_write_unit_min: __u32,
+pub stx_atomic_write_unit_max: __u32,
+pub stx_atomic_write_segments_max: __u32,
+pub __spare1: [__u32; 1usize],
+pub __spare3: [__u64; 9usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1000,9 +1054,9 @@ pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 395264;
+pub const LINUX_VERSION_CODE: u32 = 396032;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 11;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_DCACHEBSIZE: u32 = 19;
 pub const AT_ICACHEBSIZE: u32 = 20;
@@ -1043,7 +1097,10 @@ pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_RSEQ_FEATURE_SIZE: u32 = 27;
 pub const AT_RSEQ_ALIGN: u32 = 28;
+pub const AT_HWCAP3: u32 = 29;
+pub const AT_HWCAP4: u32 = 30;
 pub const AT_EXECFN: u32 = 31;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
 pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
@@ -1175,9 +1232,10 @@ pub const RESOLVE_IN_ROOT: u32 = 16;
 pub const RESOLVE_CACHED: u32 = 32;
 pub const F_SETLEASE: u32 = 1024;
 pub const F_GETLEASE: u32 = 1025;
+pub const F_NOTIFY: u32 = 1026;
+pub const F_DUPFD_QUERY: u32 = 1027;
 pub const F_CANCELLK: u32 = 1029;
 pub const F_DUPFD_CLOEXEC: u32 = 1030;
-pub const F_NOTIFY: u32 = 1026;
 pub const F_SETPIPE_SZ: u32 = 1031;
 pub const F_GETPIPE_SZ: u32 = 1032;
 pub const F_ADD_SEALS: u32 = 1033;
@@ -1223,6 +1281,7 @@ pub const EPOLL_CLOEXEC: u32 = 524288;
 pub const EPOLL_CTL_ADD: u32 = 1;
 pub const EPOLL_CTL_DEL: u32 = 2;
 pub const EPOLL_CTL_MOD: u32 = 3;
+pub const EPOLL_IOC_TYPE: u32 = 138;
 pub const POSIX_FADV_NORMAL: u32 = 0;
 pub const POSIX_FADV_RANDOM: u32 = 1;
 pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
@@ -1384,13 +1443,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1462,6 +1525,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1590,6 +1654,7 @@ pub const EFIVARFS_MAGIC: u32 = 3730735588;
 pub const HOSTFS_SUPER_MAGIC: u32 = 12648430;
 pub const OVERLAYFS_SUPER_MAGIC: u32 = 2035054128;
 pub const FUSE_SUPER_MAGIC: u32 = 1702057286;
+pub const BCACHEFS_SUPER_MAGIC: u32 = 3393526350;
 pub const MINIX_SUPER_MAGIC: u32 = 4991;
 pub const MINIX_SUPER_MAGIC2: u32 = 5007;
 pub const MINIX2_SUPER_MAGIC: u32 = 9320;
@@ -1639,6 +1704,7 @@ pub const UDF_SUPER_MAGIC: u32 = 352400198;
 pub const DMA_BUF_MAGIC: u32 = 1145913666;
 pub const DEVMEM_MAGIC: u32 = 1162691661;
 pub const SECRETMEM_MAGIC: u32 = 1397048141;
+pub const PID_FS_MAGIC: u32 = 1346978886;
 pub const PROT_READ: u32 = 1;
 pub const PROT_WRITE: u32 = 2;
 pub const PROT_EXEC: u32 = 4;
@@ -1724,6 +1790,7 @@ pub const OVERCOMMIT_NEVER: u32 = 2;
 pub const MAP_SHARED: u32 = 1;
 pub const MAP_PRIVATE: u32 = 2;
 pub const MAP_SHARED_VALIDATE: u32 = 3;
+pub const MAP_DROPPABLE: u32 = 8;
 pub const MAP_HUGE_SHIFT: u32 = 26;
 pub const MAP_HUGE_MASK: u32 = 63;
 pub const MAP_HUGE_16KB: u32 = 939524096;
@@ -2033,6 +2100,8 @@ pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
 pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
+pub const STATX_SUBVOL: u32 = 32768;
+pub const STATX_WRITE_ATOMIC: u32 = 65536;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2044,6 +2113,7 @@ pub const STATX_ATTR_AUTOMOUNT: u32 = 4096;
 pub const STATX_ATTR_MOUNT_ROOT: u32 = 8192;
 pub const STATX_ATTR_VERITY: u32 = 1048576;
 pub const STATX_ATTR_DAX: u32 = 2097152;
+pub const STATX_ATTR_WRITE_ATOMIC: u32 = 4194304;
 pub const TIOCM_LE: u32 = 1;
 pub const TIOCM_DTR: u32 = 2;
 pub const TIOCM_RTS: u32 = 4;
@@ -2657,6 +2727,7 @@ pub const __NR_listmount: u32 = 458;
 pub const __NR_lsm_get_self_attr: u32 = 459;
 pub const __NR_lsm_set_self_attr: u32 = 460;
 pub const __NR_lsm_list_modules: u32 = 461;
+pub const __NR_mseal: u32 = 462;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
 pub const WSTOPPED: u32 = 2;
@@ -2841,6 +2912,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/powerpc64/if_arp.rs
+++ b/src/powerpc64/if_arp.rs
@@ -618,6 +618,7 @@ pub ar_hln: crate::ctypes::c_uchar,
 pub ar_pln: crate::ctypes::c_uchar,
 pub ar_op: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1387,6 +1388,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
@@ -1420,6 +1423,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1521,6 +1525,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
@@ -2287,7 +2292,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2325,7 +2332,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2501,7 +2509,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/powerpc64/if_ether.rs
+++ b/src/powerpc64/if_ether.rs
@@ -63,6 +63,7 @@ pub h_dest: [crate::ctypes::c_uchar; 6usize],
 pub h_source: [crate::ctypes::c_uchar; 6usize],
 pub h_proto: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const ETH_ALEN: u32 = 6;
 pub const ETH_TLEN: u32 = 2;
 pub const ETH_HLEN: u32 = 14;

--- a/src/powerpc64/if_packet.rs
+++ b/src/powerpc64/if_packet.rs
@@ -211,6 +211,7 @@ pub id: __u16,
 pub max_num_members: __u32,
 }
 pub const __BIG_ENDIAN: u32 = 4321;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PACKET_HOST: u32 = 0;
 pub const PACKET_BROADCAST: u32 = 1;
 pub const PACKET_MULTICAST: u32 = 2;

--- a/src/powerpc64/io_uring.rs
+++ b/src/powerpc64/io_uring.rs
@@ -146,7 +146,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -164,7 +164,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -174,6 +175,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -189,6 +191,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -255,6 +269,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -498,6 +531,14 @@ pub resv: [__u32; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_napi {
+pub busy_poll_to: __u32,
+pub prefer_busy_poll: __u8,
+pub pad: [__u8; 3usize],
+pub resv: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -563,6 +604,7 @@ pub const IOC_OUT: u32 = 1073741824;
 pub const IOC_INOUT: u32 = 3221225472;
 pub const IOCSIZE_MASK: u32 = 536805376;
 pub const IOCSIZE_SHIFT: u32 = 16;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const FSCRYPT_POLICY_FLAGS_PAD_4: u32 = 0;
 pub const FSCRYPT_POLICY_FLAGS_PAD_8: u32 = 1;
 pub const FSCRYPT_POLICY_FLAGS_PAD_16: u32 = 2;
@@ -677,13 +719,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -755,6 +801,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -810,15 +857,20 @@ pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
 pub const IORING_SEND_ZC_REPORT_USAGE: u32 = 8;
+pub const IORING_RECVSEND_BUNDLE: u32 = 16;
 pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
+pub const IORING_ACCEPT_DONTWAIT: u32 = 2;
+pub const IORING_ACCEPT_POLL_FIRST: u32 = 4;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
 pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
+pub const IORING_NOP_INJECT_RESULT: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
 pub const IORING_CQE_F_NOTIF: u32 = 8;
+pub const IORING_CQE_BUFFER_SHIFT: u32 = 16;
 pub const IORING_OFF_SQ_RING: u32 = 0;
 pub const IORING_OFF_CQ_RING: u32 = 134217728;
 pub const IORING_OFF_SQES: u32 = 268435456;
@@ -848,60 +900,10 @@ pub const IORING_FEAT_RSRC_TAGS: u32 = 1024;
 pub const IORING_FEAT_CQE_SKIP: u32 = 2048;
 pub const IORING_FEAT_LINKED_FILE: u32 = 4096;
 pub const IORING_FEAT_REG_REG_RING: u32 = 8192;
+pub const IORING_FEAT_RECVSEND_BUNDLE: u32 = 16384;
 pub const IORING_RSRC_REGISTER_SPARSE: u32 = 1;
 pub const IORING_REGISTER_FILES_SKIP: i32 = -2;
 pub const IO_URING_OP_SUPPORTED: u32 = 1;
-pub const IOSQE_FIXED_FILE_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_FIXED_FILE_BIT;
-pub const IOSQE_IO_DRAIN_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_DRAIN_BIT;
-pub const IOSQE_IO_LINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_LINK_BIT;
-pub const IOSQE_IO_HARDLINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_HARDLINK_BIT;
-pub const IOSQE_ASYNC_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_ASYNC_BIT;
-pub const IOSQE_BUFFER_SELECT_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_BUFFER_SELECT_BIT;
-pub const IOSQE_CQE_SKIP_SUCCESS_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_CQE_SKIP_SUCCESS_BIT;
-pub const IORING_MSG_DATA: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_DATA;
-pub const IORING_MSG_SEND_FD: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_SEND_FD;
-pub const IORING_CQE_BUFFER_SHIFT: _bindgen_ty_3 = _bindgen_ty_3::IORING_CQE_BUFFER_SHIFT;
-pub const IORING_REGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS;
-pub const IORING_UNREGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_BUFFERS;
-pub const IORING_REGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES;
-pub const IORING_UNREGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_FILES;
-pub const IORING_REGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD;
-pub const IORING_UNREGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_EVENTFD;
-pub const IORING_REGISTER_FILES_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE;
-pub const IORING_REGISTER_EVENTFD_ASYNC: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD_ASYNC;
-pub const IORING_REGISTER_PROBE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PROBE;
-pub const IORING_REGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PERSONALITY;
-pub const IORING_UNREGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PERSONALITY;
-pub const IORING_REGISTER_RESTRICTIONS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RESTRICTIONS;
-pub const IORING_REGISTER_ENABLE_RINGS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_ENABLE_RINGS;
-pub const IORING_REGISTER_FILES2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES2;
-pub const IORING_REGISTER_FILES_UPDATE2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE2;
-pub const IORING_REGISTER_BUFFERS2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS2;
-pub const IORING_REGISTER_BUFFERS_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS_UPDATE;
-pub const IORING_REGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_AFF;
-pub const IORING_UNREGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_IOWQ_AFF;
-pub const IORING_REGISTER_IOWQ_MAX_WORKERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_MAX_WORKERS;
-pub const IORING_REGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RING_FDS;
-pub const IORING_UNREGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_RING_FDS;
-pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_RING;
-pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
-pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
-pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
-pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
-pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
-pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
-pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
-pub const IO_WQ_UNBOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_UNBOUND;
-pub const IOU_PBUF_RING_MMAP: _bindgen_ty_6 = _bindgen_ty_6::IOU_PBUF_RING_MMAP;
-pub const IORING_RESTRICTION_REGISTER_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_REGISTER_OP;
-pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_OP;
-pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
-pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
-pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
-pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
-pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
-pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
-pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -919,7 +921,18 @@ FSCONFIG_CMD_CREATE_EXCL = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_1 {
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum io_uring_sqe_flags_bit {
 IOSQE_FIXED_FILE_BIT = 0,
 IOSQE_IO_DRAIN_BIT = 1,
 IOSQE_IO_LINK_BIT = 2,
@@ -987,25 +1000,22 @@ IORING_OP_FUTEX_WAIT = 51,
 IORING_OP_FUTEX_WAKE = 52,
 IORING_OP_FUTEX_WAITV = 53,
 IORING_OP_FIXED_FD_INSTALL = 54,
-IORING_OP_LAST = 55,
+IORING_OP_FTRUNCATE = 55,
+IORING_OP_BIND = 56,
+IORING_OP_LISTEN = 57,
+IORING_OP_LAST = 58,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_2 {
+pub enum io_uring_msg_ring_flags {
 IORING_MSG_DATA = 0,
 IORING_MSG_SEND_FD = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_3 {
-IORING_CQE_BUFFER_SHIFT = 16,
-}
-#[repr(u32)]
-#[non_exhaustive]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_4 {
+pub enum io_uring_register_op {
 IORING_REGISTER_BUFFERS = 0,
 IORING_UNREGISTER_BUFFERS = 1,
 IORING_REGISTER_FILES = 2,
@@ -1033,26 +1043,28 @@ IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
 IORING_REGISTER_PBUF_STATUS = 26,
-IORING_REGISTER_LAST = 27,
+IORING_REGISTER_NAPI = 27,
+IORING_UNREGISTER_NAPI = 28,
+IORING_REGISTER_LAST = 29,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_5 {
+pub enum io_wq_type {
 IO_WQ_BOUND = 0,
 IO_WQ_UNBOUND = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_6 {
+pub enum io_uring_register_pbuf_ring_flags {
 IOU_PBUF_RING_MMAP = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_7 {
+pub enum io_uring_register_restriction_op {
 IORING_RESTRICTION_REGISTER_OP = 0,
 IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
@@ -1062,7 +1074,7 @@ IORING_RESTRICTION_LAST = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_8 {
+pub enum io_uring_socket_op {
 SOCKET_URING_OP_SIOCINQ = 0,
 SOCKET_URING_OP_SIOCOUTQ = 1,
 SOCKET_URING_OP_GETSOCKOPT = 2,
@@ -1121,6 +1133,7 @@ pub uring_cmd_flags: __u32,
 pub waitid_flags: __u32,
 pub futex_flags: __u32,
 pub install_fd_flags: __u32,
+pub nop_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]

--- a/src/powerpc64/loop_device.rs
+++ b/src/powerpc64/loop_device.rs
@@ -99,6 +99,7 @@ pub __reserved: [__u64; 8usize],
 }
 pub const LO_NAME_SIZE: u32 = 64;
 pub const LO_KEY_SIZE: u32 = 32;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const LO_CRYPT_NONE: u32 = 0;
 pub const LO_CRYPT_XOR: u32 = 1;
 pub const LO_CRYPT_DES: u32 = 2;

--- a/src/powerpc64/mempolicy.rs
+++ b/src/powerpc64/mempolicy.rs
@@ -158,6 +158,7 @@ pub const MPOL_BIND: _bindgen_ty_1 = _bindgen_ty_1::MPOL_BIND;
 pub const MPOL_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_INTERLEAVE;
 pub const MPOL_LOCAL: _bindgen_ty_1 = _bindgen_ty_1::MPOL_LOCAL;
 pub const MPOL_PREFERRED_MANY: _bindgen_ty_1 = _bindgen_ty_1::MPOL_PREFERRED_MANY;
+pub const MPOL_WEIGHTED_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_WEIGHTED_INTERLEAVE;
 pub const MPOL_MAX: _bindgen_ty_1 = _bindgen_ty_1::MPOL_MAX;
 #[repr(u32)]
 #[non_exhaustive]
@@ -169,5 +170,6 @@ MPOL_BIND = 2,
 MPOL_INTERLEAVE = 3,
 MPOL_LOCAL = 4,
 MPOL_PREFERRED_MANY = 5,
-MPOL_MAX = 6,
+MPOL_WEIGHTED_INTERLEAVE = 6,
+MPOL_MAX = 7,
 }

--- a/src/powerpc64/net.rs
+++ b/src/powerpc64/net.rs
@@ -860,6 +860,7 @@ pub _address: u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1273,6 +1274,7 @@ pub const TCP_AO_DEL_KEY: u32 = 39;
 pub const TCP_AO_INFO: u32 = 40;
 pub const TCP_AO_GET_KEYS: u32 = 41;
 pub const TCP_AO_REPAIR: u32 = 42;
+pub const TCP_IS_MPTCP: u32 = 43;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1559,6 +1561,7 @@ pub const IPPROTO_UDPLITE: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_UDPLITE;
 pub const IPPROTO_MPLS: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPLS;
 pub const IPPROTO_ETHERNET: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ETHERNET;
 pub const IPPROTO_RAW: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_RAW;
+pub const IPPROTO_SMC: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_SMC;
 pub const IPPROTO_MPTCP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPTCP;
 pub const IPPROTO_MAX: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MAX;
 pub const IPV4_DEVCONF_FORWARDING: _bindgen_ty_2 = _bindgen_ty_2::IPV4_DEVCONF_FORWARDING;
@@ -1747,6 +1750,7 @@ IPPROTO_UDPLITE = 136,
 IPPROTO_MPLS = 137,
 IPPROTO_ETHERNET = 143,
 IPPROTO_RAW = 255,
+IPPROTO_SMC = 256,
 IPPROTO_MPTCP = 262,
 IPPROTO_MAX = 263,
 }

--- a/src/powerpc64/netlink.rs
+++ b/src/powerpc64/netlink.rs
@@ -555,6 +555,7 @@ pub const SOCK_BUF_LOCK_MASK: u32 = 3;
 pub const SOCK_TXREHASH_DEFAULT: u32 = 255;
 pub const SOCK_TXREHASH_DISABLED: u32 = 0;
 pub const SOCK_TXREHASH_ENABLED: u32 = 1;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const NETLINK_ROUTE: u32 = 0;
 pub const NETLINK_UNUSED: u32 = 1;
 pub const NETLINK_USERSOCK: u32 = 2;
@@ -1102,6 +1103,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
@@ -1135,6 +1138,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1236,6 +1240,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
@@ -2150,7 +2155,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2188,7 +2195,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2364,7 +2372,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/powerpc64/prctl.rs
+++ b/src/powerpc64/prctl.rs
@@ -74,6 +74,7 @@ pub auxv: *mut __u64,
 pub auxv_size: __u32,
 pub exe_fd: __u32,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PR_SET_PDEATHSIG: u32 = 1;
 pub const PR_GET_PDEATHSIG: u32 = 2;
 pub const PR_GET_DUMPABLE: u32 = 3;
@@ -240,3 +241,20 @@ pub const PR_RISCV_V_VSTATE_CTRL_INHERIT: u32 = 16;
 pub const PR_RISCV_V_VSTATE_CTRL_CUR_MASK: u32 = 3;
 pub const PR_RISCV_V_VSTATE_CTRL_NEXT_MASK: u32 = 12;
 pub const PR_RISCV_V_VSTATE_CTRL_MASK: u32 = 31;
+pub const PR_RISCV_SET_ICACHE_FLUSH_CTX: u32 = 71;
+pub const PR_RISCV_CTX_SW_FENCEI_ON: u32 = 0;
+pub const PR_RISCV_CTX_SW_FENCEI_OFF: u32 = 1;
+pub const PR_RISCV_SCOPE_PER_PROCESS: u32 = 0;
+pub const PR_RISCV_SCOPE_PER_THREAD: u32 = 1;
+pub const PR_PPC_GET_DEXCR: u32 = 72;
+pub const PR_PPC_SET_DEXCR: u32 = 73;
+pub const PR_PPC_DEXCR_SBHE: u32 = 0;
+pub const PR_PPC_DEXCR_IBRTPD: u32 = 1;
+pub const PR_PPC_DEXCR_SRAPD: u32 = 2;
+pub const PR_PPC_DEXCR_NPHIE: u32 = 3;
+pub const PR_PPC_DEXCR_CTRL_EDITABLE: u32 = 1;
+pub const PR_PPC_DEXCR_CTRL_SET: u32 = 2;
+pub const PR_PPC_DEXCR_CTRL_CLEAR: u32 = 4;
+pub const PR_PPC_DEXCR_CTRL_SET_ONEXEC: u32 = 8;
+pub const PR_PPC_DEXCR_CTRL_CLEAR_ONEXEC: u32 = 16;
+pub const PR_PPC_DEXCR_CTRL_MASK: u32 = 31;

--- a/src/powerpc64/system.rs
+++ b/src/powerpc64/system.rs
@@ -105,6 +105,7 @@ pub version: [crate::ctypes::c_char; 65usize],
 pub machine: [crate::ctypes::c_char; 65usize],
 pub domainname: [crate::ctypes::c_char; 65usize],
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const SI_LOAD_SHIFT: u32 = 16;
 pub const __OLD_UTS_LEN: u32 = 8;
 pub const __NEW_UTS_LEN: u32 = 64;

--- a/src/powerpc64/xdp.rs
+++ b/src/powerpc64/xdp.rs
@@ -160,6 +160,7 @@ pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,
 pub tx_invalid_descs: __u64,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
@@ -167,6 +168,7 @@ pub const XDP_USE_NEED_WAKEUP: u32 = 8;
 pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
 pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
+pub const XDP_UMEM_TX_METADATA_LEN: u32 = 4;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;

--- a/src/riscv32/btrfs.rs
+++ b/src/riscv32/btrfs.rs
@@ -136,7 +136,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -154,7 +154,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -164,6 +165,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -179,6 +181,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -245,6 +259,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -855,10 +888,17 @@ pub physical: __le64,
 }
 #[repr(C, packed)]
 pub struct btrfs_stripe_extent {
-pub encoding: __u8,
-pub reserved: [__u8; 7usize],
+pub __bindgen_anon_1: btrfs_stripe_extent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct btrfs_stripe_extent__bindgen_ty_1 {
+pub __empty_strides: btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1,
 pub strides: __IncompleteArrayField<btrfs_raid_stride>,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct btrfs_extent_item {
@@ -1127,6 +1167,7 @@ pub encryption: __u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _IOC_NRBITS: u32 = 8;
 pub const _IOC_TYPEBITS: u32 = 8;
 pub const _IOC_SIZEBITS: u32 = 14;
@@ -1274,13 +1315,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1352,6 +1397,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1384,6 +1430,7 @@ pub const BTRFS_QGROUP_LIMIT_RSV_EXCL: u32 = 8;
 pub const BTRFS_QGROUP_LIMIT_RFER_CMPR: u32 = 16;
 pub const BTRFS_QGROUP_LIMIT_EXCL_CMPR: u32 = 32;
 pub const BTRFS_QGROUP_INHERIT_SET_LIMITS: u32 = 1;
+pub const BTRFS_QGROUP_INHERIT_FLAGS_SUPP: u32 = 1;
 pub const BTRFS_DEVICE_REMOVE_ARGS_MASK: u32 = 8;
 pub const BTRFS_SUBVOL_CREATE_ARGS_MASK: u32 = 6;
 pub const BTRFS_SUBVOL_DELETE_ARGS_MASK: u32 = 16;
@@ -1589,14 +1636,6 @@ pub const BTRFS_SYSTEM_CHUNK_ARRAY_SIZE: u32 = 2048;
 pub const BTRFS_NUM_BACKUP_ROOTS: u32 = 4;
 pub const BTRFS_FREE_SPACE_EXTENT: u32 = 1;
 pub const BTRFS_FREE_SPACE_BITMAP: u32 = 2;
-pub const BTRFS_STRIPE_RAID0: u32 = 1;
-pub const BTRFS_STRIPE_RAID1: u32 = 2;
-pub const BTRFS_STRIPE_DUP: u32 = 3;
-pub const BTRFS_STRIPE_RAID10: u32 = 4;
-pub const BTRFS_STRIPE_RAID5: u32 = 5;
-pub const BTRFS_STRIPE_RAID6: u32 = 6;
-pub const BTRFS_STRIPE_RAID1C3: u32 = 7;
-pub const BTRFS_STRIPE_RAID1C4: u32 = 8;
 pub const BTRFS_HEADER_FLAG_WRITTEN: u32 = 1;
 pub const BTRFS_HEADER_FLAG_RELOC: u32 = 2;
 pub const BTRFS_SUPER_FLAG_ERROR: u32 = 4;
@@ -1605,6 +1644,9 @@ pub const BTRFS_SUPER_FLAG_METADUMP: u64 = 8589934592;
 pub const BTRFS_SUPER_FLAG_METADUMP_V2: u64 = 17179869184;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID: u64 = 34359738368;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID_V2: u64 = 68719476736;
+pub const BTRFS_SUPER_FLAG_CHANGING_BG_TREE: u64 = 274877906944;
+pub const BTRFS_SUPER_FLAG_CHANGING_DATA_CSUM: u64 = 549755813888;
+pub const BTRFS_SUPER_FLAG_CHANGING_META_CSUM: u64 = 1099511627776;
 pub const BTRFS_EXTENT_FLAG_DATA: u32 = 1;
 pub const BTRFS_EXTENT_FLAG_TREE_BLOCK: u32 = 2;
 pub const BTRFS_BLOCK_FLAG_FULL_BACKREF: u32 = 256;
@@ -1660,6 +1702,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/riscv32/general.rs
+++ b/src/riscv32/general.rs
@@ -160,6 +160,14 @@ pub data: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct epoll_params {
+pub busy_poll_usecs: __u32,
+pub busy_poll_budget: __u16,
+pub prefer_busy_poll: __u8,
+pub __pad: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct fscrypt_policy_v1 {
 pub version: __u8,
 pub contents_encryption_mode: __u8,
@@ -242,7 +250,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -260,7 +268,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -270,6 +279,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -285,6 +295,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -354,6 +376,25 @@ pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct futex_waitv {
 pub val: __u64,
 pub uaddr: __u64,
@@ -409,6 +450,14 @@ pub struct rand_pool_info {
 pub entropy_count: crate::ctypes::c_int,
 pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vgetrandom_opaque_params {
+pub size_of_opaque_state: __u32,
+pub mmap_prot: __u32,
+pub mmap_flags: __u32,
+pub reserved: [__u32; 13usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -641,7 +690,12 @@ pub stx_dev_minor: __u32,
 pub stx_mnt_id: __u64,
 pub stx_dio_mem_align: __u32,
 pub stx_dio_offset_align: __u32,
-pub __spare3: [__u64; 12usize],
+pub stx_subvol: __u64,
+pub stx_atomic_write_unit_min: __u32,
+pub stx_atomic_write_unit_max: __u32,
+pub stx_atomic_write_segments_max: __u32,
+pub __spare1: [__u32; 1usize],
+pub __spare3: [__u64; 9usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -964,9 +1018,9 @@ pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 395264;
+pub const LINUX_VERSION_CODE: u32 = 396032;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 11;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_L1I_CACHESIZE: u32 = 40;
@@ -977,7 +1031,7 @@ pub const AT_L2_CACHESIZE: u32 = 44;
 pub const AT_L2_CACHEGEOMETRY: u32 = 45;
 pub const AT_L3_CACHESIZE: u32 = 46;
 pub const AT_L3_CACHEGEOMETRY: u32 = 47;
-pub const AT_VECTOR_SIZE_ARCH: u32 = 9;
+pub const AT_VECTOR_SIZE_ARCH: u32 = 10;
 pub const AT_MINSIGSTKSZ: u32 = 51;
 pub const AT_NULL: u32 = 0;
 pub const AT_IGNORE: u32 = 1;
@@ -1003,7 +1057,10 @@ pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_RSEQ_FEATURE_SIZE: u32 = 27;
 pub const AT_RSEQ_ALIGN: u32 = 28;
+pub const AT_HWCAP3: u32 = 29;
+pub const AT_HWCAP4: u32 = 30;
 pub const AT_EXECFN: u32 = 31;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
 pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
@@ -1138,9 +1195,10 @@ pub const RESOLVE_IN_ROOT: u32 = 16;
 pub const RESOLVE_CACHED: u32 = 32;
 pub const F_SETLEASE: u32 = 1024;
 pub const F_GETLEASE: u32 = 1025;
+pub const F_NOTIFY: u32 = 1026;
+pub const F_DUPFD_QUERY: u32 = 1027;
 pub const F_CANCELLK: u32 = 1029;
 pub const F_DUPFD_CLOEXEC: u32 = 1030;
-pub const F_NOTIFY: u32 = 1026;
 pub const F_SETPIPE_SZ: u32 = 1031;
 pub const F_GETPIPE_SZ: u32 = 1032;
 pub const F_ADD_SEALS: u32 = 1033;
@@ -1186,6 +1244,7 @@ pub const EPOLL_CLOEXEC: u32 = 524288;
 pub const EPOLL_CTL_ADD: u32 = 1;
 pub const EPOLL_CTL_DEL: u32 = 2;
 pub const EPOLL_CTL_MOD: u32 = 3;
+pub const EPOLL_IOC_TYPE: u32 = 138;
 pub const POSIX_FADV_NORMAL: u32 = 0;
 pub const POSIX_FADV_RANDOM: u32 = 1;
 pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
@@ -1347,13 +1406,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1425,6 +1488,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1553,6 +1617,7 @@ pub const EFIVARFS_MAGIC: u32 = 3730735588;
 pub const HOSTFS_SUPER_MAGIC: u32 = 12648430;
 pub const OVERLAYFS_SUPER_MAGIC: u32 = 2035054128;
 pub const FUSE_SUPER_MAGIC: u32 = 1702057286;
+pub const BCACHEFS_SUPER_MAGIC: u32 = 3393526350;
 pub const MINIX_SUPER_MAGIC: u32 = 4991;
 pub const MINIX_SUPER_MAGIC2: u32 = 5007;
 pub const MINIX2_SUPER_MAGIC: u32 = 9320;
@@ -1602,6 +1667,7 @@ pub const UDF_SUPER_MAGIC: u32 = 352400198;
 pub const DMA_BUF_MAGIC: u32 = 1145913666;
 pub const DEVMEM_MAGIC: u32 = 1162691661;
 pub const SECRETMEM_MAGIC: u32 = 1397048141;
+pub const PID_FS_MAGIC: u32 = 1346978886;
 pub const PROT_READ: u32 = 1;
 pub const PROT_WRITE: u32 = 2;
 pub const PROT_EXEC: u32 = 4;
@@ -1684,6 +1750,7 @@ pub const OVERCOMMIT_NEVER: u32 = 2;
 pub const MAP_SHARED: u32 = 1;
 pub const MAP_PRIVATE: u32 = 2;
 pub const MAP_SHARED_VALIDATE: u32 = 3;
+pub const MAP_DROPPABLE: u32 = 8;
 pub const MAP_HUGE_SHIFT: u32 = 26;
 pub const MAP_HUGE_MASK: u32 = 63;
 pub const MAP_HUGE_16KB: u32 = 939524096;
@@ -1990,6 +2057,8 @@ pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
 pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
+pub const STATX_SUBVOL: u32 = 32768;
+pub const STATX_WRITE_ATOMIC: u32 = 65536;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2001,6 +2070,7 @@ pub const STATX_ATTR_AUTOMOUNT: u32 = 4096;
 pub const STATX_ATTR_MOUNT_ROOT: u32 = 8192;
 pub const STATX_ATTR_VERITY: u32 = 1048576;
 pub const STATX_ATTR_DAX: u32 = 2097152;
+pub const STATX_ATTR_WRITE_ATOMIC: u32 = 4194304;
 pub const IGNBRK: u32 = 1;
 pub const BRKINT: u32 = 2;
 pub const IGNPAR: u32 = 4;
@@ -2212,7 +2282,7 @@ pub const __NR_epoll_ctl: u32 = 21;
 pub const __NR_epoll_pwait: u32 = 22;
 pub const __NR_dup: u32 = 23;
 pub const __NR_dup3: u32 = 24;
-pub const __NR3264_fcntl: u32 = 25;
+pub const __NR_fcntl64: u32 = 25;
 pub const __NR_inotify_init1: u32 = 26;
 pub const __NR_inotify_add_watch: u32 = 27;
 pub const __NR_inotify_rm_watch: u32 = 28;
@@ -2229,10 +2299,10 @@ pub const __NR_umount2: u32 = 39;
 pub const __NR_mount: u32 = 40;
 pub const __NR_pivot_root: u32 = 41;
 pub const __NR_nfsservctl: u32 = 42;
-pub const __NR3264_statfs: u32 = 43;
-pub const __NR3264_fstatfs: u32 = 44;
-pub const __NR3264_truncate: u32 = 45;
-pub const __NR3264_ftruncate: u32 = 46;
+pub const __NR_statfs64: u32 = 43;
+pub const __NR_fstatfs64: u32 = 44;
+pub const __NR_truncate64: u32 = 45;
+pub const __NR_ftruncate64: u32 = 46;
 pub const __NR_fallocate: u32 = 47;
 pub const __NR_faccessat: u32 = 48;
 pub const __NR_chdir: u32 = 49;
@@ -2248,7 +2318,7 @@ pub const __NR_vhangup: u32 = 58;
 pub const __NR_pipe2: u32 = 59;
 pub const __NR_quotactl: u32 = 60;
 pub const __NR_getdents64: u32 = 61;
-pub const __NR3264_lseek: u32 = 62;
+pub const __NR_llseek: u32 = 62;
 pub const __NR_read: u32 = 63;
 pub const __NR_write: u32 = 64;
 pub const __NR_readv: u32 = 65;
@@ -2257,7 +2327,7 @@ pub const __NR_pread64: u32 = 67;
 pub const __NR_pwrite64: u32 = 68;
 pub const __NR_preadv: u32 = 69;
 pub const __NR_pwritev: u32 = 70;
-pub const __NR3264_sendfile: u32 = 71;
+pub const __NR_sendfile64: u32 = 71;
 pub const __NR_signalfd4: u32 = 74;
 pub const __NR_vmsplice: u32 = 75;
 pub const __NR_splice: u32 = 76;
@@ -2383,8 +2453,8 @@ pub const __NR_request_key: u32 = 218;
 pub const __NR_keyctl: u32 = 219;
 pub const __NR_clone: u32 = 220;
 pub const __NR_execve: u32 = 221;
-pub const __NR3264_mmap: u32 = 222;
-pub const __NR3264_fadvise64: u32 = 223;
+pub const __NR_mmap2: u32 = 222;
+pub const __NR_fadvise64_64: u32 = 223;
 pub const __NR_swapon: u32 = 224;
 pub const __NR_swapoff: u32 = 225;
 pub const __NR_mprotect: u32 = 226;
@@ -2404,7 +2474,8 @@ pub const __NR_move_pages: u32 = 239;
 pub const __NR_rt_tgsigqueueinfo: u32 = 240;
 pub const __NR_perf_event_open: u32 = 241;
 pub const __NR_accept4: u32 = 242;
-pub const __NR_arch_specific_syscall: u32 = 244;
+pub const __NR_riscv_hwprobe: u32 = 258;
+pub const __NR_riscv_flush_icache: u32 = 259;
 pub const __NR_prlimit64: u32 = 261;
 pub const __NR_fanotify_init: u32 = 262;
 pub const __NR_fanotify_mark: u32 = 263;
@@ -2495,18 +2566,7 @@ pub const __NR_listmount: u32 = 458;
 pub const __NR_lsm_get_self_attr: u32 = 459;
 pub const __NR_lsm_set_self_attr: u32 = 460;
 pub const __NR_lsm_list_modules: u32 = 461;
-pub const __NR_syscalls: u32 = 462;
-pub const __NR_fcntl64: u32 = 25;
-pub const __NR_statfs64: u32 = 43;
-pub const __NR_fstatfs64: u32 = 44;
-pub const __NR_truncate64: u32 = 45;
-pub const __NR_ftruncate64: u32 = 46;
-pub const __NR_llseek: u32 = 62;
-pub const __NR_sendfile64: u32 = 71;
-pub const __NR_mmap2: u32 = 222;
-pub const __NR_fadvise64_64: u32 = 223;
-pub const __NR_riscv_flush_icache: u32 = 259;
-pub const __NR_riscv_hwprobe: u32 = 258;
+pub const __NR_mseal: u32 = 462;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
 pub const WSTOPPED: u32 = 2;
@@ -2691,6 +2751,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/riscv32/if_arp.rs
+++ b/src/riscv32/if_arp.rs
@@ -610,6 +610,7 @@ pub ar_hln: crate::ctypes::c_uchar,
 pub ar_pln: crate::ctypes::c_uchar,
 pub ar_op: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1379,6 +1380,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
@@ -1412,6 +1415,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1513,6 +1517,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
@@ -2279,7 +2284,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2317,7 +2324,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2493,7 +2501,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/riscv32/if_ether.rs
+++ b/src/riscv32/if_ether.rs
@@ -55,6 +55,7 @@ pub h_dest: [crate::ctypes::c_uchar; 6usize],
 pub h_source: [crate::ctypes::c_uchar; 6usize],
 pub h_proto: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const ETH_ALEN: u32 = 6;
 pub const ETH_TLEN: u32 = 2;
 pub const ETH_HLEN: u32 = 14;

--- a/src/riscv32/if_packet.rs
+++ b/src/riscv32/if_packet.rs
@@ -203,6 +203,7 @@ pub type_flags: __u16,
 pub max_num_members: __u32,
 }
 pub const __LITTLE_ENDIAN: u32 = 1234;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PACKET_HOST: u32 = 0;
 pub const PACKET_BROADCAST: u32 = 1;
 pub const PACKET_MULTICAST: u32 = 2;

--- a/src/riscv32/io_uring.rs
+++ b/src/riscv32/io_uring.rs
@@ -138,7 +138,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -156,7 +156,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -166,6 +167,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -181,6 +183,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -247,6 +261,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -490,6 +523,14 @@ pub resv: [__u32; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_napi {
+pub busy_poll_to: __u32,
+pub prefer_busy_poll: __u8,
+pub pad: [__u8; 3usize],
+pub resv: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -555,6 +596,7 @@ pub const IOC_OUT: u32 = 2147483648;
 pub const IOC_INOUT: u32 = 3221225472;
 pub const IOCSIZE_MASK: u32 = 1073676288;
 pub const IOCSIZE_SHIFT: u32 = 16;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const FSCRYPT_POLICY_FLAGS_PAD_4: u32 = 0;
 pub const FSCRYPT_POLICY_FLAGS_PAD_8: u32 = 1;
 pub const FSCRYPT_POLICY_FLAGS_PAD_16: u32 = 2;
@@ -669,13 +711,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -747,6 +793,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -802,15 +849,20 @@ pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
 pub const IORING_SEND_ZC_REPORT_USAGE: u32 = 8;
+pub const IORING_RECVSEND_BUNDLE: u32 = 16;
 pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
+pub const IORING_ACCEPT_DONTWAIT: u32 = 2;
+pub const IORING_ACCEPT_POLL_FIRST: u32 = 4;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
 pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
+pub const IORING_NOP_INJECT_RESULT: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
 pub const IORING_CQE_F_NOTIF: u32 = 8;
+pub const IORING_CQE_BUFFER_SHIFT: u32 = 16;
 pub const IORING_OFF_SQ_RING: u32 = 0;
 pub const IORING_OFF_CQ_RING: u32 = 134217728;
 pub const IORING_OFF_SQES: u32 = 268435456;
@@ -840,60 +892,10 @@ pub const IORING_FEAT_RSRC_TAGS: u32 = 1024;
 pub const IORING_FEAT_CQE_SKIP: u32 = 2048;
 pub const IORING_FEAT_LINKED_FILE: u32 = 4096;
 pub const IORING_FEAT_REG_REG_RING: u32 = 8192;
+pub const IORING_FEAT_RECVSEND_BUNDLE: u32 = 16384;
 pub const IORING_RSRC_REGISTER_SPARSE: u32 = 1;
 pub const IORING_REGISTER_FILES_SKIP: i32 = -2;
 pub const IO_URING_OP_SUPPORTED: u32 = 1;
-pub const IOSQE_FIXED_FILE_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_FIXED_FILE_BIT;
-pub const IOSQE_IO_DRAIN_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_DRAIN_BIT;
-pub const IOSQE_IO_LINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_LINK_BIT;
-pub const IOSQE_IO_HARDLINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_HARDLINK_BIT;
-pub const IOSQE_ASYNC_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_ASYNC_BIT;
-pub const IOSQE_BUFFER_SELECT_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_BUFFER_SELECT_BIT;
-pub const IOSQE_CQE_SKIP_SUCCESS_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_CQE_SKIP_SUCCESS_BIT;
-pub const IORING_MSG_DATA: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_DATA;
-pub const IORING_MSG_SEND_FD: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_SEND_FD;
-pub const IORING_CQE_BUFFER_SHIFT: _bindgen_ty_3 = _bindgen_ty_3::IORING_CQE_BUFFER_SHIFT;
-pub const IORING_REGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS;
-pub const IORING_UNREGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_BUFFERS;
-pub const IORING_REGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES;
-pub const IORING_UNREGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_FILES;
-pub const IORING_REGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD;
-pub const IORING_UNREGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_EVENTFD;
-pub const IORING_REGISTER_FILES_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE;
-pub const IORING_REGISTER_EVENTFD_ASYNC: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD_ASYNC;
-pub const IORING_REGISTER_PROBE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PROBE;
-pub const IORING_REGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PERSONALITY;
-pub const IORING_UNREGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PERSONALITY;
-pub const IORING_REGISTER_RESTRICTIONS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RESTRICTIONS;
-pub const IORING_REGISTER_ENABLE_RINGS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_ENABLE_RINGS;
-pub const IORING_REGISTER_FILES2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES2;
-pub const IORING_REGISTER_FILES_UPDATE2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE2;
-pub const IORING_REGISTER_BUFFERS2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS2;
-pub const IORING_REGISTER_BUFFERS_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS_UPDATE;
-pub const IORING_REGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_AFF;
-pub const IORING_UNREGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_IOWQ_AFF;
-pub const IORING_REGISTER_IOWQ_MAX_WORKERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_MAX_WORKERS;
-pub const IORING_REGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RING_FDS;
-pub const IORING_UNREGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_RING_FDS;
-pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_RING;
-pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
-pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
-pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
-pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
-pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
-pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
-pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
-pub const IO_WQ_UNBOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_UNBOUND;
-pub const IOU_PBUF_RING_MMAP: _bindgen_ty_6 = _bindgen_ty_6::IOU_PBUF_RING_MMAP;
-pub const IORING_RESTRICTION_REGISTER_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_REGISTER_OP;
-pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_OP;
-pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
-pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
-pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
-pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
-pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
-pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
-pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -911,7 +913,18 @@ FSCONFIG_CMD_CREATE_EXCL = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_1 {
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum io_uring_sqe_flags_bit {
 IOSQE_FIXED_FILE_BIT = 0,
 IOSQE_IO_DRAIN_BIT = 1,
 IOSQE_IO_LINK_BIT = 2,
@@ -979,25 +992,22 @@ IORING_OP_FUTEX_WAIT = 51,
 IORING_OP_FUTEX_WAKE = 52,
 IORING_OP_FUTEX_WAITV = 53,
 IORING_OP_FIXED_FD_INSTALL = 54,
-IORING_OP_LAST = 55,
+IORING_OP_FTRUNCATE = 55,
+IORING_OP_BIND = 56,
+IORING_OP_LISTEN = 57,
+IORING_OP_LAST = 58,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_2 {
+pub enum io_uring_msg_ring_flags {
 IORING_MSG_DATA = 0,
 IORING_MSG_SEND_FD = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_3 {
-IORING_CQE_BUFFER_SHIFT = 16,
-}
-#[repr(u32)]
-#[non_exhaustive]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_4 {
+pub enum io_uring_register_op {
 IORING_REGISTER_BUFFERS = 0,
 IORING_UNREGISTER_BUFFERS = 1,
 IORING_REGISTER_FILES = 2,
@@ -1025,26 +1035,28 @@ IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
 IORING_REGISTER_PBUF_STATUS = 26,
-IORING_REGISTER_LAST = 27,
+IORING_REGISTER_NAPI = 27,
+IORING_UNREGISTER_NAPI = 28,
+IORING_REGISTER_LAST = 29,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_5 {
+pub enum io_wq_type {
 IO_WQ_BOUND = 0,
 IO_WQ_UNBOUND = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_6 {
+pub enum io_uring_register_pbuf_ring_flags {
 IOU_PBUF_RING_MMAP = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_7 {
+pub enum io_uring_register_restriction_op {
 IORING_RESTRICTION_REGISTER_OP = 0,
 IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
@@ -1054,7 +1066,7 @@ IORING_RESTRICTION_LAST = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_8 {
+pub enum io_uring_socket_op {
 SOCKET_URING_OP_SIOCINQ = 0,
 SOCKET_URING_OP_SIOCOUTQ = 1,
 SOCKET_URING_OP_GETSOCKOPT = 2,
@@ -1113,6 +1125,7 @@ pub uring_cmd_flags: __u32,
 pub waitid_flags: __u32,
 pub futex_flags: __u32,
 pub install_fd_flags: __u32,
+pub nop_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]

--- a/src/riscv32/loop_device.rs
+++ b/src/riscv32/loop_device.rs
@@ -91,6 +91,7 @@ pub __reserved: [__u64; 8usize],
 }
 pub const LO_NAME_SIZE: u32 = 64;
 pub const LO_KEY_SIZE: u32 = 32;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const LO_CRYPT_NONE: u32 = 0;
 pub const LO_CRYPT_XOR: u32 = 1;
 pub const LO_CRYPT_DES: u32 = 2;

--- a/src/riscv32/mempolicy.rs
+++ b/src/riscv32/mempolicy.rs
@@ -158,6 +158,7 @@ pub const MPOL_BIND: _bindgen_ty_1 = _bindgen_ty_1::MPOL_BIND;
 pub const MPOL_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_INTERLEAVE;
 pub const MPOL_LOCAL: _bindgen_ty_1 = _bindgen_ty_1::MPOL_LOCAL;
 pub const MPOL_PREFERRED_MANY: _bindgen_ty_1 = _bindgen_ty_1::MPOL_PREFERRED_MANY;
+pub const MPOL_WEIGHTED_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_WEIGHTED_INTERLEAVE;
 pub const MPOL_MAX: _bindgen_ty_1 = _bindgen_ty_1::MPOL_MAX;
 #[repr(u32)]
 #[non_exhaustive]
@@ -169,5 +170,6 @@ MPOL_BIND = 2,
 MPOL_INTERLEAVE = 3,
 MPOL_LOCAL = 4,
 MPOL_PREFERRED_MANY = 5,
-MPOL_MAX = 6,
+MPOL_WEIGHTED_INTERLEAVE = 6,
+MPOL_MAX = 7,
 }

--- a/src/riscv32/net.rs
+++ b/src/riscv32/net.rs
@@ -854,6 +854,7 @@ pub _address: u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1259,6 +1260,7 @@ pub const TCP_AO_DEL_KEY: u32 = 39;
 pub const TCP_AO_INFO: u32 = 40;
 pub const TCP_AO_GET_KEYS: u32 = 41;
 pub const TCP_AO_REPAIR: u32 = 42;
+pub const TCP_IS_MPTCP: u32 = 43;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1545,6 +1547,7 @@ pub const IPPROTO_UDPLITE: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_UDPLITE;
 pub const IPPROTO_MPLS: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPLS;
 pub const IPPROTO_ETHERNET: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ETHERNET;
 pub const IPPROTO_RAW: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_RAW;
+pub const IPPROTO_SMC: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_SMC;
 pub const IPPROTO_MPTCP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPTCP;
 pub const IPPROTO_MAX: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MAX;
 pub const IPV4_DEVCONF_FORWARDING: _bindgen_ty_2 = _bindgen_ty_2::IPV4_DEVCONF_FORWARDING;
@@ -1733,6 +1736,7 @@ IPPROTO_UDPLITE = 136,
 IPPROTO_MPLS = 137,
 IPPROTO_ETHERNET = 143,
 IPPROTO_RAW = 255,
+IPPROTO_SMC = 256,
 IPPROTO_MPTCP = 262,
 IPPROTO_MAX = 263,
 }

--- a/src/riscv32/netlink.rs
+++ b/src/riscv32/netlink.rs
@@ -547,6 +547,7 @@ pub const SOCK_BUF_LOCK_MASK: u32 = 3;
 pub const SOCK_TXREHASH_DEFAULT: u32 = 255;
 pub const SOCK_TXREHASH_DISABLED: u32 = 0;
 pub const SOCK_TXREHASH_ENABLED: u32 = 1;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const NETLINK_ROUTE: u32 = 0;
 pub const NETLINK_UNUSED: u32 = 1;
 pub const NETLINK_USERSOCK: u32 = 2;
@@ -1094,6 +1095,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
@@ -1127,6 +1130,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1228,6 +1232,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
@@ -2142,7 +2147,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2180,7 +2187,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2356,7 +2364,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/riscv32/prctl.rs
+++ b/src/riscv32/prctl.rs
@@ -66,6 +66,7 @@ pub auxv: *mut __u64,
 pub auxv_size: __u32,
 pub exe_fd: __u32,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PR_SET_PDEATHSIG: u32 = 1;
 pub const PR_GET_PDEATHSIG: u32 = 2;
 pub const PR_GET_DUMPABLE: u32 = 3;
@@ -232,3 +233,20 @@ pub const PR_RISCV_V_VSTATE_CTRL_INHERIT: u32 = 16;
 pub const PR_RISCV_V_VSTATE_CTRL_CUR_MASK: u32 = 3;
 pub const PR_RISCV_V_VSTATE_CTRL_NEXT_MASK: u32 = 12;
 pub const PR_RISCV_V_VSTATE_CTRL_MASK: u32 = 31;
+pub const PR_RISCV_SET_ICACHE_FLUSH_CTX: u32 = 71;
+pub const PR_RISCV_CTX_SW_FENCEI_ON: u32 = 0;
+pub const PR_RISCV_CTX_SW_FENCEI_OFF: u32 = 1;
+pub const PR_RISCV_SCOPE_PER_PROCESS: u32 = 0;
+pub const PR_RISCV_SCOPE_PER_THREAD: u32 = 1;
+pub const PR_PPC_GET_DEXCR: u32 = 72;
+pub const PR_PPC_SET_DEXCR: u32 = 73;
+pub const PR_PPC_DEXCR_SBHE: u32 = 0;
+pub const PR_PPC_DEXCR_IBRTPD: u32 = 1;
+pub const PR_PPC_DEXCR_SRAPD: u32 = 2;
+pub const PR_PPC_DEXCR_NPHIE: u32 = 3;
+pub const PR_PPC_DEXCR_CTRL_EDITABLE: u32 = 1;
+pub const PR_PPC_DEXCR_CTRL_SET: u32 = 2;
+pub const PR_PPC_DEXCR_CTRL_CLEAR: u32 = 4;
+pub const PR_PPC_DEXCR_CTRL_SET_ONEXEC: u32 = 8;
+pub const PR_PPC_DEXCR_CTRL_CLEAR_ONEXEC: u32 = 16;
+pub const PR_PPC_DEXCR_CTRL_MASK: u32 = 31;

--- a/src/riscv32/system.rs
+++ b/src/riscv32/system.rs
@@ -94,6 +94,7 @@ pub version: [crate::ctypes::c_char; 65usize],
 pub machine: [crate::ctypes::c_char; 65usize],
 pub domainname: [crate::ctypes::c_char; 65usize],
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const SI_LOAD_SHIFT: u32 = 16;
 pub const __OLD_UTS_LEN: u32 = 8;
 pub const __NEW_UTS_LEN: u32 = 64;

--- a/src/riscv32/xdp.rs
+++ b/src/riscv32/xdp.rs
@@ -152,6 +152,7 @@ pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,
 pub tx_invalid_descs: __u64,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
@@ -159,6 +160,7 @@ pub const XDP_USE_NEED_WAKEUP: u32 = 8;
 pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
 pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
+pub const XDP_UMEM_TX_METADATA_LEN: u32 = 4;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;

--- a/src/riscv64/btrfs.rs
+++ b/src/riscv64/btrfs.rs
@@ -138,7 +138,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -156,7 +156,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -166,6 +167,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -181,6 +183,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -247,6 +261,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -857,10 +890,17 @@ pub physical: __le64,
 }
 #[repr(C, packed)]
 pub struct btrfs_stripe_extent {
-pub encoding: __u8,
-pub reserved: [__u8; 7usize],
+pub __bindgen_anon_1: btrfs_stripe_extent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct btrfs_stripe_extent__bindgen_ty_1 {
+pub __empty_strides: btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1,
 pub strides: __IncompleteArrayField<btrfs_raid_stride>,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct btrfs_extent_item {
@@ -1129,6 +1169,7 @@ pub encryption: __u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _IOC_NRBITS: u32 = 8;
 pub const _IOC_TYPEBITS: u32 = 8;
 pub const _IOC_SIZEBITS: u32 = 14;
@@ -1276,13 +1317,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1354,6 +1399,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1386,6 +1432,7 @@ pub const BTRFS_QGROUP_LIMIT_RSV_EXCL: u32 = 8;
 pub const BTRFS_QGROUP_LIMIT_RFER_CMPR: u32 = 16;
 pub const BTRFS_QGROUP_LIMIT_EXCL_CMPR: u32 = 32;
 pub const BTRFS_QGROUP_INHERIT_SET_LIMITS: u32 = 1;
+pub const BTRFS_QGROUP_INHERIT_FLAGS_SUPP: u32 = 1;
 pub const BTRFS_DEVICE_REMOVE_ARGS_MASK: u32 = 8;
 pub const BTRFS_SUBVOL_CREATE_ARGS_MASK: u32 = 6;
 pub const BTRFS_SUBVOL_DELETE_ARGS_MASK: u32 = 16;
@@ -1591,14 +1638,6 @@ pub const BTRFS_SYSTEM_CHUNK_ARRAY_SIZE: u32 = 2048;
 pub const BTRFS_NUM_BACKUP_ROOTS: u32 = 4;
 pub const BTRFS_FREE_SPACE_EXTENT: u32 = 1;
 pub const BTRFS_FREE_SPACE_BITMAP: u32 = 2;
-pub const BTRFS_STRIPE_RAID0: u32 = 1;
-pub const BTRFS_STRIPE_RAID1: u32 = 2;
-pub const BTRFS_STRIPE_DUP: u32 = 3;
-pub const BTRFS_STRIPE_RAID10: u32 = 4;
-pub const BTRFS_STRIPE_RAID5: u32 = 5;
-pub const BTRFS_STRIPE_RAID6: u32 = 6;
-pub const BTRFS_STRIPE_RAID1C3: u32 = 7;
-pub const BTRFS_STRIPE_RAID1C4: u32 = 8;
 pub const BTRFS_HEADER_FLAG_WRITTEN: u32 = 1;
 pub const BTRFS_HEADER_FLAG_RELOC: u32 = 2;
 pub const BTRFS_SUPER_FLAG_ERROR: u32 = 4;
@@ -1607,6 +1646,9 @@ pub const BTRFS_SUPER_FLAG_METADUMP: u64 = 8589934592;
 pub const BTRFS_SUPER_FLAG_METADUMP_V2: u64 = 17179869184;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID: u64 = 34359738368;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID_V2: u64 = 68719476736;
+pub const BTRFS_SUPER_FLAG_CHANGING_BG_TREE: u64 = 274877906944;
+pub const BTRFS_SUPER_FLAG_CHANGING_DATA_CSUM: u64 = 549755813888;
+pub const BTRFS_SUPER_FLAG_CHANGING_META_CSUM: u64 = 1099511627776;
 pub const BTRFS_EXTENT_FLAG_DATA: u32 = 1;
 pub const BTRFS_EXTENT_FLAG_TREE_BLOCK: u32 = 2;
 pub const BTRFS_BLOCK_FLAG_FULL_BACKREF: u32 = 256;
@@ -1662,6 +1704,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/riscv64/general.rs
+++ b/src/riscv64/general.rs
@@ -162,6 +162,14 @@ pub data: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct epoll_params {
+pub busy_poll_usecs: __u32,
+pub busy_poll_budget: __u16,
+pub prefer_busy_poll: __u8,
+pub __pad: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct fscrypt_policy_v1 {
 pub version: __u8,
 pub contents_encryption_mode: __u8,
@@ -244,7 +252,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -262,7 +270,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -272,6 +281,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -287,6 +297,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -356,6 +378,25 @@ pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct futex_waitv {
 pub val: __u64,
 pub uaddr: __u64,
@@ -411,6 +452,14 @@ pub struct rand_pool_info {
 pub entropy_count: crate::ctypes::c_int,
 pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vgetrandom_opaque_params {
+pub size_of_opaque_state: __u32,
+pub mmap_prot: __u32,
+pub mmap_flags: __u32,
+pub reserved: [__u32; 13usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -643,7 +692,12 @@ pub stx_dev_minor: __u32,
 pub stx_mnt_id: __u64,
 pub stx_dio_mem_align: __u32,
 pub stx_dio_offset_align: __u32,
-pub __spare3: [__u64; 12usize],
+pub stx_subvol: __u64,
+pub stx_atomic_write_unit_min: __u32,
+pub stx_atomic_write_unit_max: __u32,
+pub stx_atomic_write_segments_max: __u32,
+pub __spare1: [__u32; 1usize],
+pub __spare3: [__u64; 9usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -942,9 +996,9 @@ pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 395264;
+pub const LINUX_VERSION_CODE: u32 = 396032;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 11;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_L1I_CACHESIZE: u32 = 40;
@@ -955,7 +1009,7 @@ pub const AT_L2_CACHESIZE: u32 = 44;
 pub const AT_L2_CACHEGEOMETRY: u32 = 45;
 pub const AT_L3_CACHESIZE: u32 = 46;
 pub const AT_L3_CACHEGEOMETRY: u32 = 47;
-pub const AT_VECTOR_SIZE_ARCH: u32 = 9;
+pub const AT_VECTOR_SIZE_ARCH: u32 = 10;
 pub const AT_MINSIGSTKSZ: u32 = 51;
 pub const AT_NULL: u32 = 0;
 pub const AT_IGNORE: u32 = 1;
@@ -981,7 +1035,10 @@ pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_RSEQ_FEATURE_SIZE: u32 = 27;
 pub const AT_RSEQ_ALIGN: u32 = 28;
+pub const AT_HWCAP3: u32 = 29;
+pub const AT_HWCAP4: u32 = 30;
 pub const AT_EXECFN: u32 = 31;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
 pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
@@ -1113,9 +1170,10 @@ pub const RESOLVE_IN_ROOT: u32 = 16;
 pub const RESOLVE_CACHED: u32 = 32;
 pub const F_SETLEASE: u32 = 1024;
 pub const F_GETLEASE: u32 = 1025;
+pub const F_NOTIFY: u32 = 1026;
+pub const F_DUPFD_QUERY: u32 = 1027;
 pub const F_CANCELLK: u32 = 1029;
 pub const F_DUPFD_CLOEXEC: u32 = 1030;
-pub const F_NOTIFY: u32 = 1026;
 pub const F_SETPIPE_SZ: u32 = 1031;
 pub const F_GETPIPE_SZ: u32 = 1032;
 pub const F_ADD_SEALS: u32 = 1033;
@@ -1161,6 +1219,7 @@ pub const EPOLL_CLOEXEC: u32 = 524288;
 pub const EPOLL_CTL_ADD: u32 = 1;
 pub const EPOLL_CTL_DEL: u32 = 2;
 pub const EPOLL_CTL_MOD: u32 = 3;
+pub const EPOLL_IOC_TYPE: u32 = 138;
 pub const POSIX_FADV_NORMAL: u32 = 0;
 pub const POSIX_FADV_RANDOM: u32 = 1;
 pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
@@ -1322,13 +1381,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1400,6 +1463,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1528,6 +1592,7 @@ pub const EFIVARFS_MAGIC: u32 = 3730735588;
 pub const HOSTFS_SUPER_MAGIC: u32 = 12648430;
 pub const OVERLAYFS_SUPER_MAGIC: u32 = 2035054128;
 pub const FUSE_SUPER_MAGIC: u32 = 1702057286;
+pub const BCACHEFS_SUPER_MAGIC: u32 = 3393526350;
 pub const MINIX_SUPER_MAGIC: u32 = 4991;
 pub const MINIX_SUPER_MAGIC2: u32 = 5007;
 pub const MINIX2_SUPER_MAGIC: u32 = 9320;
@@ -1577,6 +1642,7 @@ pub const UDF_SUPER_MAGIC: u32 = 352400198;
 pub const DMA_BUF_MAGIC: u32 = 1145913666;
 pub const DEVMEM_MAGIC: u32 = 1162691661;
 pub const SECRETMEM_MAGIC: u32 = 1397048141;
+pub const PID_FS_MAGIC: u32 = 1346978886;
 pub const PROT_READ: u32 = 1;
 pub const PROT_WRITE: u32 = 2;
 pub const PROT_EXEC: u32 = 4;
@@ -1659,6 +1725,7 @@ pub const OVERCOMMIT_NEVER: u32 = 2;
 pub const MAP_SHARED: u32 = 1;
 pub const MAP_PRIVATE: u32 = 2;
 pub const MAP_SHARED_VALIDATE: u32 = 3;
+pub const MAP_DROPPABLE: u32 = 8;
 pub const MAP_HUGE_SHIFT: u32 = 26;
 pub const MAP_HUGE_MASK: u32 = 63;
 pub const MAP_HUGE_16KB: u32 = 939524096;
@@ -1965,6 +2032,8 @@ pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
 pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
+pub const STATX_SUBVOL: u32 = 32768;
+pub const STATX_WRITE_ATOMIC: u32 = 65536;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -1976,6 +2045,7 @@ pub const STATX_ATTR_AUTOMOUNT: u32 = 4096;
 pub const STATX_ATTR_MOUNT_ROOT: u32 = 8192;
 pub const STATX_ATTR_VERITY: u32 = 1048576;
 pub const STATX_ATTR_DAX: u32 = 2097152;
+pub const STATX_ATTR_WRITE_ATOMIC: u32 = 4194304;
 pub const IGNBRK: u32 = 1;
 pub const BRKINT: u32 = 2;
 pub const IGNPAR: u32 = 4;
@@ -2188,7 +2258,7 @@ pub const __NR_epoll_ctl: u32 = 21;
 pub const __NR_epoll_pwait: u32 = 22;
 pub const __NR_dup: u32 = 23;
 pub const __NR_dup3: u32 = 24;
-pub const __NR3264_fcntl: u32 = 25;
+pub const __NR_fcntl: u32 = 25;
 pub const __NR_inotify_init1: u32 = 26;
 pub const __NR_inotify_add_watch: u32 = 27;
 pub const __NR_inotify_rm_watch: u32 = 28;
@@ -2205,10 +2275,10 @@ pub const __NR_umount2: u32 = 39;
 pub const __NR_mount: u32 = 40;
 pub const __NR_pivot_root: u32 = 41;
 pub const __NR_nfsservctl: u32 = 42;
-pub const __NR3264_statfs: u32 = 43;
-pub const __NR3264_fstatfs: u32 = 44;
-pub const __NR3264_truncate: u32 = 45;
-pub const __NR3264_ftruncate: u32 = 46;
+pub const __NR_statfs: u32 = 43;
+pub const __NR_fstatfs: u32 = 44;
+pub const __NR_truncate: u32 = 45;
+pub const __NR_ftruncate: u32 = 46;
 pub const __NR_fallocate: u32 = 47;
 pub const __NR_faccessat: u32 = 48;
 pub const __NR_chdir: u32 = 49;
@@ -2224,7 +2294,7 @@ pub const __NR_vhangup: u32 = 58;
 pub const __NR_pipe2: u32 = 59;
 pub const __NR_quotactl: u32 = 60;
 pub const __NR_getdents64: u32 = 61;
-pub const __NR3264_lseek: u32 = 62;
+pub const __NR_lseek: u32 = 62;
 pub const __NR_read: u32 = 63;
 pub const __NR_write: u32 = 64;
 pub const __NR_readv: u32 = 65;
@@ -2233,7 +2303,7 @@ pub const __NR_pread64: u32 = 67;
 pub const __NR_pwrite64: u32 = 68;
 pub const __NR_preadv: u32 = 69;
 pub const __NR_pwritev: u32 = 70;
-pub const __NR3264_sendfile: u32 = 71;
+pub const __NR_sendfile: u32 = 71;
 pub const __NR_pselect6: u32 = 72;
 pub const __NR_ppoll: u32 = 73;
 pub const __NR_signalfd4: u32 = 74;
@@ -2241,8 +2311,8 @@ pub const __NR_vmsplice: u32 = 75;
 pub const __NR_splice: u32 = 76;
 pub const __NR_tee: u32 = 77;
 pub const __NR_readlinkat: u32 = 78;
-pub const __NR3264_fstatat: u32 = 79;
-pub const __NR3264_fstat: u32 = 80;
+pub const __NR_newfstatat: u32 = 79;
+pub const __NR_fstat: u32 = 80;
 pub const __NR_sync: u32 = 81;
 pub const __NR_fsync: u32 = 82;
 pub const __NR_fdatasync: u32 = 83;
@@ -2384,8 +2454,8 @@ pub const __NR_request_key: u32 = 218;
 pub const __NR_keyctl: u32 = 219;
 pub const __NR_clone: u32 = 220;
 pub const __NR_execve: u32 = 221;
-pub const __NR3264_mmap: u32 = 222;
-pub const __NR3264_fadvise64: u32 = 223;
+pub const __NR_mmap: u32 = 222;
+pub const __NR_fadvise64: u32 = 223;
 pub const __NR_swapon: u32 = 224;
 pub const __NR_swapoff: u32 = 225;
 pub const __NR_mprotect: u32 = 226;
@@ -2406,7 +2476,8 @@ pub const __NR_rt_tgsigqueueinfo: u32 = 240;
 pub const __NR_perf_event_open: u32 = 241;
 pub const __NR_accept4: u32 = 242;
 pub const __NR_recvmmsg: u32 = 243;
-pub const __NR_arch_specific_syscall: u32 = 244;
+pub const __NR_riscv_hwprobe: u32 = 258;
+pub const __NR_riscv_flush_icache: u32 = 259;
 pub const __NR_wait4: u32 = 260;
 pub const __NR_prlimit64: u32 = 261;
 pub const __NR_fanotify_init: u32 = 262;
@@ -2480,20 +2551,7 @@ pub const __NR_listmount: u32 = 458;
 pub const __NR_lsm_get_self_attr: u32 = 459;
 pub const __NR_lsm_set_self_attr: u32 = 460;
 pub const __NR_lsm_list_modules: u32 = 461;
-pub const __NR_syscalls: u32 = 462;
-pub const __NR_fcntl: u32 = 25;
-pub const __NR_statfs: u32 = 43;
-pub const __NR_fstatfs: u32 = 44;
-pub const __NR_truncate: u32 = 45;
-pub const __NR_ftruncate: u32 = 46;
-pub const __NR_lseek: u32 = 62;
-pub const __NR_sendfile: u32 = 71;
-pub const __NR_newfstatat: u32 = 79;
-pub const __NR_fstat: u32 = 80;
-pub const __NR_mmap: u32 = 222;
-pub const __NR_fadvise64: u32 = 223;
-pub const __NR_riscv_flush_icache: u32 = 259;
-pub const __NR_riscv_hwprobe: u32 = 258;
+pub const __NR_mseal: u32 = 462;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
 pub const WSTOPPED: u32 = 2;
@@ -2678,6 +2736,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/riscv64/if_arp.rs
+++ b/src/riscv64/if_arp.rs
@@ -612,6 +612,7 @@ pub ar_hln: crate::ctypes::c_uchar,
 pub ar_pln: crate::ctypes::c_uchar,
 pub ar_op: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1381,6 +1382,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
@@ -1414,6 +1417,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1515,6 +1519,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
@@ -2281,7 +2286,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2319,7 +2326,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2495,7 +2503,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/riscv64/if_ether.rs
+++ b/src/riscv64/if_ether.rs
@@ -57,6 +57,7 @@ pub h_dest: [crate::ctypes::c_uchar; 6usize],
 pub h_source: [crate::ctypes::c_uchar; 6usize],
 pub h_proto: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const ETH_ALEN: u32 = 6;
 pub const ETH_TLEN: u32 = 2;
 pub const ETH_HLEN: u32 = 14;

--- a/src/riscv64/if_packet.rs
+++ b/src/riscv64/if_packet.rs
@@ -205,6 +205,7 @@ pub type_flags: __u16,
 pub max_num_members: __u32,
 }
 pub const __LITTLE_ENDIAN: u32 = 1234;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PACKET_HOST: u32 = 0;
 pub const PACKET_BROADCAST: u32 = 1;
 pub const PACKET_MULTICAST: u32 = 2;

--- a/src/riscv64/io_uring.rs
+++ b/src/riscv64/io_uring.rs
@@ -140,7 +140,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -158,7 +158,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -168,6 +169,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -183,6 +185,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -249,6 +263,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -492,6 +525,14 @@ pub resv: [__u32; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_napi {
+pub busy_poll_to: __u32,
+pub prefer_busy_poll: __u8,
+pub pad: [__u8; 3usize],
+pub resv: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -557,6 +598,7 @@ pub const IOC_OUT: u32 = 2147483648;
 pub const IOC_INOUT: u32 = 3221225472;
 pub const IOCSIZE_MASK: u32 = 1073676288;
 pub const IOCSIZE_SHIFT: u32 = 16;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const FSCRYPT_POLICY_FLAGS_PAD_4: u32 = 0;
 pub const FSCRYPT_POLICY_FLAGS_PAD_8: u32 = 1;
 pub const FSCRYPT_POLICY_FLAGS_PAD_16: u32 = 2;
@@ -671,13 +713,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -749,6 +795,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -804,15 +851,20 @@ pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
 pub const IORING_SEND_ZC_REPORT_USAGE: u32 = 8;
+pub const IORING_RECVSEND_BUNDLE: u32 = 16;
 pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
+pub const IORING_ACCEPT_DONTWAIT: u32 = 2;
+pub const IORING_ACCEPT_POLL_FIRST: u32 = 4;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
 pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
+pub const IORING_NOP_INJECT_RESULT: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
 pub const IORING_CQE_F_NOTIF: u32 = 8;
+pub const IORING_CQE_BUFFER_SHIFT: u32 = 16;
 pub const IORING_OFF_SQ_RING: u32 = 0;
 pub const IORING_OFF_CQ_RING: u32 = 134217728;
 pub const IORING_OFF_SQES: u32 = 268435456;
@@ -842,60 +894,10 @@ pub const IORING_FEAT_RSRC_TAGS: u32 = 1024;
 pub const IORING_FEAT_CQE_SKIP: u32 = 2048;
 pub const IORING_FEAT_LINKED_FILE: u32 = 4096;
 pub const IORING_FEAT_REG_REG_RING: u32 = 8192;
+pub const IORING_FEAT_RECVSEND_BUNDLE: u32 = 16384;
 pub const IORING_RSRC_REGISTER_SPARSE: u32 = 1;
 pub const IORING_REGISTER_FILES_SKIP: i32 = -2;
 pub const IO_URING_OP_SUPPORTED: u32 = 1;
-pub const IOSQE_FIXED_FILE_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_FIXED_FILE_BIT;
-pub const IOSQE_IO_DRAIN_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_DRAIN_BIT;
-pub const IOSQE_IO_LINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_LINK_BIT;
-pub const IOSQE_IO_HARDLINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_HARDLINK_BIT;
-pub const IOSQE_ASYNC_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_ASYNC_BIT;
-pub const IOSQE_BUFFER_SELECT_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_BUFFER_SELECT_BIT;
-pub const IOSQE_CQE_SKIP_SUCCESS_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_CQE_SKIP_SUCCESS_BIT;
-pub const IORING_MSG_DATA: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_DATA;
-pub const IORING_MSG_SEND_FD: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_SEND_FD;
-pub const IORING_CQE_BUFFER_SHIFT: _bindgen_ty_3 = _bindgen_ty_3::IORING_CQE_BUFFER_SHIFT;
-pub const IORING_REGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS;
-pub const IORING_UNREGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_BUFFERS;
-pub const IORING_REGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES;
-pub const IORING_UNREGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_FILES;
-pub const IORING_REGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD;
-pub const IORING_UNREGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_EVENTFD;
-pub const IORING_REGISTER_FILES_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE;
-pub const IORING_REGISTER_EVENTFD_ASYNC: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD_ASYNC;
-pub const IORING_REGISTER_PROBE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PROBE;
-pub const IORING_REGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PERSONALITY;
-pub const IORING_UNREGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PERSONALITY;
-pub const IORING_REGISTER_RESTRICTIONS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RESTRICTIONS;
-pub const IORING_REGISTER_ENABLE_RINGS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_ENABLE_RINGS;
-pub const IORING_REGISTER_FILES2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES2;
-pub const IORING_REGISTER_FILES_UPDATE2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE2;
-pub const IORING_REGISTER_BUFFERS2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS2;
-pub const IORING_REGISTER_BUFFERS_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS_UPDATE;
-pub const IORING_REGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_AFF;
-pub const IORING_UNREGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_IOWQ_AFF;
-pub const IORING_REGISTER_IOWQ_MAX_WORKERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_MAX_WORKERS;
-pub const IORING_REGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RING_FDS;
-pub const IORING_UNREGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_RING_FDS;
-pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_RING;
-pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
-pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
-pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
-pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
-pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
-pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
-pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
-pub const IO_WQ_UNBOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_UNBOUND;
-pub const IOU_PBUF_RING_MMAP: _bindgen_ty_6 = _bindgen_ty_6::IOU_PBUF_RING_MMAP;
-pub const IORING_RESTRICTION_REGISTER_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_REGISTER_OP;
-pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_OP;
-pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
-pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
-pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
-pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
-pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
-pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
-pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -913,7 +915,18 @@ FSCONFIG_CMD_CREATE_EXCL = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_1 {
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum io_uring_sqe_flags_bit {
 IOSQE_FIXED_FILE_BIT = 0,
 IOSQE_IO_DRAIN_BIT = 1,
 IOSQE_IO_LINK_BIT = 2,
@@ -981,25 +994,22 @@ IORING_OP_FUTEX_WAIT = 51,
 IORING_OP_FUTEX_WAKE = 52,
 IORING_OP_FUTEX_WAITV = 53,
 IORING_OP_FIXED_FD_INSTALL = 54,
-IORING_OP_LAST = 55,
+IORING_OP_FTRUNCATE = 55,
+IORING_OP_BIND = 56,
+IORING_OP_LISTEN = 57,
+IORING_OP_LAST = 58,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_2 {
+pub enum io_uring_msg_ring_flags {
 IORING_MSG_DATA = 0,
 IORING_MSG_SEND_FD = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_3 {
-IORING_CQE_BUFFER_SHIFT = 16,
-}
-#[repr(u32)]
-#[non_exhaustive]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_4 {
+pub enum io_uring_register_op {
 IORING_REGISTER_BUFFERS = 0,
 IORING_UNREGISTER_BUFFERS = 1,
 IORING_REGISTER_FILES = 2,
@@ -1027,26 +1037,28 @@ IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
 IORING_REGISTER_PBUF_STATUS = 26,
-IORING_REGISTER_LAST = 27,
+IORING_REGISTER_NAPI = 27,
+IORING_UNREGISTER_NAPI = 28,
+IORING_REGISTER_LAST = 29,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_5 {
+pub enum io_wq_type {
 IO_WQ_BOUND = 0,
 IO_WQ_UNBOUND = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_6 {
+pub enum io_uring_register_pbuf_ring_flags {
 IOU_PBUF_RING_MMAP = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_7 {
+pub enum io_uring_register_restriction_op {
 IORING_RESTRICTION_REGISTER_OP = 0,
 IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
@@ -1056,7 +1068,7 @@ IORING_RESTRICTION_LAST = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_8 {
+pub enum io_uring_socket_op {
 SOCKET_URING_OP_SIOCINQ = 0,
 SOCKET_URING_OP_SIOCOUTQ = 1,
 SOCKET_URING_OP_GETSOCKOPT = 2,
@@ -1115,6 +1127,7 @@ pub uring_cmd_flags: __u32,
 pub waitid_flags: __u32,
 pub futex_flags: __u32,
 pub install_fd_flags: __u32,
+pub nop_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]

--- a/src/riscv64/loop_device.rs
+++ b/src/riscv64/loop_device.rs
@@ -93,6 +93,7 @@ pub __reserved: [__u64; 8usize],
 }
 pub const LO_NAME_SIZE: u32 = 64;
 pub const LO_KEY_SIZE: u32 = 32;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const LO_CRYPT_NONE: u32 = 0;
 pub const LO_CRYPT_XOR: u32 = 1;
 pub const LO_CRYPT_DES: u32 = 2;

--- a/src/riscv64/mempolicy.rs
+++ b/src/riscv64/mempolicy.rs
@@ -158,6 +158,7 @@ pub const MPOL_BIND: _bindgen_ty_1 = _bindgen_ty_1::MPOL_BIND;
 pub const MPOL_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_INTERLEAVE;
 pub const MPOL_LOCAL: _bindgen_ty_1 = _bindgen_ty_1::MPOL_LOCAL;
 pub const MPOL_PREFERRED_MANY: _bindgen_ty_1 = _bindgen_ty_1::MPOL_PREFERRED_MANY;
+pub const MPOL_WEIGHTED_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_WEIGHTED_INTERLEAVE;
 pub const MPOL_MAX: _bindgen_ty_1 = _bindgen_ty_1::MPOL_MAX;
 #[repr(u32)]
 #[non_exhaustive]
@@ -169,5 +170,6 @@ MPOL_BIND = 2,
 MPOL_INTERLEAVE = 3,
 MPOL_LOCAL = 4,
 MPOL_PREFERRED_MANY = 5,
-MPOL_MAX = 6,
+MPOL_WEIGHTED_INTERLEAVE = 6,
+MPOL_MAX = 7,
 }

--- a/src/riscv64/net.rs
+++ b/src/riscv64/net.rs
@@ -854,6 +854,7 @@ pub _address: u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1267,6 +1268,7 @@ pub const TCP_AO_DEL_KEY: u32 = 39;
 pub const TCP_AO_INFO: u32 = 40;
 pub const TCP_AO_GET_KEYS: u32 = 41;
 pub const TCP_AO_REPAIR: u32 = 42;
+pub const TCP_IS_MPTCP: u32 = 43;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1553,6 +1555,7 @@ pub const IPPROTO_UDPLITE: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_UDPLITE;
 pub const IPPROTO_MPLS: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPLS;
 pub const IPPROTO_ETHERNET: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ETHERNET;
 pub const IPPROTO_RAW: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_RAW;
+pub const IPPROTO_SMC: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_SMC;
 pub const IPPROTO_MPTCP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPTCP;
 pub const IPPROTO_MAX: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MAX;
 pub const IPV4_DEVCONF_FORWARDING: _bindgen_ty_2 = _bindgen_ty_2::IPV4_DEVCONF_FORWARDING;
@@ -1741,6 +1744,7 @@ IPPROTO_UDPLITE = 136,
 IPPROTO_MPLS = 137,
 IPPROTO_ETHERNET = 143,
 IPPROTO_RAW = 255,
+IPPROTO_SMC = 256,
 IPPROTO_MPTCP = 262,
 IPPROTO_MAX = 263,
 }

--- a/src/riscv64/netlink.rs
+++ b/src/riscv64/netlink.rs
@@ -549,6 +549,7 @@ pub const SOCK_BUF_LOCK_MASK: u32 = 3;
 pub const SOCK_TXREHASH_DEFAULT: u32 = 255;
 pub const SOCK_TXREHASH_DISABLED: u32 = 0;
 pub const SOCK_TXREHASH_ENABLED: u32 = 1;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const NETLINK_ROUTE: u32 = 0;
 pub const NETLINK_UNUSED: u32 = 1;
 pub const NETLINK_USERSOCK: u32 = 2;
@@ -1096,6 +1097,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
@@ -1129,6 +1132,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1230,6 +1234,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
@@ -2144,7 +2149,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2182,7 +2189,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2358,7 +2366,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/riscv64/prctl.rs
+++ b/src/riscv64/prctl.rs
@@ -68,6 +68,7 @@ pub auxv: *mut __u64,
 pub auxv_size: __u32,
 pub exe_fd: __u32,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PR_SET_PDEATHSIG: u32 = 1;
 pub const PR_GET_PDEATHSIG: u32 = 2;
 pub const PR_GET_DUMPABLE: u32 = 3;
@@ -234,3 +235,20 @@ pub const PR_RISCV_V_VSTATE_CTRL_INHERIT: u32 = 16;
 pub const PR_RISCV_V_VSTATE_CTRL_CUR_MASK: u32 = 3;
 pub const PR_RISCV_V_VSTATE_CTRL_NEXT_MASK: u32 = 12;
 pub const PR_RISCV_V_VSTATE_CTRL_MASK: u32 = 31;
+pub const PR_RISCV_SET_ICACHE_FLUSH_CTX: u32 = 71;
+pub const PR_RISCV_CTX_SW_FENCEI_ON: u32 = 0;
+pub const PR_RISCV_CTX_SW_FENCEI_OFF: u32 = 1;
+pub const PR_RISCV_SCOPE_PER_PROCESS: u32 = 0;
+pub const PR_RISCV_SCOPE_PER_THREAD: u32 = 1;
+pub const PR_PPC_GET_DEXCR: u32 = 72;
+pub const PR_PPC_SET_DEXCR: u32 = 73;
+pub const PR_PPC_DEXCR_SBHE: u32 = 0;
+pub const PR_PPC_DEXCR_IBRTPD: u32 = 1;
+pub const PR_PPC_DEXCR_SRAPD: u32 = 2;
+pub const PR_PPC_DEXCR_NPHIE: u32 = 3;
+pub const PR_PPC_DEXCR_CTRL_EDITABLE: u32 = 1;
+pub const PR_PPC_DEXCR_CTRL_SET: u32 = 2;
+pub const PR_PPC_DEXCR_CTRL_CLEAR: u32 = 4;
+pub const PR_PPC_DEXCR_CTRL_SET_ONEXEC: u32 = 8;
+pub const PR_PPC_DEXCR_CTRL_CLEAR_ONEXEC: u32 = 16;
+pub const PR_PPC_DEXCR_CTRL_MASK: u32 = 31;

--- a/src/riscv64/system.rs
+++ b/src/riscv64/system.rs
@@ -99,6 +99,7 @@ pub version: [crate::ctypes::c_char; 65usize],
 pub machine: [crate::ctypes::c_char; 65usize],
 pub domainname: [crate::ctypes::c_char; 65usize],
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const SI_LOAD_SHIFT: u32 = 16;
 pub const __OLD_UTS_LEN: u32 = 8;
 pub const __NEW_UTS_LEN: u32 = 64;

--- a/src/riscv64/xdp.rs
+++ b/src/riscv64/xdp.rs
@@ -154,6 +154,7 @@ pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,
 pub tx_invalid_descs: __u64,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
@@ -161,6 +162,7 @@ pub const XDP_USE_NEED_WAKEUP: u32 = 8;
 pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
 pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
+pub const XDP_UMEM_TX_METADATA_LEN: u32 = 4;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;

--- a/src/s390x/btrfs.rs
+++ b/src/s390x/btrfs.rs
@@ -152,7 +152,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -170,7 +170,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -180,6 +181,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -195,6 +197,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -261,6 +275,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -871,10 +904,17 @@ pub physical: __le64,
 }
 #[repr(C, packed)]
 pub struct btrfs_stripe_extent {
-pub encoding: __u8,
-pub reserved: [__u8; 7usize],
+pub __bindgen_anon_1: btrfs_stripe_extent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct btrfs_stripe_extent__bindgen_ty_1 {
+pub __empty_strides: btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1,
 pub strides: __IncompleteArrayField<btrfs_raid_stride>,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct btrfs_extent_item {
@@ -1143,6 +1183,7 @@ pub encryption: __u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _IOC_NRBITS: u32 = 8;
 pub const _IOC_TYPEBITS: u32 = 8;
 pub const _IOC_SIZEBITS: u32 = 14;
@@ -1290,13 +1331,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1368,6 +1413,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1400,6 +1446,7 @@ pub const BTRFS_QGROUP_LIMIT_RSV_EXCL: u32 = 8;
 pub const BTRFS_QGROUP_LIMIT_RFER_CMPR: u32 = 16;
 pub const BTRFS_QGROUP_LIMIT_EXCL_CMPR: u32 = 32;
 pub const BTRFS_QGROUP_INHERIT_SET_LIMITS: u32 = 1;
+pub const BTRFS_QGROUP_INHERIT_FLAGS_SUPP: u32 = 1;
 pub const BTRFS_DEVICE_REMOVE_ARGS_MASK: u32 = 8;
 pub const BTRFS_SUBVOL_CREATE_ARGS_MASK: u32 = 6;
 pub const BTRFS_SUBVOL_DELETE_ARGS_MASK: u32 = 16;
@@ -1605,14 +1652,6 @@ pub const BTRFS_SYSTEM_CHUNK_ARRAY_SIZE: u32 = 2048;
 pub const BTRFS_NUM_BACKUP_ROOTS: u32 = 4;
 pub const BTRFS_FREE_SPACE_EXTENT: u32 = 1;
 pub const BTRFS_FREE_SPACE_BITMAP: u32 = 2;
-pub const BTRFS_STRIPE_RAID0: u32 = 1;
-pub const BTRFS_STRIPE_RAID1: u32 = 2;
-pub const BTRFS_STRIPE_DUP: u32 = 3;
-pub const BTRFS_STRIPE_RAID10: u32 = 4;
-pub const BTRFS_STRIPE_RAID5: u32 = 5;
-pub const BTRFS_STRIPE_RAID6: u32 = 6;
-pub const BTRFS_STRIPE_RAID1C3: u32 = 7;
-pub const BTRFS_STRIPE_RAID1C4: u32 = 8;
 pub const BTRFS_HEADER_FLAG_WRITTEN: u32 = 1;
 pub const BTRFS_HEADER_FLAG_RELOC: u32 = 2;
 pub const BTRFS_SUPER_FLAG_ERROR: u32 = 4;
@@ -1621,6 +1660,9 @@ pub const BTRFS_SUPER_FLAG_METADUMP: u64 = 8589934592;
 pub const BTRFS_SUPER_FLAG_METADUMP_V2: u64 = 17179869184;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID: u64 = 34359738368;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID_V2: u64 = 68719476736;
+pub const BTRFS_SUPER_FLAG_CHANGING_BG_TREE: u64 = 274877906944;
+pub const BTRFS_SUPER_FLAG_CHANGING_DATA_CSUM: u64 = 549755813888;
+pub const BTRFS_SUPER_FLAG_CHANGING_META_CSUM: u64 = 1099511627776;
 pub const BTRFS_EXTENT_FLAG_DATA: u32 = 1;
 pub const BTRFS_EXTENT_FLAG_TREE_BLOCK: u32 = 2;
 pub const BTRFS_BLOCK_FLAG_FULL_BACKREF: u32 = 256;
@@ -1676,6 +1718,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/s390x/general.rs
+++ b/src/s390x/general.rs
@@ -177,6 +177,14 @@ pub data: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct epoll_params {
+pub busy_poll_usecs: __u32,
+pub busy_poll_budget: __u16,
+pub prefer_busy_poll: __u8,
+pub __pad: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct fscrypt_policy_v1 {
 pub version: __u8,
 pub contents_encryption_mode: __u8,
@@ -259,7 +267,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -277,7 +285,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -287,6 +296,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -302,6 +312,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -371,6 +393,25 @@ pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct futex_waitv {
 pub val: __u64,
 pub uaddr: __u64,
@@ -426,6 +467,14 @@ pub struct rand_pool_info {
 pub entropy_count: crate::ctypes::c_int,
 pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vgetrandom_opaque_params {
+pub size_of_opaque_state: __u32,
+pub mmap_prot: __u32,
+pub mmap_flags: __u32,
+pub reserved: [__u32; 13usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -689,7 +738,12 @@ pub stx_dev_minor: __u32,
 pub stx_mnt_id: __u64,
 pub stx_dio_mem_align: __u32,
 pub stx_dio_offset_align: __u32,
-pub __spare3: [__u64; 12usize],
+pub stx_subvol: __u64,
+pub stx_atomic_write_unit_min: __u32,
+pub stx_atomic_write_unit_max: __u32,
+pub stx_atomic_write_segments_max: __u32,
+pub __spare1: [__u32; 1usize],
+pub __spare3: [__u64; 9usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -941,9 +995,9 @@ pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 395264;
+pub const LINUX_VERSION_CODE: u32 = 396032;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 11;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_VECTOR_SIZE_ARCH: u32 = 1;
@@ -971,8 +1025,11 @@ pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_RSEQ_FEATURE_SIZE: u32 = 27;
 pub const AT_RSEQ_ALIGN: u32 = 28;
+pub const AT_HWCAP3: u32 = 29;
+pub const AT_HWCAP4: u32 = 30;
 pub const AT_EXECFN: u32 = 31;
 pub const AT_MINSIGSTKSZ: u32 = 51;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
 pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
@@ -1104,9 +1161,10 @@ pub const RESOLVE_IN_ROOT: u32 = 16;
 pub const RESOLVE_CACHED: u32 = 32;
 pub const F_SETLEASE: u32 = 1024;
 pub const F_GETLEASE: u32 = 1025;
+pub const F_NOTIFY: u32 = 1026;
+pub const F_DUPFD_QUERY: u32 = 1027;
 pub const F_CANCELLK: u32 = 1029;
 pub const F_DUPFD_CLOEXEC: u32 = 1030;
-pub const F_NOTIFY: u32 = 1026;
 pub const F_SETPIPE_SZ: u32 = 1031;
 pub const F_GETPIPE_SZ: u32 = 1032;
 pub const F_ADD_SEALS: u32 = 1033;
@@ -1152,6 +1210,7 @@ pub const EPOLL_CLOEXEC: u32 = 524288;
 pub const EPOLL_CTL_ADD: u32 = 1;
 pub const EPOLL_CTL_DEL: u32 = 2;
 pub const EPOLL_CTL_MOD: u32 = 3;
+pub const EPOLL_IOC_TYPE: u32 = 138;
 pub const POSIX_FADV_NORMAL: u32 = 0;
 pub const POSIX_FADV_RANDOM: u32 = 1;
 pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
@@ -1313,13 +1372,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1391,6 +1454,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1519,6 +1583,7 @@ pub const EFIVARFS_MAGIC: u32 = 3730735588;
 pub const HOSTFS_SUPER_MAGIC: u32 = 12648430;
 pub const OVERLAYFS_SUPER_MAGIC: u32 = 2035054128;
 pub const FUSE_SUPER_MAGIC: u32 = 1702057286;
+pub const BCACHEFS_SUPER_MAGIC: u32 = 3393526350;
 pub const MINIX_SUPER_MAGIC: u32 = 4991;
 pub const MINIX_SUPER_MAGIC2: u32 = 5007;
 pub const MINIX2_SUPER_MAGIC: u32 = 9320;
@@ -1568,6 +1633,7 @@ pub const UDF_SUPER_MAGIC: u32 = 352400198;
 pub const DMA_BUF_MAGIC: u32 = 1145913666;
 pub const DEVMEM_MAGIC: u32 = 1162691661;
 pub const SECRETMEM_MAGIC: u32 = 1397048141;
+pub const PID_FS_MAGIC: u32 = 1346978886;
 pub const PROT_READ: u32 = 1;
 pub const PROT_WRITE: u32 = 2;
 pub const PROT_EXEC: u32 = 4;
@@ -1650,6 +1716,7 @@ pub const OVERCOMMIT_NEVER: u32 = 2;
 pub const MAP_SHARED: u32 = 1;
 pub const MAP_PRIVATE: u32 = 2;
 pub const MAP_SHARED_VALIDATE: u32 = 3;
+pub const MAP_DROPPABLE: u32 = 8;
 pub const MAP_HUGE_SHIFT: u32 = 26;
 pub const MAP_HUGE_MASK: u32 = 63;
 pub const MAP_HUGE_16KB: u32 = 939524096;
@@ -1975,6 +2042,8 @@ pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
 pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
+pub const STATX_SUBVOL: u32 = 32768;
+pub const STATX_WRITE_ATOMIC: u32 = 65536;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -1986,6 +2055,7 @@ pub const STATX_ATTR_AUTOMOUNT: u32 = 4096;
 pub const STATX_ATTR_MOUNT_ROOT: u32 = 8192;
 pub const STATX_ATTR_VERITY: u32 = 1048576;
 pub const STATX_ATTR_DAX: u32 = 2097152;
+pub const STATX_ATTR_WRITE_ATOMIC: u32 = 4194304;
 pub const IGNBRK: u32 = 1;
 pub const BRKINT: u32 = 2;
 pub const IGNPAR: u32 = 4;
@@ -2534,6 +2604,7 @@ pub const __NR_listmount: u32 = 458;
 pub const __NR_lsm_get_self_attr: u32 = 459;
 pub const __NR_lsm_set_self_attr: u32 = 460;
 pub const __NR_lsm_list_modules: u32 = 461;
+pub const __NR_mseal: u32 = 462;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
 pub const WSTOPPED: u32 = 2;
@@ -2719,6 +2790,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/s390x/if_arp.rs
+++ b/src/s390x/if_arp.rs
@@ -626,6 +626,7 @@ pub ar_hln: crate::ctypes::c_uchar,
 pub ar_pln: crate::ctypes::c_uchar,
 pub ar_op: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1395,6 +1396,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
@@ -1428,6 +1431,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1529,6 +1533,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
@@ -2295,7 +2300,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2333,7 +2340,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2509,7 +2517,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/s390x/if_ether.rs
+++ b/src/s390x/if_ether.rs
@@ -71,6 +71,7 @@ pub h_dest: [crate::ctypes::c_uchar; 6usize],
 pub h_source: [crate::ctypes::c_uchar; 6usize],
 pub h_proto: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const ETH_ALEN: u32 = 6;
 pub const ETH_TLEN: u32 = 2;
 pub const ETH_HLEN: u32 = 14;

--- a/src/s390x/if_packet.rs
+++ b/src/s390x/if_packet.rs
@@ -219,6 +219,7 @@ pub id: __u16,
 pub max_num_members: __u32,
 }
 pub const __BIG_ENDIAN: u32 = 4321;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PACKET_HOST: u32 = 0;
 pub const PACKET_BROADCAST: u32 = 1;
 pub const PACKET_MULTICAST: u32 = 2;

--- a/src/s390x/io_uring.rs
+++ b/src/s390x/io_uring.rs
@@ -154,7 +154,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -172,7 +172,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -182,6 +183,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -197,6 +199,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -263,6 +277,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -506,6 +539,14 @@ pub resv: [__u32; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_napi {
+pub busy_poll_to: __u32,
+pub prefer_busy_poll: __u8,
+pub pad: [__u8; 3usize],
+pub resv: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -571,6 +612,7 @@ pub const IOC_OUT: u32 = 2147483648;
 pub const IOC_INOUT: u32 = 3221225472;
 pub const IOCSIZE_MASK: u32 = 1073676288;
 pub const IOCSIZE_SHIFT: u32 = 16;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const FSCRYPT_POLICY_FLAGS_PAD_4: u32 = 0;
 pub const FSCRYPT_POLICY_FLAGS_PAD_8: u32 = 1;
 pub const FSCRYPT_POLICY_FLAGS_PAD_16: u32 = 2;
@@ -685,13 +727,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -763,6 +809,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -818,15 +865,20 @@ pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
 pub const IORING_SEND_ZC_REPORT_USAGE: u32 = 8;
+pub const IORING_RECVSEND_BUNDLE: u32 = 16;
 pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
+pub const IORING_ACCEPT_DONTWAIT: u32 = 2;
+pub const IORING_ACCEPT_POLL_FIRST: u32 = 4;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
 pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
+pub const IORING_NOP_INJECT_RESULT: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
 pub const IORING_CQE_F_NOTIF: u32 = 8;
+pub const IORING_CQE_BUFFER_SHIFT: u32 = 16;
 pub const IORING_OFF_SQ_RING: u32 = 0;
 pub const IORING_OFF_CQ_RING: u32 = 134217728;
 pub const IORING_OFF_SQES: u32 = 268435456;
@@ -856,60 +908,10 @@ pub const IORING_FEAT_RSRC_TAGS: u32 = 1024;
 pub const IORING_FEAT_CQE_SKIP: u32 = 2048;
 pub const IORING_FEAT_LINKED_FILE: u32 = 4096;
 pub const IORING_FEAT_REG_REG_RING: u32 = 8192;
+pub const IORING_FEAT_RECVSEND_BUNDLE: u32 = 16384;
 pub const IORING_RSRC_REGISTER_SPARSE: u32 = 1;
 pub const IORING_REGISTER_FILES_SKIP: i32 = -2;
 pub const IO_URING_OP_SUPPORTED: u32 = 1;
-pub const IOSQE_FIXED_FILE_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_FIXED_FILE_BIT;
-pub const IOSQE_IO_DRAIN_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_DRAIN_BIT;
-pub const IOSQE_IO_LINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_LINK_BIT;
-pub const IOSQE_IO_HARDLINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_HARDLINK_BIT;
-pub const IOSQE_ASYNC_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_ASYNC_BIT;
-pub const IOSQE_BUFFER_SELECT_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_BUFFER_SELECT_BIT;
-pub const IOSQE_CQE_SKIP_SUCCESS_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_CQE_SKIP_SUCCESS_BIT;
-pub const IORING_MSG_DATA: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_DATA;
-pub const IORING_MSG_SEND_FD: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_SEND_FD;
-pub const IORING_CQE_BUFFER_SHIFT: _bindgen_ty_3 = _bindgen_ty_3::IORING_CQE_BUFFER_SHIFT;
-pub const IORING_REGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS;
-pub const IORING_UNREGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_BUFFERS;
-pub const IORING_REGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES;
-pub const IORING_UNREGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_FILES;
-pub const IORING_REGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD;
-pub const IORING_UNREGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_EVENTFD;
-pub const IORING_REGISTER_FILES_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE;
-pub const IORING_REGISTER_EVENTFD_ASYNC: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD_ASYNC;
-pub const IORING_REGISTER_PROBE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PROBE;
-pub const IORING_REGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PERSONALITY;
-pub const IORING_UNREGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PERSONALITY;
-pub const IORING_REGISTER_RESTRICTIONS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RESTRICTIONS;
-pub const IORING_REGISTER_ENABLE_RINGS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_ENABLE_RINGS;
-pub const IORING_REGISTER_FILES2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES2;
-pub const IORING_REGISTER_FILES_UPDATE2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE2;
-pub const IORING_REGISTER_BUFFERS2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS2;
-pub const IORING_REGISTER_BUFFERS_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS_UPDATE;
-pub const IORING_REGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_AFF;
-pub const IORING_UNREGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_IOWQ_AFF;
-pub const IORING_REGISTER_IOWQ_MAX_WORKERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_MAX_WORKERS;
-pub const IORING_REGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RING_FDS;
-pub const IORING_UNREGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_RING_FDS;
-pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_RING;
-pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
-pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
-pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
-pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
-pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
-pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
-pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
-pub const IO_WQ_UNBOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_UNBOUND;
-pub const IOU_PBUF_RING_MMAP: _bindgen_ty_6 = _bindgen_ty_6::IOU_PBUF_RING_MMAP;
-pub const IORING_RESTRICTION_REGISTER_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_REGISTER_OP;
-pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_OP;
-pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
-pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
-pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
-pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
-pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
-pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
-pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -927,7 +929,18 @@ FSCONFIG_CMD_CREATE_EXCL = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_1 {
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum io_uring_sqe_flags_bit {
 IOSQE_FIXED_FILE_BIT = 0,
 IOSQE_IO_DRAIN_BIT = 1,
 IOSQE_IO_LINK_BIT = 2,
@@ -995,25 +1008,22 @@ IORING_OP_FUTEX_WAIT = 51,
 IORING_OP_FUTEX_WAKE = 52,
 IORING_OP_FUTEX_WAITV = 53,
 IORING_OP_FIXED_FD_INSTALL = 54,
-IORING_OP_LAST = 55,
+IORING_OP_FTRUNCATE = 55,
+IORING_OP_BIND = 56,
+IORING_OP_LISTEN = 57,
+IORING_OP_LAST = 58,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_2 {
+pub enum io_uring_msg_ring_flags {
 IORING_MSG_DATA = 0,
 IORING_MSG_SEND_FD = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_3 {
-IORING_CQE_BUFFER_SHIFT = 16,
-}
-#[repr(u32)]
-#[non_exhaustive]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_4 {
+pub enum io_uring_register_op {
 IORING_REGISTER_BUFFERS = 0,
 IORING_UNREGISTER_BUFFERS = 1,
 IORING_REGISTER_FILES = 2,
@@ -1041,26 +1051,28 @@ IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
 IORING_REGISTER_PBUF_STATUS = 26,
-IORING_REGISTER_LAST = 27,
+IORING_REGISTER_NAPI = 27,
+IORING_UNREGISTER_NAPI = 28,
+IORING_REGISTER_LAST = 29,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_5 {
+pub enum io_wq_type {
 IO_WQ_BOUND = 0,
 IO_WQ_UNBOUND = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_6 {
+pub enum io_uring_register_pbuf_ring_flags {
 IOU_PBUF_RING_MMAP = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_7 {
+pub enum io_uring_register_restriction_op {
 IORING_RESTRICTION_REGISTER_OP = 0,
 IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
@@ -1070,7 +1082,7 @@ IORING_RESTRICTION_LAST = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_8 {
+pub enum io_uring_socket_op {
 SOCKET_URING_OP_SIOCINQ = 0,
 SOCKET_URING_OP_SIOCOUTQ = 1,
 SOCKET_URING_OP_GETSOCKOPT = 2,
@@ -1135,6 +1147,7 @@ pub uring_cmd_flags: __u32,
 pub waitid_flags: __u32,
 pub futex_flags: __u32,
 pub install_fd_flags: __u32,
+pub nop_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]

--- a/src/s390x/loop_device.rs
+++ b/src/s390x/loop_device.rs
@@ -107,6 +107,7 @@ pub __reserved: [__u64; 8usize],
 }
 pub const LO_NAME_SIZE: u32 = 64;
 pub const LO_KEY_SIZE: u32 = 32;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const LO_CRYPT_NONE: u32 = 0;
 pub const LO_CRYPT_XOR: u32 = 1;
 pub const LO_CRYPT_DES: u32 = 2;

--- a/src/s390x/mempolicy.rs
+++ b/src/s390x/mempolicy.rs
@@ -158,6 +158,7 @@ pub const MPOL_BIND: _bindgen_ty_1 = _bindgen_ty_1::MPOL_BIND;
 pub const MPOL_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_INTERLEAVE;
 pub const MPOL_LOCAL: _bindgen_ty_1 = _bindgen_ty_1::MPOL_LOCAL;
 pub const MPOL_PREFERRED_MANY: _bindgen_ty_1 = _bindgen_ty_1::MPOL_PREFERRED_MANY;
+pub const MPOL_WEIGHTED_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_WEIGHTED_INTERLEAVE;
 pub const MPOL_MAX: _bindgen_ty_1 = _bindgen_ty_1::MPOL_MAX;
 #[repr(u32)]
 #[non_exhaustive]
@@ -169,5 +170,6 @@ MPOL_BIND = 2,
 MPOL_INTERLEAVE = 3,
 MPOL_LOCAL = 4,
 MPOL_PREFERRED_MANY = 5,
-MPOL_MAX = 6,
+MPOL_WEIGHTED_INTERLEAVE = 6,
+MPOL_MAX = 7,
 }

--- a/src/s390x/net.rs
+++ b/src/s390x/net.rs
@@ -868,6 +868,7 @@ pub _address: u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1281,6 +1282,7 @@ pub const TCP_AO_DEL_KEY: u32 = 39;
 pub const TCP_AO_INFO: u32 = 40;
 pub const TCP_AO_GET_KEYS: u32 = 41;
 pub const TCP_AO_REPAIR: u32 = 42;
+pub const TCP_IS_MPTCP: u32 = 43;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1567,6 +1569,7 @@ pub const IPPROTO_UDPLITE: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_UDPLITE;
 pub const IPPROTO_MPLS: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPLS;
 pub const IPPROTO_ETHERNET: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ETHERNET;
 pub const IPPROTO_RAW: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_RAW;
+pub const IPPROTO_SMC: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_SMC;
 pub const IPPROTO_MPTCP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPTCP;
 pub const IPPROTO_MAX: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MAX;
 pub const IPV4_DEVCONF_FORWARDING: _bindgen_ty_2 = _bindgen_ty_2::IPV4_DEVCONF_FORWARDING;
@@ -1755,6 +1758,7 @@ IPPROTO_UDPLITE = 136,
 IPPROTO_MPLS = 137,
 IPPROTO_ETHERNET = 143,
 IPPROTO_RAW = 255,
+IPPROTO_SMC = 256,
 IPPROTO_MPTCP = 262,
 IPPROTO_MAX = 263,
 }

--- a/src/s390x/netlink.rs
+++ b/src/s390x/netlink.rs
@@ -563,6 +563,7 @@ pub const SOCK_BUF_LOCK_MASK: u32 = 3;
 pub const SOCK_TXREHASH_DEFAULT: u32 = 255;
 pub const SOCK_TXREHASH_DISABLED: u32 = 0;
 pub const SOCK_TXREHASH_ENABLED: u32 = 1;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const NETLINK_ROUTE: u32 = 0;
 pub const NETLINK_UNUSED: u32 = 1;
 pub const NETLINK_USERSOCK: u32 = 2;
@@ -1110,6 +1111,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
@@ -1143,6 +1146,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1244,6 +1248,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
@@ -2158,7 +2163,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2196,7 +2203,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2372,7 +2380,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/s390x/prctl.rs
+++ b/src/s390x/prctl.rs
@@ -82,6 +82,7 @@ pub auxv: *mut __u64,
 pub auxv_size: __u32,
 pub exe_fd: __u32,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PR_SET_PDEATHSIG: u32 = 1;
 pub const PR_GET_PDEATHSIG: u32 = 2;
 pub const PR_GET_DUMPABLE: u32 = 3;
@@ -248,6 +249,23 @@ pub const PR_RISCV_V_VSTATE_CTRL_INHERIT: u32 = 16;
 pub const PR_RISCV_V_VSTATE_CTRL_CUR_MASK: u32 = 3;
 pub const PR_RISCV_V_VSTATE_CTRL_NEXT_MASK: u32 = 12;
 pub const PR_RISCV_V_VSTATE_CTRL_MASK: u32 = 31;
+pub const PR_RISCV_SET_ICACHE_FLUSH_CTX: u32 = 71;
+pub const PR_RISCV_CTX_SW_FENCEI_ON: u32 = 0;
+pub const PR_RISCV_CTX_SW_FENCEI_OFF: u32 = 1;
+pub const PR_RISCV_SCOPE_PER_PROCESS: u32 = 0;
+pub const PR_RISCV_SCOPE_PER_THREAD: u32 = 1;
+pub const PR_PPC_GET_DEXCR: u32 = 72;
+pub const PR_PPC_SET_DEXCR: u32 = 73;
+pub const PR_PPC_DEXCR_SBHE: u32 = 0;
+pub const PR_PPC_DEXCR_IBRTPD: u32 = 1;
+pub const PR_PPC_DEXCR_SRAPD: u32 = 2;
+pub const PR_PPC_DEXCR_NPHIE: u32 = 3;
+pub const PR_PPC_DEXCR_CTRL_EDITABLE: u32 = 1;
+pub const PR_PPC_DEXCR_CTRL_SET: u32 = 2;
+pub const PR_PPC_DEXCR_CTRL_CLEAR: u32 = 4;
+pub const PR_PPC_DEXCR_CTRL_SET_ONEXEC: u32 = 8;
+pub const PR_PPC_DEXCR_CTRL_CLEAR_ONEXEC: u32 = 16;
+pub const PR_PPC_DEXCR_CTRL_MASK: u32 = 31;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union __vector128__bindgen_ty_1 {

--- a/src/s390x/system.rs
+++ b/src/s390x/system.rs
@@ -113,6 +113,7 @@ pub version: [crate::ctypes::c_char; 65usize],
 pub machine: [crate::ctypes::c_char; 65usize],
 pub domainname: [crate::ctypes::c_char; 65usize],
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const SI_LOAD_SHIFT: u32 = 16;
 pub const __OLD_UTS_LEN: u32 = 8;
 pub const __NEW_UTS_LEN: u32 = 64;

--- a/src/s390x/xdp.rs
+++ b/src/s390x/xdp.rs
@@ -168,6 +168,7 @@ pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,
 pub tx_invalid_descs: __u64,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
@@ -175,6 +176,7 @@ pub const XDP_USE_NEED_WAKEUP: u32 = 8;
 pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
 pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
+pub const XDP_UMEM_TX_METADATA_LEN: u32 = 4;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;

--- a/src/sparc/btrfs.rs
+++ b/src/sparc/btrfs.rs
@@ -136,7 +136,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -154,7 +154,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -164,6 +165,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -179,6 +181,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -245,6 +259,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -855,10 +888,17 @@ pub physical: __le64,
 }
 #[repr(C, packed)]
 pub struct btrfs_stripe_extent {
-pub encoding: __u8,
-pub reserved: [__u8; 7usize],
+pub __bindgen_anon_1: btrfs_stripe_extent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct btrfs_stripe_extent__bindgen_ty_1 {
+pub __empty_strides: btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1,
 pub strides: __IncompleteArrayField<btrfs_raid_stride>,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct btrfs_extent_item {
@@ -1127,6 +1167,7 @@ pub encryption: __u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _IOC_NRBITS: u32 = 8;
 pub const _IOC_TYPEBITS: u32 = 8;
 pub const _IOC_SIZEBITS: u32 = 13;
@@ -1275,13 +1316,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1353,6 +1398,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1385,6 +1431,7 @@ pub const BTRFS_QGROUP_LIMIT_RSV_EXCL: u32 = 8;
 pub const BTRFS_QGROUP_LIMIT_RFER_CMPR: u32 = 16;
 pub const BTRFS_QGROUP_LIMIT_EXCL_CMPR: u32 = 32;
 pub const BTRFS_QGROUP_INHERIT_SET_LIMITS: u32 = 1;
+pub const BTRFS_QGROUP_INHERIT_FLAGS_SUPP: u32 = 1;
 pub const BTRFS_DEVICE_REMOVE_ARGS_MASK: u32 = 8;
 pub const BTRFS_SUBVOL_CREATE_ARGS_MASK: u32 = 6;
 pub const BTRFS_SUBVOL_DELETE_ARGS_MASK: u32 = 16;
@@ -1590,14 +1637,6 @@ pub const BTRFS_SYSTEM_CHUNK_ARRAY_SIZE: u32 = 2048;
 pub const BTRFS_NUM_BACKUP_ROOTS: u32 = 4;
 pub const BTRFS_FREE_SPACE_EXTENT: u32 = 1;
 pub const BTRFS_FREE_SPACE_BITMAP: u32 = 2;
-pub const BTRFS_STRIPE_RAID0: u32 = 1;
-pub const BTRFS_STRIPE_RAID1: u32 = 2;
-pub const BTRFS_STRIPE_DUP: u32 = 3;
-pub const BTRFS_STRIPE_RAID10: u32 = 4;
-pub const BTRFS_STRIPE_RAID5: u32 = 5;
-pub const BTRFS_STRIPE_RAID6: u32 = 6;
-pub const BTRFS_STRIPE_RAID1C3: u32 = 7;
-pub const BTRFS_STRIPE_RAID1C4: u32 = 8;
 pub const BTRFS_HEADER_FLAG_WRITTEN: u32 = 1;
 pub const BTRFS_HEADER_FLAG_RELOC: u32 = 2;
 pub const BTRFS_SUPER_FLAG_ERROR: u32 = 4;
@@ -1606,6 +1645,9 @@ pub const BTRFS_SUPER_FLAG_METADUMP: u64 = 8589934592;
 pub const BTRFS_SUPER_FLAG_METADUMP_V2: u64 = 17179869184;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID: u64 = 34359738368;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID_V2: u64 = 68719476736;
+pub const BTRFS_SUPER_FLAG_CHANGING_BG_TREE: u64 = 274877906944;
+pub const BTRFS_SUPER_FLAG_CHANGING_DATA_CSUM: u64 = 549755813888;
+pub const BTRFS_SUPER_FLAG_CHANGING_META_CSUM: u64 = 1099511627776;
 pub const BTRFS_EXTENT_FLAG_DATA: u32 = 1;
 pub const BTRFS_EXTENT_FLAG_TREE_BLOCK: u32 = 2;
 pub const BTRFS_BLOCK_FLAG_FULL_BACKREF: u32 = 256;
@@ -1661,6 +1703,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/sparc/general.rs
+++ b/src/sparc/general.rs
@@ -162,6 +162,14 @@ pub data: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct epoll_params {
+pub busy_poll_usecs: __u32,
+pub busy_poll_budget: __u16,
+pub prefer_busy_poll: __u8,
+pub __pad: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct fscrypt_policy_v1 {
 pub version: __u8,
 pub contents_encryption_mode: __u8,
@@ -244,7 +252,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -262,7 +270,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -272,6 +281,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -287,6 +297,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -356,6 +378,25 @@ pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct futex_waitv {
 pub val: __u64,
 pub uaddr: __u64,
@@ -411,6 +452,14 @@ pub struct rand_pool_info {
 pub entropy_count: crate::ctypes::c_int,
 pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vgetrandom_opaque_params {
+pub size_of_opaque_state: __u32,
+pub mmap_prot: __u32,
+pub mmap_flags: __u32,
+pub reserved: [__u32; 13usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -658,17 +707,12 @@ pub stx_dev_minor: __u32,
 pub stx_mnt_id: __u64,
 pub stx_dio_mem_align: __u32,
 pub stx_dio_offset_align: __u32,
-pub __spare3: [__u64; 12usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct termio {
-pub c_iflag: crate::ctypes::c_ushort,
-pub c_oflag: crate::ctypes::c_ushort,
-pub c_cflag: crate::ctypes::c_ushort,
-pub c_lflag: crate::ctypes::c_ushort,
-pub c_line: crate::ctypes::c_uchar,
-pub c_cc: [crate::ctypes::c_uchar; 8usize],
+pub stx_subvol: __u64,
+pub stx_atomic_write_unit_min: __u32,
+pub stx_atomic_write_unit_max: __u32,
+pub stx_atomic_write_segments_max: __u32,
+pub __spare1: [__u32; 1usize],
+pub __spare3: [__u64; 9usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -711,6 +755,16 @@ pub ws_row: crate::ctypes::c_ushort,
 pub ws_col: crate::ctypes::c_ushort,
 pub ws_xpixel: crate::ctypes::c_ushort,
 pub ws_ypixel: crate::ctypes::c_ushort,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct termio {
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -978,9 +1032,9 @@ pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 395264;
+pub const LINUX_VERSION_CODE: u32 = 396032;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 11;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_ADI_BLKSZ: u32 = 48;
@@ -1011,8 +1065,11 @@ pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_RSEQ_FEATURE_SIZE: u32 = 27;
 pub const AT_RSEQ_ALIGN: u32 = 28;
+pub const AT_HWCAP3: u32 = 29;
+pub const AT_HWCAP4: u32 = 30;
 pub const AT_EXECFN: u32 = 31;
 pub const AT_MINSIGSTKSZ: u32 = 51;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
 pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
@@ -1147,9 +1204,10 @@ pub const RESOLVE_IN_ROOT: u32 = 16;
 pub const RESOLVE_CACHED: u32 = 32;
 pub const F_SETLEASE: u32 = 1024;
 pub const F_GETLEASE: u32 = 1025;
+pub const F_NOTIFY: u32 = 1026;
+pub const F_DUPFD_QUERY: u32 = 1027;
 pub const F_CANCELLK: u32 = 1029;
 pub const F_DUPFD_CLOEXEC: u32 = 1030;
-pub const F_NOTIFY: u32 = 1026;
 pub const F_SETPIPE_SZ: u32 = 1031;
 pub const F_GETPIPE_SZ: u32 = 1032;
 pub const F_ADD_SEALS: u32 = 1033;
@@ -1195,6 +1253,7 @@ pub const EPOLL_CLOEXEC: u32 = 4194304;
 pub const EPOLL_CTL_ADD: u32 = 1;
 pub const EPOLL_CTL_DEL: u32 = 2;
 pub const EPOLL_CTL_MOD: u32 = 3;
+pub const EPOLL_IOC_TYPE: u32 = 138;
 pub const POSIX_FADV_NORMAL: u32 = 0;
 pub const POSIX_FADV_RANDOM: u32 = 1;
 pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
@@ -1357,13 +1416,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1435,6 +1498,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1563,6 +1627,7 @@ pub const EFIVARFS_MAGIC: u32 = 3730735588;
 pub const HOSTFS_SUPER_MAGIC: u32 = 12648430;
 pub const OVERLAYFS_SUPER_MAGIC: u32 = 2035054128;
 pub const FUSE_SUPER_MAGIC: u32 = 1702057286;
+pub const BCACHEFS_SUPER_MAGIC: u32 = 3393526350;
 pub const MINIX_SUPER_MAGIC: u32 = 4991;
 pub const MINIX_SUPER_MAGIC2: u32 = 5007;
 pub const MINIX2_SUPER_MAGIC: u32 = 9320;
@@ -1612,6 +1677,7 @@ pub const UDF_SUPER_MAGIC: u32 = 352400198;
 pub const DMA_BUF_MAGIC: u32 = 1145913666;
 pub const DEVMEM_MAGIC: u32 = 1162691661;
 pub const SECRETMEM_MAGIC: u32 = 1397048141;
+pub const PID_FS_MAGIC: u32 = 1346978886;
 pub const PROT_READ: u32 = 1;
 pub const PROT_WRITE: u32 = 2;
 pub const PROT_EXEC: u32 = 4;
@@ -1698,6 +1764,7 @@ pub const OVERCOMMIT_NEVER: u32 = 2;
 pub const MAP_SHARED: u32 = 1;
 pub const MAP_PRIVATE: u32 = 2;
 pub const MAP_SHARED_VALIDATE: u32 = 3;
+pub const MAP_DROPPABLE: u32 = 8;
 pub const MAP_HUGE_SHIFT: u32 = 26;
 pub const MAP_HUGE_MASK: u32 = 63;
 pub const MAP_HUGE_16KB: u32 = 939524096;
@@ -2034,6 +2101,8 @@ pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
 pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
+pub const STATX_SUBVOL: u32 = 32768;
+pub const STATX_WRITE_ATOMIC: u32 = 65536;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2045,6 +2114,7 @@ pub const STATX_ATTR_AUTOMOUNT: u32 = 4096;
 pub const STATX_ATTR_MOUNT_ROOT: u32 = 8192;
 pub const STATX_ATTR_VERITY: u32 = 1048576;
 pub const STATX_ATTR_DAX: u32 = 2097152;
+pub const STATX_ATTR_WRITE_ATOMIC: u32 = 4194304;
 pub const TIOCPKT_DATA: u32 = 0;
 pub const TIOCPKT_FLUSHREAD: u32 = 1;
 pub const TIOCPKT_FLUSHWRITE: u32 = 2;
@@ -2098,7 +2168,6 @@ pub const TCION: u32 = 3;
 pub const TCIFLUSH: u32 = 0;
 pub const TCOFLUSH: u32 = 1;
 pub const TCIOFLUSH: u32 = 2;
-pub const NCC: u32 = 8;
 pub const NCCS: u32 = 17;
 pub const VINTR: u32 = 0;
 pub const VQUIT: u32 = 1;
@@ -2215,6 +2284,7 @@ pub const TIOCSER_TEMT: u32 = 1;
 pub const TCSANOW: u32 = 0;
 pub const TCSADRAIN: u32 = 1;
 pub const TCSAFLUSH: u32 = 2;
+pub const NCC: u32 = 8;
 pub const ITIMER_REAL: u32 = 0;
 pub const ITIMER_VIRTUAL: u32 = 1;
 pub const ITIMER_PROF: u32 = 2;
@@ -2666,6 +2736,7 @@ pub const __NR_listmount: u32 = 458;
 pub const __NR_lsm_get_self_attr: u32 = 459;
 pub const __NR_lsm_set_self_attr: u32 = 460;
 pub const __NR_lsm_list_modules: u32 = 461;
+pub const __NR_mseal: u32 = 462;
 pub const KERN_FEATURE_MIXED_MODE_STACK: u32 = 1;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
@@ -2851,6 +2922,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/sparc/if_arp.rs
+++ b/src/sparc/if_arp.rs
@@ -610,6 +610,7 @@ pub ar_hln: crate::ctypes::c_uchar,
 pub ar_pln: crate::ctypes::c_uchar,
 pub ar_op: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1595,6 +1596,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
@@ -1628,6 +1631,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1729,6 +1733,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
@@ -2495,7 +2500,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2533,7 +2540,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2709,7 +2717,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/sparc/if_ether.rs
+++ b/src/sparc/if_ether.rs
@@ -55,6 +55,7 @@ pub h_dest: [crate::ctypes::c_uchar; 6usize],
 pub h_source: [crate::ctypes::c_uchar; 6usize],
 pub h_proto: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const ETH_ALEN: u32 = 6;
 pub const ETH_TLEN: u32 = 2;
 pub const ETH_HLEN: u32 = 14;

--- a/src/sparc/if_packet.rs
+++ b/src/sparc/if_packet.rs
@@ -203,6 +203,7 @@ pub id: __u16,
 pub max_num_members: __u32,
 }
 pub const __BIG_ENDIAN: u32 = 4321;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const ASI_NULL1: u32 = 0;
 pub const ASI_NULL2: u32 = 1;
 pub const ASI_CONTROL: u32 = 2;

--- a/src/sparc/io_uring.rs
+++ b/src/sparc/io_uring.rs
@@ -138,7 +138,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -156,7 +156,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -166,6 +167,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -181,6 +183,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -247,6 +261,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -490,6 +523,14 @@ pub resv: [__u32; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_napi {
+pub busy_poll_to: __u32,
+pub prefer_busy_poll: __u8,
+pub pad: [__u8; 3usize],
+pub resv: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -556,6 +597,7 @@ pub const IOC_OUT: u32 = 1073741824;
 pub const IOC_INOUT: u32 = 3221225472;
 pub const IOCSIZE_MASK: u32 = 1073676288;
 pub const IOCSIZE_SHIFT: u32 = 16;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const FSCRYPT_POLICY_FLAGS_PAD_4: u32 = 0;
 pub const FSCRYPT_POLICY_FLAGS_PAD_8: u32 = 1;
 pub const FSCRYPT_POLICY_FLAGS_PAD_16: u32 = 2;
@@ -670,13 +712,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -748,6 +794,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -803,15 +850,20 @@ pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
 pub const IORING_SEND_ZC_REPORT_USAGE: u32 = 8;
+pub const IORING_RECVSEND_BUNDLE: u32 = 16;
 pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
+pub const IORING_ACCEPT_DONTWAIT: u32 = 2;
+pub const IORING_ACCEPT_POLL_FIRST: u32 = 4;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
 pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
+pub const IORING_NOP_INJECT_RESULT: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
 pub const IORING_CQE_F_NOTIF: u32 = 8;
+pub const IORING_CQE_BUFFER_SHIFT: u32 = 16;
 pub const IORING_OFF_SQ_RING: u32 = 0;
 pub const IORING_OFF_CQ_RING: u32 = 134217728;
 pub const IORING_OFF_SQES: u32 = 268435456;
@@ -841,60 +893,10 @@ pub const IORING_FEAT_RSRC_TAGS: u32 = 1024;
 pub const IORING_FEAT_CQE_SKIP: u32 = 2048;
 pub const IORING_FEAT_LINKED_FILE: u32 = 4096;
 pub const IORING_FEAT_REG_REG_RING: u32 = 8192;
+pub const IORING_FEAT_RECVSEND_BUNDLE: u32 = 16384;
 pub const IORING_RSRC_REGISTER_SPARSE: u32 = 1;
 pub const IORING_REGISTER_FILES_SKIP: i32 = -2;
 pub const IO_URING_OP_SUPPORTED: u32 = 1;
-pub const IOSQE_FIXED_FILE_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_FIXED_FILE_BIT;
-pub const IOSQE_IO_DRAIN_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_DRAIN_BIT;
-pub const IOSQE_IO_LINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_LINK_BIT;
-pub const IOSQE_IO_HARDLINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_HARDLINK_BIT;
-pub const IOSQE_ASYNC_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_ASYNC_BIT;
-pub const IOSQE_BUFFER_SELECT_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_BUFFER_SELECT_BIT;
-pub const IOSQE_CQE_SKIP_SUCCESS_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_CQE_SKIP_SUCCESS_BIT;
-pub const IORING_MSG_DATA: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_DATA;
-pub const IORING_MSG_SEND_FD: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_SEND_FD;
-pub const IORING_CQE_BUFFER_SHIFT: _bindgen_ty_3 = _bindgen_ty_3::IORING_CQE_BUFFER_SHIFT;
-pub const IORING_REGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS;
-pub const IORING_UNREGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_BUFFERS;
-pub const IORING_REGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES;
-pub const IORING_UNREGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_FILES;
-pub const IORING_REGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD;
-pub const IORING_UNREGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_EVENTFD;
-pub const IORING_REGISTER_FILES_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE;
-pub const IORING_REGISTER_EVENTFD_ASYNC: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD_ASYNC;
-pub const IORING_REGISTER_PROBE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PROBE;
-pub const IORING_REGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PERSONALITY;
-pub const IORING_UNREGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PERSONALITY;
-pub const IORING_REGISTER_RESTRICTIONS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RESTRICTIONS;
-pub const IORING_REGISTER_ENABLE_RINGS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_ENABLE_RINGS;
-pub const IORING_REGISTER_FILES2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES2;
-pub const IORING_REGISTER_FILES_UPDATE2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE2;
-pub const IORING_REGISTER_BUFFERS2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS2;
-pub const IORING_REGISTER_BUFFERS_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS_UPDATE;
-pub const IORING_REGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_AFF;
-pub const IORING_UNREGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_IOWQ_AFF;
-pub const IORING_REGISTER_IOWQ_MAX_WORKERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_MAX_WORKERS;
-pub const IORING_REGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RING_FDS;
-pub const IORING_UNREGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_RING_FDS;
-pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_RING;
-pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
-pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
-pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
-pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
-pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
-pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
-pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
-pub const IO_WQ_UNBOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_UNBOUND;
-pub const IOU_PBUF_RING_MMAP: _bindgen_ty_6 = _bindgen_ty_6::IOU_PBUF_RING_MMAP;
-pub const IORING_RESTRICTION_REGISTER_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_REGISTER_OP;
-pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_OP;
-pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
-pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
-pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
-pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
-pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
-pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
-pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -912,7 +914,18 @@ FSCONFIG_CMD_CREATE_EXCL = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_1 {
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum io_uring_sqe_flags_bit {
 IOSQE_FIXED_FILE_BIT = 0,
 IOSQE_IO_DRAIN_BIT = 1,
 IOSQE_IO_LINK_BIT = 2,
@@ -980,25 +993,22 @@ IORING_OP_FUTEX_WAIT = 51,
 IORING_OP_FUTEX_WAKE = 52,
 IORING_OP_FUTEX_WAITV = 53,
 IORING_OP_FIXED_FD_INSTALL = 54,
-IORING_OP_LAST = 55,
+IORING_OP_FTRUNCATE = 55,
+IORING_OP_BIND = 56,
+IORING_OP_LISTEN = 57,
+IORING_OP_LAST = 58,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_2 {
+pub enum io_uring_msg_ring_flags {
 IORING_MSG_DATA = 0,
 IORING_MSG_SEND_FD = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_3 {
-IORING_CQE_BUFFER_SHIFT = 16,
-}
-#[repr(u32)]
-#[non_exhaustive]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_4 {
+pub enum io_uring_register_op {
 IORING_REGISTER_BUFFERS = 0,
 IORING_UNREGISTER_BUFFERS = 1,
 IORING_REGISTER_FILES = 2,
@@ -1026,26 +1036,28 @@ IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
 IORING_REGISTER_PBUF_STATUS = 26,
-IORING_REGISTER_LAST = 27,
+IORING_REGISTER_NAPI = 27,
+IORING_UNREGISTER_NAPI = 28,
+IORING_REGISTER_LAST = 29,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_5 {
+pub enum io_wq_type {
 IO_WQ_BOUND = 0,
 IO_WQ_UNBOUND = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_6 {
+pub enum io_uring_register_pbuf_ring_flags {
 IOU_PBUF_RING_MMAP = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_7 {
+pub enum io_uring_register_restriction_op {
 IORING_RESTRICTION_REGISTER_OP = 0,
 IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
@@ -1055,7 +1067,7 @@ IORING_RESTRICTION_LAST = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_8 {
+pub enum io_uring_socket_op {
 SOCKET_URING_OP_SIOCINQ = 0,
 SOCKET_URING_OP_SIOCOUTQ = 1,
 SOCKET_URING_OP_GETSOCKOPT = 2,
@@ -1114,6 +1126,7 @@ pub uring_cmd_flags: __u32,
 pub waitid_flags: __u32,
 pub futex_flags: __u32,
 pub install_fd_flags: __u32,
+pub nop_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]

--- a/src/sparc/loop_device.rs
+++ b/src/sparc/loop_device.rs
@@ -91,6 +91,7 @@ pub __reserved: [__u64; 8usize],
 }
 pub const LO_NAME_SIZE: u32 = 64;
 pub const LO_KEY_SIZE: u32 = 32;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const LO_CRYPT_NONE: u32 = 0;
 pub const LO_CRYPT_XOR: u32 = 1;
 pub const LO_CRYPT_DES: u32 = 2;

--- a/src/sparc/mempolicy.rs
+++ b/src/sparc/mempolicy.rs
@@ -160,6 +160,7 @@ pub const MPOL_BIND: _bindgen_ty_1 = _bindgen_ty_1::MPOL_BIND;
 pub const MPOL_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_INTERLEAVE;
 pub const MPOL_LOCAL: _bindgen_ty_1 = _bindgen_ty_1::MPOL_LOCAL;
 pub const MPOL_PREFERRED_MANY: _bindgen_ty_1 = _bindgen_ty_1::MPOL_PREFERRED_MANY;
+pub const MPOL_WEIGHTED_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_WEIGHTED_INTERLEAVE;
 pub const MPOL_MAX: _bindgen_ty_1 = _bindgen_ty_1::MPOL_MAX;
 #[repr(u32)]
 #[non_exhaustive]
@@ -171,5 +172,6 @@ MPOL_BIND = 2,
 MPOL_INTERLEAVE = 3,
 MPOL_LOCAL = 4,
 MPOL_PREFERRED_MANY = 5,
-MPOL_MAX = 6,
+MPOL_WEIGHTED_INTERLEAVE = 6,
+MPOL_MAX = 7,
 }

--- a/src/sparc/net.rs
+++ b/src/sparc/net.rs
@@ -854,6 +854,7 @@ pub _address: u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1475,6 +1476,7 @@ pub const TCP_AO_DEL_KEY: u32 = 39;
 pub const TCP_AO_INFO: u32 = 40;
 pub const TCP_AO_GET_KEYS: u32 = 41;
 pub const TCP_AO_REPAIR: u32 = 42;
+pub const TCP_IS_MPTCP: u32 = 43;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1761,6 +1763,7 @@ pub const IPPROTO_UDPLITE: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_UDPLITE;
 pub const IPPROTO_MPLS: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPLS;
 pub const IPPROTO_ETHERNET: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ETHERNET;
 pub const IPPROTO_RAW: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_RAW;
+pub const IPPROTO_SMC: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_SMC;
 pub const IPPROTO_MPTCP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPTCP;
 pub const IPPROTO_MAX: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MAX;
 pub const IPV4_DEVCONF_FORWARDING: _bindgen_ty_2 = _bindgen_ty_2::IPV4_DEVCONF_FORWARDING;
@@ -1949,6 +1952,7 @@ IPPROTO_UDPLITE = 136,
 IPPROTO_MPLS = 137,
 IPPROTO_ETHERNET = 143,
 IPPROTO_RAW = 255,
+IPPROTO_SMC = 256,
 IPPROTO_MPTCP = 262,
 IPPROTO_MAX = 263,
 }

--- a/src/sparc/netlink.rs
+++ b/src/sparc/netlink.rs
@@ -547,6 +547,7 @@ pub const SOCK_BUF_LOCK_MASK: u32 = 3;
 pub const SOCK_TXREHASH_DEFAULT: u32 = 255;
 pub const SOCK_TXREHASH_DISABLED: u32 = 0;
 pub const SOCK_TXREHASH_ENABLED: u32 = 1;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const NETLINK_ROUTE: u32 = 0;
 pub const NETLINK_UNUSED: u32 = 1;
 pub const NETLINK_USERSOCK: u32 = 2;
@@ -1094,6 +1095,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
@@ -1127,6 +1130,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1228,6 +1232,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
@@ -2142,7 +2147,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2180,7 +2187,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2356,7 +2364,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/sparc/prctl.rs
+++ b/src/sparc/prctl.rs
@@ -66,6 +66,7 @@ pub auxv: *mut __u64,
 pub auxv_size: __u32,
 pub exe_fd: __u32,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PR_SET_PDEATHSIG: u32 = 1;
 pub const PR_GET_PDEATHSIG: u32 = 2;
 pub const PR_GET_DUMPABLE: u32 = 3;
@@ -232,3 +233,20 @@ pub const PR_RISCV_V_VSTATE_CTRL_INHERIT: u32 = 16;
 pub const PR_RISCV_V_VSTATE_CTRL_CUR_MASK: u32 = 3;
 pub const PR_RISCV_V_VSTATE_CTRL_NEXT_MASK: u32 = 12;
 pub const PR_RISCV_V_VSTATE_CTRL_MASK: u32 = 31;
+pub const PR_RISCV_SET_ICACHE_FLUSH_CTX: u32 = 71;
+pub const PR_RISCV_CTX_SW_FENCEI_ON: u32 = 0;
+pub const PR_RISCV_CTX_SW_FENCEI_OFF: u32 = 1;
+pub const PR_RISCV_SCOPE_PER_PROCESS: u32 = 0;
+pub const PR_RISCV_SCOPE_PER_THREAD: u32 = 1;
+pub const PR_PPC_GET_DEXCR: u32 = 72;
+pub const PR_PPC_SET_DEXCR: u32 = 73;
+pub const PR_PPC_DEXCR_SBHE: u32 = 0;
+pub const PR_PPC_DEXCR_IBRTPD: u32 = 1;
+pub const PR_PPC_DEXCR_SRAPD: u32 = 2;
+pub const PR_PPC_DEXCR_NPHIE: u32 = 3;
+pub const PR_PPC_DEXCR_CTRL_EDITABLE: u32 = 1;
+pub const PR_PPC_DEXCR_CTRL_SET: u32 = 2;
+pub const PR_PPC_DEXCR_CTRL_CLEAR: u32 = 4;
+pub const PR_PPC_DEXCR_CTRL_SET_ONEXEC: u32 = 8;
+pub const PR_PPC_DEXCR_CTRL_CLEAR_ONEXEC: u32 = 16;
+pub const PR_PPC_DEXCR_CTRL_MASK: u32 = 31;

--- a/src/sparc/system.rs
+++ b/src/sparc/system.rs
@@ -94,6 +94,7 @@ pub version: [crate::ctypes::c_char; 65usize],
 pub machine: [crate::ctypes::c_char; 65usize],
 pub domainname: [crate::ctypes::c_char; 65usize],
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const SI_LOAD_SHIFT: u32 = 16;
 pub const __OLD_UTS_LEN: u32 = 8;
 pub const __NEW_UTS_LEN: u32 = 64;

--- a/src/sparc/xdp.rs
+++ b/src/sparc/xdp.rs
@@ -152,6 +152,7 @@ pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,
 pub tx_invalid_descs: __u64,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
@@ -159,6 +160,7 @@ pub const XDP_USE_NEED_WAKEUP: u32 = 8;
 pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
 pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
+pub const XDP_UMEM_TX_METADATA_LEN: u32 = 4;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;

--- a/src/sparc64/btrfs.rs
+++ b/src/sparc64/btrfs.rs
@@ -144,7 +144,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -162,7 +162,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -172,6 +173,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -187,6 +189,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -253,6 +267,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -863,10 +896,17 @@ pub physical: __le64,
 }
 #[repr(C, packed)]
 pub struct btrfs_stripe_extent {
-pub encoding: __u8,
-pub reserved: [__u8; 7usize],
+pub __bindgen_anon_1: btrfs_stripe_extent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct btrfs_stripe_extent__bindgen_ty_1 {
+pub __empty_strides: btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1,
 pub strides: __IncompleteArrayField<btrfs_raid_stride>,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct btrfs_extent_item {
@@ -1135,6 +1175,7 @@ pub encryption: __u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _IOC_NRBITS: u32 = 8;
 pub const _IOC_TYPEBITS: u32 = 8;
 pub const _IOC_SIZEBITS: u32 = 13;
@@ -1283,13 +1324,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1361,6 +1406,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1393,6 +1439,7 @@ pub const BTRFS_QGROUP_LIMIT_RSV_EXCL: u32 = 8;
 pub const BTRFS_QGROUP_LIMIT_RFER_CMPR: u32 = 16;
 pub const BTRFS_QGROUP_LIMIT_EXCL_CMPR: u32 = 32;
 pub const BTRFS_QGROUP_INHERIT_SET_LIMITS: u32 = 1;
+pub const BTRFS_QGROUP_INHERIT_FLAGS_SUPP: u32 = 1;
 pub const BTRFS_DEVICE_REMOVE_ARGS_MASK: u32 = 8;
 pub const BTRFS_SUBVOL_CREATE_ARGS_MASK: u32 = 6;
 pub const BTRFS_SUBVOL_DELETE_ARGS_MASK: u32 = 16;
@@ -1598,14 +1645,6 @@ pub const BTRFS_SYSTEM_CHUNK_ARRAY_SIZE: u32 = 2048;
 pub const BTRFS_NUM_BACKUP_ROOTS: u32 = 4;
 pub const BTRFS_FREE_SPACE_EXTENT: u32 = 1;
 pub const BTRFS_FREE_SPACE_BITMAP: u32 = 2;
-pub const BTRFS_STRIPE_RAID0: u32 = 1;
-pub const BTRFS_STRIPE_RAID1: u32 = 2;
-pub const BTRFS_STRIPE_DUP: u32 = 3;
-pub const BTRFS_STRIPE_RAID10: u32 = 4;
-pub const BTRFS_STRIPE_RAID5: u32 = 5;
-pub const BTRFS_STRIPE_RAID6: u32 = 6;
-pub const BTRFS_STRIPE_RAID1C3: u32 = 7;
-pub const BTRFS_STRIPE_RAID1C4: u32 = 8;
 pub const BTRFS_HEADER_FLAG_WRITTEN: u32 = 1;
 pub const BTRFS_HEADER_FLAG_RELOC: u32 = 2;
 pub const BTRFS_SUPER_FLAG_ERROR: u32 = 4;
@@ -1614,6 +1653,9 @@ pub const BTRFS_SUPER_FLAG_METADUMP: u64 = 8589934592;
 pub const BTRFS_SUPER_FLAG_METADUMP_V2: u64 = 17179869184;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID: u64 = 34359738368;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID_V2: u64 = 68719476736;
+pub const BTRFS_SUPER_FLAG_CHANGING_BG_TREE: u64 = 274877906944;
+pub const BTRFS_SUPER_FLAG_CHANGING_DATA_CSUM: u64 = 549755813888;
+pub const BTRFS_SUPER_FLAG_CHANGING_META_CSUM: u64 = 1099511627776;
 pub const BTRFS_EXTENT_FLAG_DATA: u32 = 1;
 pub const BTRFS_EXTENT_FLAG_TREE_BLOCK: u32 = 2;
 pub const BTRFS_BLOCK_FLAG_FULL_BACKREF: u32 = 256;
@@ -1669,6 +1711,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/sparc64/general.rs
+++ b/src/sparc64/general.rs
@@ -170,6 +170,14 @@ pub data: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct epoll_params {
+pub busy_poll_usecs: __u32,
+pub busy_poll_budget: __u16,
+pub prefer_busy_poll: __u8,
+pub __pad: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct fscrypt_policy_v1 {
 pub version: __u8,
 pub contents_encryption_mode: __u8,
@@ -252,7 +260,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -270,7 +278,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -280,6 +289,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -295,6 +305,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -364,6 +386,25 @@ pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct futex_waitv {
 pub val: __u64,
 pub uaddr: __u64,
@@ -419,6 +460,14 @@ pub struct rand_pool_info {
 pub entropy_count: crate::ctypes::c_int,
 pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vgetrandom_opaque_params {
+pub size_of_opaque_state: __u32,
+pub mmap_prot: __u32,
+pub mmap_flags: __u32,
+pub reserved: [__u32; 13usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -660,17 +709,12 @@ pub stx_dev_minor: __u32,
 pub stx_mnt_id: __u64,
 pub stx_dio_mem_align: __u32,
 pub stx_dio_offset_align: __u32,
-pub __spare3: [__u64; 12usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct termio {
-pub c_iflag: crate::ctypes::c_ushort,
-pub c_oflag: crate::ctypes::c_ushort,
-pub c_cflag: crate::ctypes::c_ushort,
-pub c_lflag: crate::ctypes::c_ushort,
-pub c_line: crate::ctypes::c_uchar,
-pub c_cc: [crate::ctypes::c_uchar; 8usize],
+pub stx_subvol: __u64,
+pub stx_atomic_write_unit_min: __u32,
+pub stx_atomic_write_unit_max: __u32,
+pub stx_atomic_write_segments_max: __u32,
+pub __spare1: [__u32; 1usize],
+pub __spare3: [__u64; 9usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -713,6 +757,16 @@ pub ws_row: crate::ctypes::c_ushort,
 pub ws_col: crate::ctypes::c_ushort,
 pub ws_xpixel: crate::ctypes::c_ushort,
 pub ws_ypixel: crate::ctypes::c_ushort,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct termio {
+pub c_iflag: crate::ctypes::c_ushort,
+pub c_oflag: crate::ctypes::c_ushort,
+pub c_cflag: crate::ctypes::c_ushort,
+pub c_lflag: crate::ctypes::c_ushort,
+pub c_line: crate::ctypes::c_uchar,
+pub c_cc: [crate::ctypes::c_uchar; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -975,9 +1029,9 @@ pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 395264;
+pub const LINUX_VERSION_CODE: u32 = 396032;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 11;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_ADI_BLKSZ: u32 = 48;
@@ -1008,8 +1062,11 @@ pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_RSEQ_FEATURE_SIZE: u32 = 27;
 pub const AT_RSEQ_ALIGN: u32 = 28;
+pub const AT_HWCAP3: u32 = 29;
+pub const AT_HWCAP4: u32 = 30;
 pub const AT_EXECFN: u32 = 31;
 pub const AT_MINSIGSTKSZ: u32 = 51;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
 pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
@@ -1141,9 +1198,10 @@ pub const RESOLVE_IN_ROOT: u32 = 16;
 pub const RESOLVE_CACHED: u32 = 32;
 pub const F_SETLEASE: u32 = 1024;
 pub const F_GETLEASE: u32 = 1025;
+pub const F_NOTIFY: u32 = 1026;
+pub const F_DUPFD_QUERY: u32 = 1027;
 pub const F_CANCELLK: u32 = 1029;
 pub const F_DUPFD_CLOEXEC: u32 = 1030;
-pub const F_NOTIFY: u32 = 1026;
 pub const F_SETPIPE_SZ: u32 = 1031;
 pub const F_GETPIPE_SZ: u32 = 1032;
 pub const F_ADD_SEALS: u32 = 1033;
@@ -1189,6 +1247,7 @@ pub const EPOLL_CLOEXEC: u32 = 4194304;
 pub const EPOLL_CTL_ADD: u32 = 1;
 pub const EPOLL_CTL_DEL: u32 = 2;
 pub const EPOLL_CTL_MOD: u32 = 3;
+pub const EPOLL_IOC_TYPE: u32 = 138;
 pub const POSIX_FADV_NORMAL: u32 = 0;
 pub const POSIX_FADV_RANDOM: u32 = 1;
 pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
@@ -1351,13 +1410,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1429,6 +1492,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1557,6 +1621,7 @@ pub const EFIVARFS_MAGIC: u32 = 3730735588;
 pub const HOSTFS_SUPER_MAGIC: u32 = 12648430;
 pub const OVERLAYFS_SUPER_MAGIC: u32 = 2035054128;
 pub const FUSE_SUPER_MAGIC: u32 = 1702057286;
+pub const BCACHEFS_SUPER_MAGIC: u32 = 3393526350;
 pub const MINIX_SUPER_MAGIC: u32 = 4991;
 pub const MINIX_SUPER_MAGIC2: u32 = 5007;
 pub const MINIX2_SUPER_MAGIC: u32 = 9320;
@@ -1606,6 +1671,7 @@ pub const UDF_SUPER_MAGIC: u32 = 352400198;
 pub const DMA_BUF_MAGIC: u32 = 1145913666;
 pub const DEVMEM_MAGIC: u32 = 1162691661;
 pub const SECRETMEM_MAGIC: u32 = 1397048141;
+pub const PID_FS_MAGIC: u32 = 1346978886;
 pub const PROT_READ: u32 = 1;
 pub const PROT_WRITE: u32 = 2;
 pub const PROT_EXEC: u32 = 4;
@@ -1692,6 +1758,7 @@ pub const OVERCOMMIT_NEVER: u32 = 2;
 pub const MAP_SHARED: u32 = 1;
 pub const MAP_PRIVATE: u32 = 2;
 pub const MAP_SHARED_VALIDATE: u32 = 3;
+pub const MAP_DROPPABLE: u32 = 8;
 pub const MAP_HUGE_SHIFT: u32 = 26;
 pub const MAP_HUGE_MASK: u32 = 63;
 pub const MAP_HUGE_16KB: u32 = 939524096;
@@ -2028,6 +2095,8 @@ pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
 pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
+pub const STATX_SUBVOL: u32 = 32768;
+pub const STATX_WRITE_ATOMIC: u32 = 65536;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2039,6 +2108,7 @@ pub const STATX_ATTR_AUTOMOUNT: u32 = 4096;
 pub const STATX_ATTR_MOUNT_ROOT: u32 = 8192;
 pub const STATX_ATTR_VERITY: u32 = 1048576;
 pub const STATX_ATTR_DAX: u32 = 2097152;
+pub const STATX_ATTR_WRITE_ATOMIC: u32 = 4194304;
 pub const TIOCPKT_DATA: u32 = 0;
 pub const TIOCPKT_FLUSHREAD: u32 = 1;
 pub const TIOCPKT_FLUSHWRITE: u32 = 2;
@@ -2092,7 +2162,6 @@ pub const TCION: u32 = 3;
 pub const TCIFLUSH: u32 = 0;
 pub const TCOFLUSH: u32 = 1;
 pub const TCIOFLUSH: u32 = 2;
-pub const NCC: u32 = 8;
 pub const NCCS: u32 = 17;
 pub const VINTR: u32 = 0;
 pub const VQUIT: u32 = 1;
@@ -2209,6 +2278,7 @@ pub const TIOCSER_TEMT: u32 = 1;
 pub const TCSANOW: u32 = 0;
 pub const TCSADRAIN: u32 = 1;
 pub const TCSAFLUSH: u32 = 2;
+pub const NCC: u32 = 8;
 pub const ITIMER_REAL: u32 = 0;
 pub const ITIMER_VIRTUAL: u32 = 1;
 pub const ITIMER_PROF: u32 = 2;
@@ -2623,6 +2693,7 @@ pub const __NR_listmount: u32 = 458;
 pub const __NR_lsm_get_self_attr: u32 = 459;
 pub const __NR_lsm_set_self_attr: u32 = 460;
 pub const __NR_lsm_list_modules: u32 = 461;
+pub const __NR_mseal: u32 = 462;
 pub const KERN_FEATURE_MIXED_MODE_STACK: u32 = 1;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
@@ -2807,6 +2878,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/sparc64/if_arp.rs
+++ b/src/sparc64/if_arp.rs
@@ -618,6 +618,7 @@ pub ar_hln: crate::ctypes::c_uchar,
 pub ar_pln: crate::ctypes::c_uchar,
 pub ar_op: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1603,6 +1604,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
@@ -1636,6 +1639,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1737,6 +1741,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
@@ -2503,7 +2508,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2541,7 +2548,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2717,7 +2725,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/sparc64/if_ether.rs
+++ b/src/sparc64/if_ether.rs
@@ -63,6 +63,7 @@ pub h_dest: [crate::ctypes::c_uchar; 6usize],
 pub h_source: [crate::ctypes::c_uchar; 6usize],
 pub h_proto: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const ETH_ALEN: u32 = 6;
 pub const ETH_TLEN: u32 = 2;
 pub const ETH_HLEN: u32 = 14;

--- a/src/sparc64/if_packet.rs
+++ b/src/sparc64/if_packet.rs
@@ -211,6 +211,7 @@ pub id: __u16,
 pub max_num_members: __u32,
 }
 pub const __BIG_ENDIAN: u32 = 4321;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const ASI_NULL1: u32 = 0;
 pub const ASI_NULL2: u32 = 1;
 pub const ASI_CONTROL: u32 = 2;

--- a/src/sparc64/io_uring.rs
+++ b/src/sparc64/io_uring.rs
@@ -146,7 +146,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -164,7 +164,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -174,6 +175,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -189,6 +191,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -255,6 +269,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -492,6 +525,14 @@ pub resv: [__u32; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_napi {
+pub busy_poll_to: __u32,
+pub prefer_busy_poll: __u8,
+pub pad: [__u8; 3usize],
+pub resv: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -558,6 +599,7 @@ pub const IOC_OUT: u32 = 1073741824;
 pub const IOC_INOUT: u32 = 3221225472;
 pub const IOCSIZE_MASK: u32 = 1073676288;
 pub const IOCSIZE_SHIFT: u32 = 16;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const FSCRYPT_POLICY_FLAGS_PAD_4: u32 = 0;
 pub const FSCRYPT_POLICY_FLAGS_PAD_8: u32 = 1;
 pub const FSCRYPT_POLICY_FLAGS_PAD_16: u32 = 2;
@@ -672,13 +714,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -750,6 +796,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -805,15 +852,20 @@ pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
 pub const IORING_SEND_ZC_REPORT_USAGE: u32 = 8;
+pub const IORING_RECVSEND_BUNDLE: u32 = 16;
 pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
+pub const IORING_ACCEPT_DONTWAIT: u32 = 2;
+pub const IORING_ACCEPT_POLL_FIRST: u32 = 4;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
 pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
+pub const IORING_NOP_INJECT_RESULT: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
 pub const IORING_CQE_F_NOTIF: u32 = 8;
+pub const IORING_CQE_BUFFER_SHIFT: u32 = 16;
 pub const IORING_OFF_SQ_RING: u32 = 0;
 pub const IORING_OFF_CQ_RING: u32 = 134217728;
 pub const IORING_OFF_SQES: u32 = 268435456;
@@ -843,60 +895,10 @@ pub const IORING_FEAT_RSRC_TAGS: u32 = 1024;
 pub const IORING_FEAT_CQE_SKIP: u32 = 2048;
 pub const IORING_FEAT_LINKED_FILE: u32 = 4096;
 pub const IORING_FEAT_REG_REG_RING: u32 = 8192;
+pub const IORING_FEAT_RECVSEND_BUNDLE: u32 = 16384;
 pub const IORING_RSRC_REGISTER_SPARSE: u32 = 1;
 pub const IORING_REGISTER_FILES_SKIP: i32 = -2;
 pub const IO_URING_OP_SUPPORTED: u32 = 1;
-pub const IOSQE_FIXED_FILE_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_FIXED_FILE_BIT;
-pub const IOSQE_IO_DRAIN_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_DRAIN_BIT;
-pub const IOSQE_IO_LINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_LINK_BIT;
-pub const IOSQE_IO_HARDLINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_HARDLINK_BIT;
-pub const IOSQE_ASYNC_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_ASYNC_BIT;
-pub const IOSQE_BUFFER_SELECT_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_BUFFER_SELECT_BIT;
-pub const IOSQE_CQE_SKIP_SUCCESS_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_CQE_SKIP_SUCCESS_BIT;
-pub const IORING_MSG_DATA: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_DATA;
-pub const IORING_MSG_SEND_FD: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_SEND_FD;
-pub const IORING_CQE_BUFFER_SHIFT: _bindgen_ty_3 = _bindgen_ty_3::IORING_CQE_BUFFER_SHIFT;
-pub const IORING_REGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS;
-pub const IORING_UNREGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_BUFFERS;
-pub const IORING_REGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES;
-pub const IORING_UNREGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_FILES;
-pub const IORING_REGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD;
-pub const IORING_UNREGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_EVENTFD;
-pub const IORING_REGISTER_FILES_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE;
-pub const IORING_REGISTER_EVENTFD_ASYNC: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD_ASYNC;
-pub const IORING_REGISTER_PROBE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PROBE;
-pub const IORING_REGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PERSONALITY;
-pub const IORING_UNREGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PERSONALITY;
-pub const IORING_REGISTER_RESTRICTIONS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RESTRICTIONS;
-pub const IORING_REGISTER_ENABLE_RINGS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_ENABLE_RINGS;
-pub const IORING_REGISTER_FILES2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES2;
-pub const IORING_REGISTER_FILES_UPDATE2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE2;
-pub const IORING_REGISTER_BUFFERS2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS2;
-pub const IORING_REGISTER_BUFFERS_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS_UPDATE;
-pub const IORING_REGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_AFF;
-pub const IORING_UNREGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_IOWQ_AFF;
-pub const IORING_REGISTER_IOWQ_MAX_WORKERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_MAX_WORKERS;
-pub const IORING_REGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RING_FDS;
-pub const IORING_UNREGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_RING_FDS;
-pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_RING;
-pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
-pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
-pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
-pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
-pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
-pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
-pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
-pub const IO_WQ_UNBOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_UNBOUND;
-pub const IOU_PBUF_RING_MMAP: _bindgen_ty_6 = _bindgen_ty_6::IOU_PBUF_RING_MMAP;
-pub const IORING_RESTRICTION_REGISTER_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_REGISTER_OP;
-pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_OP;
-pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
-pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
-pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
-pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
-pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
-pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
-pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -914,7 +916,18 @@ FSCONFIG_CMD_CREATE_EXCL = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_1 {
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum io_uring_sqe_flags_bit {
 IOSQE_FIXED_FILE_BIT = 0,
 IOSQE_IO_DRAIN_BIT = 1,
 IOSQE_IO_LINK_BIT = 2,
@@ -982,25 +995,22 @@ IORING_OP_FUTEX_WAIT = 51,
 IORING_OP_FUTEX_WAKE = 52,
 IORING_OP_FUTEX_WAITV = 53,
 IORING_OP_FIXED_FD_INSTALL = 54,
-IORING_OP_LAST = 55,
+IORING_OP_FTRUNCATE = 55,
+IORING_OP_BIND = 56,
+IORING_OP_LISTEN = 57,
+IORING_OP_LAST = 58,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_2 {
+pub enum io_uring_msg_ring_flags {
 IORING_MSG_DATA = 0,
 IORING_MSG_SEND_FD = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_3 {
-IORING_CQE_BUFFER_SHIFT = 16,
-}
-#[repr(u32)]
-#[non_exhaustive]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_4 {
+pub enum io_uring_register_op {
 IORING_REGISTER_BUFFERS = 0,
 IORING_UNREGISTER_BUFFERS = 1,
 IORING_REGISTER_FILES = 2,
@@ -1028,26 +1038,28 @@ IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
 IORING_REGISTER_PBUF_STATUS = 26,
-IORING_REGISTER_LAST = 27,
+IORING_REGISTER_NAPI = 27,
+IORING_UNREGISTER_NAPI = 28,
+IORING_REGISTER_LAST = 29,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_5 {
+pub enum io_wq_type {
 IO_WQ_BOUND = 0,
 IO_WQ_UNBOUND = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_6 {
+pub enum io_uring_register_pbuf_ring_flags {
 IOU_PBUF_RING_MMAP = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_7 {
+pub enum io_uring_register_restriction_op {
 IORING_RESTRICTION_REGISTER_OP = 0,
 IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
@@ -1057,7 +1069,7 @@ IORING_RESTRICTION_LAST = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_8 {
+pub enum io_uring_socket_op {
 SOCKET_URING_OP_SIOCINQ = 0,
 SOCKET_URING_OP_SIOCOUTQ = 1,
 SOCKET_URING_OP_GETSOCKOPT = 2,
@@ -1116,6 +1128,7 @@ pub uring_cmd_flags: __u32,
 pub waitid_flags: __u32,
 pub futex_flags: __u32,
 pub install_fd_flags: __u32,
+pub nop_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]

--- a/src/sparc64/loop_device.rs
+++ b/src/sparc64/loop_device.rs
@@ -99,6 +99,7 @@ pub __reserved: [__u64; 8usize],
 }
 pub const LO_NAME_SIZE: u32 = 64;
 pub const LO_KEY_SIZE: u32 = 32;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const LO_CRYPT_NONE: u32 = 0;
 pub const LO_CRYPT_XOR: u32 = 1;
 pub const LO_CRYPT_DES: u32 = 2;

--- a/src/sparc64/mempolicy.rs
+++ b/src/sparc64/mempolicy.rs
@@ -160,6 +160,7 @@ pub const MPOL_BIND: _bindgen_ty_1 = _bindgen_ty_1::MPOL_BIND;
 pub const MPOL_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_INTERLEAVE;
 pub const MPOL_LOCAL: _bindgen_ty_1 = _bindgen_ty_1::MPOL_LOCAL;
 pub const MPOL_PREFERRED_MANY: _bindgen_ty_1 = _bindgen_ty_1::MPOL_PREFERRED_MANY;
+pub const MPOL_WEIGHTED_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_WEIGHTED_INTERLEAVE;
 pub const MPOL_MAX: _bindgen_ty_1 = _bindgen_ty_1::MPOL_MAX;
 #[repr(u32)]
 #[non_exhaustive]
@@ -171,5 +172,6 @@ MPOL_BIND = 2,
 MPOL_INTERLEAVE = 3,
 MPOL_LOCAL = 4,
 MPOL_PREFERRED_MANY = 5,
-MPOL_MAX = 6,
+MPOL_WEIGHTED_INTERLEAVE = 6,
+MPOL_MAX = 7,
 }

--- a/src/sparc64/net.rs
+++ b/src/sparc64/net.rs
@@ -860,6 +860,7 @@ pub _address: u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1489,6 +1490,7 @@ pub const TCP_AO_DEL_KEY: u32 = 39;
 pub const TCP_AO_INFO: u32 = 40;
 pub const TCP_AO_GET_KEYS: u32 = 41;
 pub const TCP_AO_REPAIR: u32 = 42;
+pub const TCP_IS_MPTCP: u32 = 43;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1775,6 +1777,7 @@ pub const IPPROTO_UDPLITE: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_UDPLITE;
 pub const IPPROTO_MPLS: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPLS;
 pub const IPPROTO_ETHERNET: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ETHERNET;
 pub const IPPROTO_RAW: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_RAW;
+pub const IPPROTO_SMC: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_SMC;
 pub const IPPROTO_MPTCP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPTCP;
 pub const IPPROTO_MAX: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MAX;
 pub const IPV4_DEVCONF_FORWARDING: _bindgen_ty_2 = _bindgen_ty_2::IPV4_DEVCONF_FORWARDING;
@@ -1963,6 +1966,7 @@ IPPROTO_UDPLITE = 136,
 IPPROTO_MPLS = 137,
 IPPROTO_ETHERNET = 143,
 IPPROTO_RAW = 255,
+IPPROTO_SMC = 256,
 IPPROTO_MPTCP = 262,
 IPPROTO_MAX = 263,
 }

--- a/src/sparc64/netlink.rs
+++ b/src/sparc64/netlink.rs
@@ -555,6 +555,7 @@ pub const SOCK_BUF_LOCK_MASK: u32 = 3;
 pub const SOCK_TXREHASH_DEFAULT: u32 = 255;
 pub const SOCK_TXREHASH_DISABLED: u32 = 0;
 pub const SOCK_TXREHASH_ENABLED: u32 = 1;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const NETLINK_ROUTE: u32 = 0;
 pub const NETLINK_UNUSED: u32 = 1;
 pub const NETLINK_USERSOCK: u32 = 2;
@@ -1102,6 +1103,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
@@ -1135,6 +1138,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1236,6 +1240,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
@@ -2150,7 +2155,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2188,7 +2195,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2364,7 +2372,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/sparc64/prctl.rs
+++ b/src/sparc64/prctl.rs
@@ -74,6 +74,7 @@ pub auxv: *mut __u64,
 pub auxv_size: __u32,
 pub exe_fd: __u32,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PR_SET_PDEATHSIG: u32 = 1;
 pub const PR_GET_PDEATHSIG: u32 = 2;
 pub const PR_GET_DUMPABLE: u32 = 3;
@@ -240,3 +241,20 @@ pub const PR_RISCV_V_VSTATE_CTRL_INHERIT: u32 = 16;
 pub const PR_RISCV_V_VSTATE_CTRL_CUR_MASK: u32 = 3;
 pub const PR_RISCV_V_VSTATE_CTRL_NEXT_MASK: u32 = 12;
 pub const PR_RISCV_V_VSTATE_CTRL_MASK: u32 = 31;
+pub const PR_RISCV_SET_ICACHE_FLUSH_CTX: u32 = 71;
+pub const PR_RISCV_CTX_SW_FENCEI_ON: u32 = 0;
+pub const PR_RISCV_CTX_SW_FENCEI_OFF: u32 = 1;
+pub const PR_RISCV_SCOPE_PER_PROCESS: u32 = 0;
+pub const PR_RISCV_SCOPE_PER_THREAD: u32 = 1;
+pub const PR_PPC_GET_DEXCR: u32 = 72;
+pub const PR_PPC_SET_DEXCR: u32 = 73;
+pub const PR_PPC_DEXCR_SBHE: u32 = 0;
+pub const PR_PPC_DEXCR_IBRTPD: u32 = 1;
+pub const PR_PPC_DEXCR_SRAPD: u32 = 2;
+pub const PR_PPC_DEXCR_NPHIE: u32 = 3;
+pub const PR_PPC_DEXCR_CTRL_EDITABLE: u32 = 1;
+pub const PR_PPC_DEXCR_CTRL_SET: u32 = 2;
+pub const PR_PPC_DEXCR_CTRL_CLEAR: u32 = 4;
+pub const PR_PPC_DEXCR_CTRL_SET_ONEXEC: u32 = 8;
+pub const PR_PPC_DEXCR_CTRL_CLEAR_ONEXEC: u32 = 16;
+pub const PR_PPC_DEXCR_CTRL_MASK: u32 = 31;

--- a/src/sparc64/system.rs
+++ b/src/sparc64/system.rs
@@ -105,6 +105,7 @@ pub version: [crate::ctypes::c_char; 65usize],
 pub machine: [crate::ctypes::c_char; 65usize],
 pub domainname: [crate::ctypes::c_char; 65usize],
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const SI_LOAD_SHIFT: u32 = 16;
 pub const __OLD_UTS_LEN: u32 = 8;
 pub const __NEW_UTS_LEN: u32 = 64;

--- a/src/sparc64/xdp.rs
+++ b/src/sparc64/xdp.rs
@@ -160,6 +160,7 @@ pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,
 pub tx_invalid_descs: __u64,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
@@ -167,6 +168,7 @@ pub const XDP_USE_NEED_WAKEUP: u32 = 8;
 pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
 pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
+pub const XDP_UMEM_TX_METADATA_LEN: u32 = 4;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;

--- a/src/x32/bootparam.rs
+++ b/src/x32/bootparam.rs
@@ -55,6 +55,64 @@ pub type apm_eventinfo_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Default)]
 pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
+#[repr(C)]
+#[derive(Debug)]
+pub struct setup_data {
+pub next: __u64,
+pub type_: __u32,
+pub len: __u32,
+pub data: __IncompleteArrayField<__u8>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct setup_indirect {
+pub type_: __u32,
+pub reserved: __u32,
+pub len: __u64,
+pub addr: __u64,
+}
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct boot_e820_entry {
+pub addr: __u64,
+pub size: __u64,
+pub type_: __u32,
+}
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct jailhouse_setup_data {
+pub hdr: jailhouse_setup_data__bindgen_ty_1,
+pub v1: jailhouse_setup_data__bindgen_ty_2,
+pub v2: jailhouse_setup_data__bindgen_ty_3,
+}
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct jailhouse_setup_data__bindgen_ty_1 {
+pub version: __u16,
+pub compatible_version: __u16,
+}
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct jailhouse_setup_data__bindgen_ty_2 {
+pub pm_timer_address: __u16,
+pub num_cpus: __u16,
+pub pci_mmconfig_base: __u64,
+pub tsc_khz: __u32,
+pub apic_khz: __u32,
+pub standard_ioapic: __u8,
+pub cpu_ids: [__u8; 255usize],
+}
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct jailhouse_setup_data__bindgen_ty_3 {
+pub flags: __u32,
+}
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct ima_setup_data {
+pub addr: __u64,
+pub size: __u64,
+}
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct screen_info {
@@ -271,22 +329,6 @@ pub perf_level: __u32,
 pub struct edid_info {
 pub dummy: [crate::ctypes::c_uchar; 128usize],
 }
-#[repr(C)]
-#[derive(Debug)]
-pub struct setup_data {
-pub next: __u64,
-pub type_: __u32,
-pub len: __u32,
-pub data: __IncompleteArrayField<__u8>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct setup_indirect {
-pub type_: __u32,
-pub reserved: __u32,
-pub len: __u64,
-pub addr: __u64,
-}
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct setup_header {
@@ -357,48 +399,6 @@ pub efi_systab_hi: __u32,
 pub efi_memmap_hi: __u32,
 }
 #[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct boot_e820_entry {
-pub addr: __u64,
-pub size: __u64,
-pub type_: __u32,
-}
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct jailhouse_setup_data {
-pub hdr: jailhouse_setup_data__bindgen_ty_1,
-pub v1: jailhouse_setup_data__bindgen_ty_2,
-pub v2: jailhouse_setup_data__bindgen_ty_3,
-}
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct jailhouse_setup_data__bindgen_ty_1 {
-pub version: __u16,
-pub compatible_version: __u16,
-}
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct jailhouse_setup_data__bindgen_ty_2 {
-pub pm_timer_address: __u16,
-pub num_cpus: __u16,
-pub pci_mmconfig_base: __u64,
-pub tsc_khz: __u32,
-pub apic_khz: __u32,
-pub standard_ioapic: __u8,
-pub cpu_ids: [__u8; 255usize],
-}
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct jailhouse_setup_data__bindgen_ty_3 {
-pub flags: __u32,
-}
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct ima_setup_data {
-pub addr: __u64,
-pub size: __u64,
-}
-#[repr(C, packed)]
 #[derive(Copy, Clone)]
 pub struct boot_params {
 pub screen_info: screen_info,
@@ -450,6 +450,7 @@ pub const SETUP_RNG_SEED: u32 = 9;
 pub const SETUP_ENUM_MAX: u32 = 9;
 pub const SETUP_INDIRECT: u32 = 2147483648;
 pub const SETUP_TYPE_MAX: u32 = 2147483657;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const RAMDISK_IMAGE_START_MASK: u32 = 2047;
 pub const RAMDISK_PROMPT_FLAG: u32 = 32768;
 pub const RAMDISK_LOAD_FLAG: u32 = 16384;
@@ -465,6 +466,7 @@ pub const XLF_EFI_HANDOVER_64: u32 = 8;
 pub const XLF_EFI_KEXEC: u32 = 16;
 pub const XLF_5LEVEL: u32 = 32;
 pub const XLF_5LEVEL_ENABLED: u32 = 64;
+pub const XLF_MEM_ENCRYPTION: u32 = 128;
 pub const VIDEO_TYPE_MDA: u32 = 16;
 pub const VIDEO_TYPE_CGA: u32 = 17;
 pub const VIDEO_TYPE_EGAM: u32 = 32;

--- a/src/x32/btrfs.rs
+++ b/src/x32/btrfs.rs
@@ -138,7 +138,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -156,7 +156,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -166,6 +167,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -181,6 +183,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -247,6 +261,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -857,10 +890,17 @@ pub physical: __le64,
 }
 #[repr(C, packed)]
 pub struct btrfs_stripe_extent {
-pub encoding: __u8,
-pub reserved: [__u8; 7usize],
+pub __bindgen_anon_1: btrfs_stripe_extent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct btrfs_stripe_extent__bindgen_ty_1 {
+pub __empty_strides: btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1,
 pub strides: __IncompleteArrayField<btrfs_raid_stride>,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct btrfs_extent_item {
@@ -1129,6 +1169,7 @@ pub encryption: __u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _IOC_NRBITS: u32 = 8;
 pub const _IOC_TYPEBITS: u32 = 8;
 pub const _IOC_SIZEBITS: u32 = 14;
@@ -1276,13 +1317,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1354,6 +1399,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1386,6 +1432,7 @@ pub const BTRFS_QGROUP_LIMIT_RSV_EXCL: u32 = 8;
 pub const BTRFS_QGROUP_LIMIT_RFER_CMPR: u32 = 16;
 pub const BTRFS_QGROUP_LIMIT_EXCL_CMPR: u32 = 32;
 pub const BTRFS_QGROUP_INHERIT_SET_LIMITS: u32 = 1;
+pub const BTRFS_QGROUP_INHERIT_FLAGS_SUPP: u32 = 1;
 pub const BTRFS_DEVICE_REMOVE_ARGS_MASK: u32 = 8;
 pub const BTRFS_SUBVOL_CREATE_ARGS_MASK: u32 = 6;
 pub const BTRFS_SUBVOL_DELETE_ARGS_MASK: u32 = 16;
@@ -1591,14 +1638,6 @@ pub const BTRFS_SYSTEM_CHUNK_ARRAY_SIZE: u32 = 2048;
 pub const BTRFS_NUM_BACKUP_ROOTS: u32 = 4;
 pub const BTRFS_FREE_SPACE_EXTENT: u32 = 1;
 pub const BTRFS_FREE_SPACE_BITMAP: u32 = 2;
-pub const BTRFS_STRIPE_RAID0: u32 = 1;
-pub const BTRFS_STRIPE_RAID1: u32 = 2;
-pub const BTRFS_STRIPE_DUP: u32 = 3;
-pub const BTRFS_STRIPE_RAID10: u32 = 4;
-pub const BTRFS_STRIPE_RAID5: u32 = 5;
-pub const BTRFS_STRIPE_RAID6: u32 = 6;
-pub const BTRFS_STRIPE_RAID1C3: u32 = 7;
-pub const BTRFS_STRIPE_RAID1C4: u32 = 8;
 pub const BTRFS_HEADER_FLAG_WRITTEN: u32 = 1;
 pub const BTRFS_HEADER_FLAG_RELOC: u32 = 2;
 pub const BTRFS_SUPER_FLAG_ERROR: u32 = 4;
@@ -1607,6 +1646,9 @@ pub const BTRFS_SUPER_FLAG_METADUMP: u64 = 8589934592;
 pub const BTRFS_SUPER_FLAG_METADUMP_V2: u64 = 17179869184;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID: u64 = 34359738368;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID_V2: u64 = 68719476736;
+pub const BTRFS_SUPER_FLAG_CHANGING_BG_TREE: u64 = 274877906944;
+pub const BTRFS_SUPER_FLAG_CHANGING_DATA_CSUM: u64 = 549755813888;
+pub const BTRFS_SUPER_FLAG_CHANGING_META_CSUM: u64 = 1099511627776;
 pub const BTRFS_EXTENT_FLAG_DATA: u32 = 1;
 pub const BTRFS_EXTENT_FLAG_TREE_BLOCK: u32 = 2;
 pub const BTRFS_BLOCK_FLAG_FULL_BACKREF: u32 = 256;
@@ -1662,6 +1704,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/x32/general.rs
+++ b/src/x32/general.rs
@@ -163,6 +163,14 @@ pub data: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct epoll_params {
+pub busy_poll_usecs: __u32,
+pub busy_poll_budget: __u16,
+pub prefer_busy_poll: __u8,
+pub __pad: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct fscrypt_policy_v1 {
 pub version: __u8,
 pub contents_encryption_mode: __u8,
@@ -245,7 +253,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -263,7 +271,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -273,6 +282,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -288,6 +298,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -357,6 +379,25 @@ pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct futex_waitv {
 pub val: __u64,
 pub uaddr: __u64,
@@ -412,6 +453,14 @@ pub struct rand_pool_info {
 pub entropy_count: crate::ctypes::c_int,
 pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vgetrandom_opaque_params {
+pub size_of_opaque_state: __u32,
+pub mmap_prot: __u32,
+pub mmap_flags: __u32,
+pub reserved: [__u32; 13usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -641,7 +690,12 @@ pub stx_dev_minor: __u32,
 pub stx_mnt_id: __u64,
 pub stx_dio_mem_align: __u32,
 pub stx_dio_offset_align: __u32,
-pub __spare3: [__u64; 12usize],
+pub stx_subvol: __u64,
+pub stx_atomic_write_unit_min: __u32,
+pub stx_atomic_write_unit_max: __u32,
+pub stx_atomic_write_segments_max: __u32,
+pub __spare1: [__u32; 1usize],
+pub __spare3: [__u64; 9usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -954,9 +1008,9 @@ pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 395264;
+pub const LINUX_VERSION_CODE: u32 = 396032;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 11;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_VECTOR_SIZE_ARCH: u32 = 3;
@@ -984,8 +1038,11 @@ pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_RSEQ_FEATURE_SIZE: u32 = 27;
 pub const AT_RSEQ_ALIGN: u32 = 28;
+pub const AT_HWCAP3: u32 = 29;
+pub const AT_HWCAP4: u32 = 30;
 pub const AT_EXECFN: u32 = 31;
 pub const AT_MINSIGSTKSZ: u32 = 51;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
 pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
@@ -1120,9 +1177,10 @@ pub const RESOLVE_IN_ROOT: u32 = 16;
 pub const RESOLVE_CACHED: u32 = 32;
 pub const F_SETLEASE: u32 = 1024;
 pub const F_GETLEASE: u32 = 1025;
+pub const F_NOTIFY: u32 = 1026;
+pub const F_DUPFD_QUERY: u32 = 1027;
 pub const F_CANCELLK: u32 = 1029;
 pub const F_DUPFD_CLOEXEC: u32 = 1030;
-pub const F_NOTIFY: u32 = 1026;
 pub const F_SETPIPE_SZ: u32 = 1031;
 pub const F_GETPIPE_SZ: u32 = 1032;
 pub const F_ADD_SEALS: u32 = 1033;
@@ -1168,6 +1226,7 @@ pub const EPOLL_CLOEXEC: u32 = 524288;
 pub const EPOLL_CTL_ADD: u32 = 1;
 pub const EPOLL_CTL_DEL: u32 = 2;
 pub const EPOLL_CTL_MOD: u32 = 3;
+pub const EPOLL_IOC_TYPE: u32 = 138;
 pub const POSIX_FADV_NORMAL: u32 = 0;
 pub const POSIX_FADV_RANDOM: u32 = 1;
 pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
@@ -1329,13 +1388,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1407,6 +1470,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1535,6 +1599,7 @@ pub const EFIVARFS_MAGIC: u32 = 3730735588;
 pub const HOSTFS_SUPER_MAGIC: u32 = 12648430;
 pub const OVERLAYFS_SUPER_MAGIC: u32 = 2035054128;
 pub const FUSE_SUPER_MAGIC: u32 = 1702057286;
+pub const BCACHEFS_SUPER_MAGIC: u32 = 3393526350;
 pub const MINIX_SUPER_MAGIC: u32 = 4991;
 pub const MINIX_SUPER_MAGIC2: u32 = 5007;
 pub const MINIX2_SUPER_MAGIC: u32 = 9320;
@@ -1584,6 +1649,7 @@ pub const UDF_SUPER_MAGIC: u32 = 352400198;
 pub const DMA_BUF_MAGIC: u32 = 1145913666;
 pub const DEVMEM_MAGIC: u32 = 1162691661;
 pub const SECRETMEM_MAGIC: u32 = 1397048141;
+pub const PID_FS_MAGIC: u32 = 1346978886;
 pub const MAP_32BIT: u32 = 64;
 pub const MAP_ABOVE4G: u32 = 128;
 pub const SHADOW_STACK_SET_TOKEN: u32 = 1;
@@ -1669,6 +1735,7 @@ pub const OVERCOMMIT_NEVER: u32 = 2;
 pub const MAP_SHARED: u32 = 1;
 pub const MAP_PRIVATE: u32 = 2;
 pub const MAP_SHARED_VALIDATE: u32 = 3;
+pub const MAP_DROPPABLE: u32 = 8;
 pub const MAP_HUGE_SHIFT: u32 = 26;
 pub const MAP_HUGE_MASK: u32 = 63;
 pub const MAP_HUGE_16KB: u32 = 939524096;
@@ -1975,6 +2042,8 @@ pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
 pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
+pub const STATX_SUBVOL: u32 = 32768;
+pub const STATX_WRITE_ATOMIC: u32 = 65536;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -1986,6 +2055,7 @@ pub const STATX_ATTR_AUTOMOUNT: u32 = 4096;
 pub const STATX_ATTR_MOUNT_ROOT: u32 = 8192;
 pub const STATX_ATTR_VERITY: u32 = 1048576;
 pub const STATX_ATTR_DAX: u32 = 2097152;
+pub const STATX_ATTR_WRITE_ATOMIC: u32 = 4194304;
 pub const IGNBRK: u32 = 1;
 pub const BRKINT: u32 = 2;
 pub const IGNPAR: u32 = 4;
@@ -2462,6 +2532,7 @@ pub const __NR_pkey_free: u32 = 1073742155;
 pub const __NR_statx: u32 = 1073742156;
 pub const __NR_io_pgetevents: u32 = 1073742157;
 pub const __NR_rseq: u32 = 1073742158;
+pub const __NR_uretprobe: u32 = 1073742159;
 pub const __NR_pidfd_send_signal: u32 = 1073742248;
 pub const __NR_io_uring_setup: u32 = 1073742249;
 pub const __NR_io_uring_enter: u32 = 1073742250;
@@ -2491,6 +2562,7 @@ pub const __NR_futex_waitv: u32 = 1073742273;
 pub const __NR_set_mempolicy_home_node: u32 = 1073742274;
 pub const __NR_cachestat: u32 = 1073742275;
 pub const __NR_fchmodat2: u32 = 1073742276;
+pub const __NR_map_shadow_stack: u32 = 1073742277;
 pub const __NR_futex_wake: u32 = 1073742278;
 pub const __NR_futex_wait: u32 = 1073742279;
 pub const __NR_futex_requeue: u32 = 1073742280;
@@ -2499,6 +2571,7 @@ pub const __NR_listmount: u32 = 1073742282;
 pub const __NR_lsm_get_self_attr: u32 = 1073742283;
 pub const __NR_lsm_set_self_attr: u32 = 1073742284;
 pub const __NR_lsm_list_modules: u32 = 1073742285;
+pub const __NR_mseal: u32 = 1073742286;
 pub const __NR_rt_sigaction: u32 = 1073742336;
 pub const __NR_rt_sigreturn: u32 = 1073742337;
 pub const __NR_ioctl: u32 = 1073742338;
@@ -2721,6 +2794,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/x32/if_arp.rs
+++ b/src/x32/if_arp.rs
@@ -612,6 +612,7 @@ pub ar_hln: crate::ctypes::c_uchar,
 pub ar_pln: crate::ctypes::c_uchar,
 pub ar_op: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1381,6 +1382,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
@@ -1414,6 +1417,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1515,6 +1519,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
@@ -2281,7 +2286,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2319,7 +2326,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2495,7 +2503,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/x32/if_ether.rs
+++ b/src/x32/if_ether.rs
@@ -57,6 +57,7 @@ pub h_dest: [crate::ctypes::c_uchar; 6usize],
 pub h_source: [crate::ctypes::c_uchar; 6usize],
 pub h_proto: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const ETH_ALEN: u32 = 6;
 pub const ETH_TLEN: u32 = 2;
 pub const ETH_HLEN: u32 = 14;

--- a/src/x32/if_packet.rs
+++ b/src/x32/if_packet.rs
@@ -205,6 +205,7 @@ pub type_flags: __u16,
 pub max_num_members: __u32,
 }
 pub const __LITTLE_ENDIAN: u32 = 1234;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PACKET_HOST: u32 = 0;
 pub const PACKET_BROADCAST: u32 = 1;
 pub const PACKET_MULTICAST: u32 = 2;

--- a/src/x32/io_uring.rs
+++ b/src/x32/io_uring.rs
@@ -140,7 +140,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -158,7 +158,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -168,6 +169,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -183,6 +185,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -249,6 +263,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -492,6 +525,14 @@ pub resv: [__u32; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_napi {
+pub busy_poll_to: __u32,
+pub prefer_busy_poll: __u8,
+pub pad: [__u8; 3usize],
+pub resv: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -557,6 +598,7 @@ pub const IOC_OUT: u32 = 2147483648;
 pub const IOC_INOUT: u32 = 3221225472;
 pub const IOCSIZE_MASK: u32 = 1073676288;
 pub const IOCSIZE_SHIFT: u32 = 16;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const FSCRYPT_POLICY_FLAGS_PAD_4: u32 = 0;
 pub const FSCRYPT_POLICY_FLAGS_PAD_8: u32 = 1;
 pub const FSCRYPT_POLICY_FLAGS_PAD_16: u32 = 2;
@@ -671,13 +713,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -749,6 +795,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -804,15 +851,20 @@ pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
 pub const IORING_SEND_ZC_REPORT_USAGE: u32 = 8;
+pub const IORING_RECVSEND_BUNDLE: u32 = 16;
 pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
+pub const IORING_ACCEPT_DONTWAIT: u32 = 2;
+pub const IORING_ACCEPT_POLL_FIRST: u32 = 4;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
 pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
+pub const IORING_NOP_INJECT_RESULT: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
 pub const IORING_CQE_F_NOTIF: u32 = 8;
+pub const IORING_CQE_BUFFER_SHIFT: u32 = 16;
 pub const IORING_OFF_SQ_RING: u32 = 0;
 pub const IORING_OFF_CQ_RING: u32 = 134217728;
 pub const IORING_OFF_SQES: u32 = 268435456;
@@ -842,60 +894,10 @@ pub const IORING_FEAT_RSRC_TAGS: u32 = 1024;
 pub const IORING_FEAT_CQE_SKIP: u32 = 2048;
 pub const IORING_FEAT_LINKED_FILE: u32 = 4096;
 pub const IORING_FEAT_REG_REG_RING: u32 = 8192;
+pub const IORING_FEAT_RECVSEND_BUNDLE: u32 = 16384;
 pub const IORING_RSRC_REGISTER_SPARSE: u32 = 1;
 pub const IORING_REGISTER_FILES_SKIP: i32 = -2;
 pub const IO_URING_OP_SUPPORTED: u32 = 1;
-pub const IOSQE_FIXED_FILE_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_FIXED_FILE_BIT;
-pub const IOSQE_IO_DRAIN_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_DRAIN_BIT;
-pub const IOSQE_IO_LINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_LINK_BIT;
-pub const IOSQE_IO_HARDLINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_HARDLINK_BIT;
-pub const IOSQE_ASYNC_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_ASYNC_BIT;
-pub const IOSQE_BUFFER_SELECT_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_BUFFER_SELECT_BIT;
-pub const IOSQE_CQE_SKIP_SUCCESS_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_CQE_SKIP_SUCCESS_BIT;
-pub const IORING_MSG_DATA: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_DATA;
-pub const IORING_MSG_SEND_FD: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_SEND_FD;
-pub const IORING_CQE_BUFFER_SHIFT: _bindgen_ty_3 = _bindgen_ty_3::IORING_CQE_BUFFER_SHIFT;
-pub const IORING_REGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS;
-pub const IORING_UNREGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_BUFFERS;
-pub const IORING_REGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES;
-pub const IORING_UNREGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_FILES;
-pub const IORING_REGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD;
-pub const IORING_UNREGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_EVENTFD;
-pub const IORING_REGISTER_FILES_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE;
-pub const IORING_REGISTER_EVENTFD_ASYNC: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD_ASYNC;
-pub const IORING_REGISTER_PROBE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PROBE;
-pub const IORING_REGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PERSONALITY;
-pub const IORING_UNREGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PERSONALITY;
-pub const IORING_REGISTER_RESTRICTIONS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RESTRICTIONS;
-pub const IORING_REGISTER_ENABLE_RINGS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_ENABLE_RINGS;
-pub const IORING_REGISTER_FILES2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES2;
-pub const IORING_REGISTER_FILES_UPDATE2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE2;
-pub const IORING_REGISTER_BUFFERS2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS2;
-pub const IORING_REGISTER_BUFFERS_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS_UPDATE;
-pub const IORING_REGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_AFF;
-pub const IORING_UNREGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_IOWQ_AFF;
-pub const IORING_REGISTER_IOWQ_MAX_WORKERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_MAX_WORKERS;
-pub const IORING_REGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RING_FDS;
-pub const IORING_UNREGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_RING_FDS;
-pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_RING;
-pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
-pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
-pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
-pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
-pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
-pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
-pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
-pub const IO_WQ_UNBOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_UNBOUND;
-pub const IOU_PBUF_RING_MMAP: _bindgen_ty_6 = _bindgen_ty_6::IOU_PBUF_RING_MMAP;
-pub const IORING_RESTRICTION_REGISTER_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_REGISTER_OP;
-pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_OP;
-pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
-pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
-pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
-pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
-pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
-pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
-pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -913,7 +915,18 @@ FSCONFIG_CMD_CREATE_EXCL = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_1 {
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum io_uring_sqe_flags_bit {
 IOSQE_FIXED_FILE_BIT = 0,
 IOSQE_IO_DRAIN_BIT = 1,
 IOSQE_IO_LINK_BIT = 2,
@@ -981,25 +994,22 @@ IORING_OP_FUTEX_WAIT = 51,
 IORING_OP_FUTEX_WAKE = 52,
 IORING_OP_FUTEX_WAITV = 53,
 IORING_OP_FIXED_FD_INSTALL = 54,
-IORING_OP_LAST = 55,
+IORING_OP_FTRUNCATE = 55,
+IORING_OP_BIND = 56,
+IORING_OP_LISTEN = 57,
+IORING_OP_LAST = 58,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_2 {
+pub enum io_uring_msg_ring_flags {
 IORING_MSG_DATA = 0,
 IORING_MSG_SEND_FD = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_3 {
-IORING_CQE_BUFFER_SHIFT = 16,
-}
-#[repr(u32)]
-#[non_exhaustive]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_4 {
+pub enum io_uring_register_op {
 IORING_REGISTER_BUFFERS = 0,
 IORING_UNREGISTER_BUFFERS = 1,
 IORING_REGISTER_FILES = 2,
@@ -1027,26 +1037,28 @@ IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
 IORING_REGISTER_PBUF_STATUS = 26,
-IORING_REGISTER_LAST = 27,
+IORING_REGISTER_NAPI = 27,
+IORING_UNREGISTER_NAPI = 28,
+IORING_REGISTER_LAST = 29,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_5 {
+pub enum io_wq_type {
 IO_WQ_BOUND = 0,
 IO_WQ_UNBOUND = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_6 {
+pub enum io_uring_register_pbuf_ring_flags {
 IOU_PBUF_RING_MMAP = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_7 {
+pub enum io_uring_register_restriction_op {
 IORING_RESTRICTION_REGISTER_OP = 0,
 IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
@@ -1056,7 +1068,7 @@ IORING_RESTRICTION_LAST = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_8 {
+pub enum io_uring_socket_op {
 SOCKET_URING_OP_SIOCINQ = 0,
 SOCKET_URING_OP_SIOCOUTQ = 1,
 SOCKET_URING_OP_GETSOCKOPT = 2,
@@ -1115,6 +1127,7 @@ pub uring_cmd_flags: __u32,
 pub waitid_flags: __u32,
 pub futex_flags: __u32,
 pub install_fd_flags: __u32,
+pub nop_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]

--- a/src/x32/loop_device.rs
+++ b/src/x32/loop_device.rs
@@ -93,6 +93,7 @@ pub __reserved: [__u64; 8usize],
 }
 pub const LO_NAME_SIZE: u32 = 64;
 pub const LO_KEY_SIZE: u32 = 32;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const LO_CRYPT_NONE: u32 = 0;
 pub const LO_CRYPT_XOR: u32 = 1;
 pub const LO_CRYPT_DES: u32 = 2;

--- a/src/x32/mempolicy.rs
+++ b/src/x32/mempolicy.rs
@@ -158,6 +158,7 @@ pub const MPOL_BIND: _bindgen_ty_1 = _bindgen_ty_1::MPOL_BIND;
 pub const MPOL_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_INTERLEAVE;
 pub const MPOL_LOCAL: _bindgen_ty_1 = _bindgen_ty_1::MPOL_LOCAL;
 pub const MPOL_PREFERRED_MANY: _bindgen_ty_1 = _bindgen_ty_1::MPOL_PREFERRED_MANY;
+pub const MPOL_WEIGHTED_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_WEIGHTED_INTERLEAVE;
 pub const MPOL_MAX: _bindgen_ty_1 = _bindgen_ty_1::MPOL_MAX;
 #[repr(u32)]
 #[non_exhaustive]
@@ -169,5 +170,6 @@ MPOL_BIND = 2,
 MPOL_INTERLEAVE = 3,
 MPOL_LOCAL = 4,
 MPOL_PREFERRED_MANY = 5,
-MPOL_MAX = 6,
+MPOL_WEIGHTED_INTERLEAVE = 6,
+MPOL_MAX = 7,
 }

--- a/src/x32/net.rs
+++ b/src/x32/net.rs
@@ -856,6 +856,7 @@ pub _address: u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1269,6 +1270,7 @@ pub const TCP_AO_DEL_KEY: u32 = 39;
 pub const TCP_AO_INFO: u32 = 40;
 pub const TCP_AO_GET_KEYS: u32 = 41;
 pub const TCP_AO_REPAIR: u32 = 42;
+pub const TCP_IS_MPTCP: u32 = 43;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1555,6 +1557,7 @@ pub const IPPROTO_UDPLITE: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_UDPLITE;
 pub const IPPROTO_MPLS: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPLS;
 pub const IPPROTO_ETHERNET: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ETHERNET;
 pub const IPPROTO_RAW: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_RAW;
+pub const IPPROTO_SMC: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_SMC;
 pub const IPPROTO_MPTCP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPTCP;
 pub const IPPROTO_MAX: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MAX;
 pub const IPV4_DEVCONF_FORWARDING: _bindgen_ty_2 = _bindgen_ty_2::IPV4_DEVCONF_FORWARDING;
@@ -1743,6 +1746,7 @@ IPPROTO_UDPLITE = 136,
 IPPROTO_MPLS = 137,
 IPPROTO_ETHERNET = 143,
 IPPROTO_RAW = 255,
+IPPROTO_SMC = 256,
 IPPROTO_MPTCP = 262,
 IPPROTO_MAX = 263,
 }

--- a/src/x32/netlink.rs
+++ b/src/x32/netlink.rs
@@ -549,6 +549,7 @@ pub const SOCK_BUF_LOCK_MASK: u32 = 3;
 pub const SOCK_TXREHASH_DEFAULT: u32 = 255;
 pub const SOCK_TXREHASH_DISABLED: u32 = 0;
 pub const SOCK_TXREHASH_ENABLED: u32 = 1;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const NETLINK_ROUTE: u32 = 0;
 pub const NETLINK_UNUSED: u32 = 1;
 pub const NETLINK_USERSOCK: u32 = 2;
@@ -1096,6 +1097,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
@@ -1129,6 +1132,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1230,6 +1234,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
@@ -2144,7 +2149,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2182,7 +2189,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2358,7 +2366,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/x32/prctl.rs
+++ b/src/x32/prctl.rs
@@ -68,6 +68,7 @@ pub auxv: *mut __u64,
 pub auxv_size: __u32,
 pub exe_fd: __u32,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PR_SET_PDEATHSIG: u32 = 1;
 pub const PR_GET_PDEATHSIG: u32 = 2;
 pub const PR_GET_DUMPABLE: u32 = 3;
@@ -234,3 +235,20 @@ pub const PR_RISCV_V_VSTATE_CTRL_INHERIT: u32 = 16;
 pub const PR_RISCV_V_VSTATE_CTRL_CUR_MASK: u32 = 3;
 pub const PR_RISCV_V_VSTATE_CTRL_NEXT_MASK: u32 = 12;
 pub const PR_RISCV_V_VSTATE_CTRL_MASK: u32 = 31;
+pub const PR_RISCV_SET_ICACHE_FLUSH_CTX: u32 = 71;
+pub const PR_RISCV_CTX_SW_FENCEI_ON: u32 = 0;
+pub const PR_RISCV_CTX_SW_FENCEI_OFF: u32 = 1;
+pub const PR_RISCV_SCOPE_PER_PROCESS: u32 = 0;
+pub const PR_RISCV_SCOPE_PER_THREAD: u32 = 1;
+pub const PR_PPC_GET_DEXCR: u32 = 72;
+pub const PR_PPC_SET_DEXCR: u32 = 73;
+pub const PR_PPC_DEXCR_SBHE: u32 = 0;
+pub const PR_PPC_DEXCR_IBRTPD: u32 = 1;
+pub const PR_PPC_DEXCR_SRAPD: u32 = 2;
+pub const PR_PPC_DEXCR_NPHIE: u32 = 3;
+pub const PR_PPC_DEXCR_CTRL_EDITABLE: u32 = 1;
+pub const PR_PPC_DEXCR_CTRL_SET: u32 = 2;
+pub const PR_PPC_DEXCR_CTRL_CLEAR: u32 = 4;
+pub const PR_PPC_DEXCR_CTRL_SET_ONEXEC: u32 = 8;
+pub const PR_PPC_DEXCR_CTRL_CLEAR_ONEXEC: u32 = 16;
+pub const PR_PPC_DEXCR_CTRL_MASK: u32 = 31;

--- a/src/x32/system.rs
+++ b/src/x32/system.rs
@@ -99,6 +99,7 @@ pub version: [crate::ctypes::c_char; 65usize],
 pub machine: [crate::ctypes::c_char; 65usize],
 pub domainname: [crate::ctypes::c_char; 65usize],
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const SI_LOAD_SHIFT: u32 = 16;
 pub const __OLD_UTS_LEN: u32 = 8;
 pub const __NEW_UTS_LEN: u32 = 64;

--- a/src/x32/xdp.rs
+++ b/src/x32/xdp.rs
@@ -154,6 +154,7 @@ pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,
 pub tx_invalid_descs: __u64,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
@@ -161,6 +162,7 @@ pub const XDP_USE_NEED_WAKEUP: u32 = 8;
 pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
 pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
+pub const XDP_UMEM_TX_METADATA_LEN: u32 = 4;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;

--- a/src/x86/bootparam.rs
+++ b/src/x86/bootparam.rs
@@ -53,6 +53,64 @@ pub type apm_eventinfo_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Default)]
 pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
+#[repr(C)]
+#[derive(Debug)]
+pub struct setup_data {
+pub next: __u64,
+pub type_: __u32,
+pub len: __u32,
+pub data: __IncompleteArrayField<__u8>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct setup_indirect {
+pub type_: __u32,
+pub reserved: __u32,
+pub len: __u64,
+pub addr: __u64,
+}
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct boot_e820_entry {
+pub addr: __u64,
+pub size: __u64,
+pub type_: __u32,
+}
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct jailhouse_setup_data {
+pub hdr: jailhouse_setup_data__bindgen_ty_1,
+pub v1: jailhouse_setup_data__bindgen_ty_2,
+pub v2: jailhouse_setup_data__bindgen_ty_3,
+}
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct jailhouse_setup_data__bindgen_ty_1 {
+pub version: __u16,
+pub compatible_version: __u16,
+}
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct jailhouse_setup_data__bindgen_ty_2 {
+pub pm_timer_address: __u16,
+pub num_cpus: __u16,
+pub pci_mmconfig_base: __u64,
+pub tsc_khz: __u32,
+pub apic_khz: __u32,
+pub standard_ioapic: __u8,
+pub cpu_ids: [__u8; 255usize],
+}
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct jailhouse_setup_data__bindgen_ty_3 {
+pub flags: __u32,
+}
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct ima_setup_data {
+pub addr: __u64,
+pub size: __u64,
+}
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct screen_info {
@@ -269,22 +327,6 @@ pub perf_level: __u32,
 pub struct edid_info {
 pub dummy: [crate::ctypes::c_uchar; 128usize],
 }
-#[repr(C)]
-#[derive(Debug)]
-pub struct setup_data {
-pub next: __u64,
-pub type_: __u32,
-pub len: __u32,
-pub data: __IncompleteArrayField<__u8>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct setup_indirect {
-pub type_: __u32,
-pub reserved: __u32,
-pub len: __u64,
-pub addr: __u64,
-}
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct setup_header {
@@ -355,48 +397,6 @@ pub efi_systab_hi: __u32,
 pub efi_memmap_hi: __u32,
 }
 #[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct boot_e820_entry {
-pub addr: __u64,
-pub size: __u64,
-pub type_: __u32,
-}
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct jailhouse_setup_data {
-pub hdr: jailhouse_setup_data__bindgen_ty_1,
-pub v1: jailhouse_setup_data__bindgen_ty_2,
-pub v2: jailhouse_setup_data__bindgen_ty_3,
-}
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct jailhouse_setup_data__bindgen_ty_1 {
-pub version: __u16,
-pub compatible_version: __u16,
-}
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct jailhouse_setup_data__bindgen_ty_2 {
-pub pm_timer_address: __u16,
-pub num_cpus: __u16,
-pub pci_mmconfig_base: __u64,
-pub tsc_khz: __u32,
-pub apic_khz: __u32,
-pub standard_ioapic: __u8,
-pub cpu_ids: [__u8; 255usize],
-}
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct jailhouse_setup_data__bindgen_ty_3 {
-pub flags: __u32,
-}
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct ima_setup_data {
-pub addr: __u64,
-pub size: __u64,
-}
-#[repr(C, packed)]
 #[derive(Copy, Clone)]
 pub struct boot_params {
 pub screen_info: screen_info,
@@ -448,6 +448,7 @@ pub const SETUP_RNG_SEED: u32 = 9;
 pub const SETUP_ENUM_MAX: u32 = 9;
 pub const SETUP_INDIRECT: u32 = 2147483648;
 pub const SETUP_TYPE_MAX: u32 = 2147483657;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const RAMDISK_IMAGE_START_MASK: u32 = 2047;
 pub const RAMDISK_PROMPT_FLAG: u32 = 32768;
 pub const RAMDISK_LOAD_FLAG: u32 = 16384;
@@ -463,6 +464,7 @@ pub const XLF_EFI_HANDOVER_64: u32 = 8;
 pub const XLF_EFI_KEXEC: u32 = 16;
 pub const XLF_5LEVEL: u32 = 32;
 pub const XLF_5LEVEL_ENABLED: u32 = 64;
+pub const XLF_MEM_ENCRYPTION: u32 = 128;
 pub const VIDEO_TYPE_MDA: u32 = 16;
 pub const VIDEO_TYPE_CGA: u32 = 17;
 pub const VIDEO_TYPE_EGAM: u32 = 32;

--- a/src/x86/btrfs.rs
+++ b/src/x86/btrfs.rs
@@ -136,7 +136,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -154,7 +154,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -164,6 +165,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -179,6 +181,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -245,6 +259,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -855,10 +888,17 @@ pub physical: __le64,
 }
 #[repr(C, packed)]
 pub struct btrfs_stripe_extent {
-pub encoding: __u8,
-pub reserved: [__u8; 7usize],
+pub __bindgen_anon_1: btrfs_stripe_extent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct btrfs_stripe_extent__bindgen_ty_1 {
+pub __empty_strides: btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1,
 pub strides: __IncompleteArrayField<btrfs_raid_stride>,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct btrfs_extent_item {
@@ -1127,6 +1167,7 @@ pub encryption: __u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _IOC_NRBITS: u32 = 8;
 pub const _IOC_TYPEBITS: u32 = 8;
 pub const _IOC_SIZEBITS: u32 = 14;
@@ -1274,13 +1315,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1352,6 +1397,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1384,6 +1430,7 @@ pub const BTRFS_QGROUP_LIMIT_RSV_EXCL: u32 = 8;
 pub const BTRFS_QGROUP_LIMIT_RFER_CMPR: u32 = 16;
 pub const BTRFS_QGROUP_LIMIT_EXCL_CMPR: u32 = 32;
 pub const BTRFS_QGROUP_INHERIT_SET_LIMITS: u32 = 1;
+pub const BTRFS_QGROUP_INHERIT_FLAGS_SUPP: u32 = 1;
 pub const BTRFS_DEVICE_REMOVE_ARGS_MASK: u32 = 8;
 pub const BTRFS_SUBVOL_CREATE_ARGS_MASK: u32 = 6;
 pub const BTRFS_SUBVOL_DELETE_ARGS_MASK: u32 = 16;
@@ -1589,14 +1636,6 @@ pub const BTRFS_SYSTEM_CHUNK_ARRAY_SIZE: u32 = 2048;
 pub const BTRFS_NUM_BACKUP_ROOTS: u32 = 4;
 pub const BTRFS_FREE_SPACE_EXTENT: u32 = 1;
 pub const BTRFS_FREE_SPACE_BITMAP: u32 = 2;
-pub const BTRFS_STRIPE_RAID0: u32 = 1;
-pub const BTRFS_STRIPE_RAID1: u32 = 2;
-pub const BTRFS_STRIPE_DUP: u32 = 3;
-pub const BTRFS_STRIPE_RAID10: u32 = 4;
-pub const BTRFS_STRIPE_RAID5: u32 = 5;
-pub const BTRFS_STRIPE_RAID6: u32 = 6;
-pub const BTRFS_STRIPE_RAID1C3: u32 = 7;
-pub const BTRFS_STRIPE_RAID1C4: u32 = 8;
 pub const BTRFS_HEADER_FLAG_WRITTEN: u32 = 1;
 pub const BTRFS_HEADER_FLAG_RELOC: u32 = 2;
 pub const BTRFS_SUPER_FLAG_ERROR: u32 = 4;
@@ -1605,6 +1644,9 @@ pub const BTRFS_SUPER_FLAG_METADUMP: u64 = 8589934592;
 pub const BTRFS_SUPER_FLAG_METADUMP_V2: u64 = 17179869184;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID: u64 = 34359738368;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID_V2: u64 = 68719476736;
+pub const BTRFS_SUPER_FLAG_CHANGING_BG_TREE: u64 = 274877906944;
+pub const BTRFS_SUPER_FLAG_CHANGING_DATA_CSUM: u64 = 549755813888;
+pub const BTRFS_SUPER_FLAG_CHANGING_META_CSUM: u64 = 1099511627776;
 pub const BTRFS_EXTENT_FLAG_DATA: u32 = 1;
 pub const BTRFS_EXTENT_FLAG_TREE_BLOCK: u32 = 2;
 pub const BTRFS_BLOCK_FLAG_FULL_BACKREF: u32 = 256;
@@ -1660,6 +1702,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/x86/general.rs
+++ b/src/x86/general.rs
@@ -160,6 +160,14 @@ pub data: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct epoll_params {
+pub busy_poll_usecs: __u32,
+pub busy_poll_budget: __u16,
+pub prefer_busy_poll: __u8,
+pub __pad: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct fscrypt_policy_v1 {
 pub version: __u8,
 pub contents_encryption_mode: __u8,
@@ -242,7 +250,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -260,7 +268,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -270,6 +279,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -285,6 +295,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -354,6 +376,25 @@ pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct futex_waitv {
 pub val: __u64,
 pub uaddr: __u64,
@@ -409,6 +450,14 @@ pub struct rand_pool_info {
 pub entropy_count: crate::ctypes::c_int,
 pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vgetrandom_opaque_params {
+pub size_of_opaque_state: __u32,
+pub mmap_prot: __u32,
+pub mmap_flags: __u32,
+pub reserved: [__u32; 13usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -638,7 +687,12 @@ pub stx_dev_minor: __u32,
 pub stx_mnt_id: __u64,
 pub stx_dio_mem_align: __u32,
 pub stx_dio_offset_align: __u32,
-pub __spare3: [__u64; 12usize],
+pub stx_subvol: __u64,
+pub stx_atomic_write_unit_min: __u32,
+pub stx_atomic_write_unit_max: __u32,
+pub stx_atomic_write_segments_max: __u32,
+pub __spare1: [__u32; 1usize],
+pub __spare3: [__u64; 9usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -974,9 +1028,9 @@ pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 395264;
+pub const LINUX_VERSION_CODE: u32 = 396032;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 11;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO: u32 = 32;
 pub const AT_SYSINFO_EHDR: u32 = 33;
@@ -1005,8 +1059,11 @@ pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_RSEQ_FEATURE_SIZE: u32 = 27;
 pub const AT_RSEQ_ALIGN: u32 = 28;
+pub const AT_HWCAP3: u32 = 29;
+pub const AT_HWCAP4: u32 = 30;
 pub const AT_EXECFN: u32 = 31;
 pub const AT_MINSIGSTKSZ: u32 = 51;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
 pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
@@ -1141,9 +1198,10 @@ pub const RESOLVE_IN_ROOT: u32 = 16;
 pub const RESOLVE_CACHED: u32 = 32;
 pub const F_SETLEASE: u32 = 1024;
 pub const F_GETLEASE: u32 = 1025;
+pub const F_NOTIFY: u32 = 1026;
+pub const F_DUPFD_QUERY: u32 = 1027;
 pub const F_CANCELLK: u32 = 1029;
 pub const F_DUPFD_CLOEXEC: u32 = 1030;
-pub const F_NOTIFY: u32 = 1026;
 pub const F_SETPIPE_SZ: u32 = 1031;
 pub const F_GETPIPE_SZ: u32 = 1032;
 pub const F_ADD_SEALS: u32 = 1033;
@@ -1189,6 +1247,7 @@ pub const EPOLL_CLOEXEC: u32 = 524288;
 pub const EPOLL_CTL_ADD: u32 = 1;
 pub const EPOLL_CTL_DEL: u32 = 2;
 pub const EPOLL_CTL_MOD: u32 = 3;
+pub const EPOLL_IOC_TYPE: u32 = 138;
 pub const POSIX_FADV_NORMAL: u32 = 0;
 pub const POSIX_FADV_RANDOM: u32 = 1;
 pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
@@ -1350,13 +1409,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1428,6 +1491,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1556,6 +1620,7 @@ pub const EFIVARFS_MAGIC: u32 = 3730735588;
 pub const HOSTFS_SUPER_MAGIC: u32 = 12648430;
 pub const OVERLAYFS_SUPER_MAGIC: u32 = 2035054128;
 pub const FUSE_SUPER_MAGIC: u32 = 1702057286;
+pub const BCACHEFS_SUPER_MAGIC: u32 = 3393526350;
 pub const MINIX_SUPER_MAGIC: u32 = 4991;
 pub const MINIX_SUPER_MAGIC2: u32 = 5007;
 pub const MINIX2_SUPER_MAGIC: u32 = 9320;
@@ -1605,6 +1670,7 @@ pub const UDF_SUPER_MAGIC: u32 = 352400198;
 pub const DMA_BUF_MAGIC: u32 = 1145913666;
 pub const DEVMEM_MAGIC: u32 = 1162691661;
 pub const SECRETMEM_MAGIC: u32 = 1397048141;
+pub const PID_FS_MAGIC: u32 = 1346978886;
 pub const MAP_32BIT: u32 = 64;
 pub const MAP_ABOVE4G: u32 = 128;
 pub const SHADOW_STACK_SET_TOKEN: u32 = 1;
@@ -1690,6 +1756,7 @@ pub const OVERCOMMIT_NEVER: u32 = 2;
 pub const MAP_SHARED: u32 = 1;
 pub const MAP_PRIVATE: u32 = 2;
 pub const MAP_SHARED_VALIDATE: u32 = 3;
+pub const MAP_DROPPABLE: u32 = 8;
 pub const MAP_HUGE_SHIFT: u32 = 26;
 pub const MAP_HUGE_MASK: u32 = 63;
 pub const MAP_HUGE_16KB: u32 = 939524096;
@@ -1996,6 +2063,8 @@ pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
 pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
+pub const STATX_SUBVOL: u32 = 32768;
+pub const STATX_WRITE_ATOMIC: u32 = 65536;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -2007,6 +2076,7 @@ pub const STATX_ATTR_AUTOMOUNT: u32 = 4096;
 pub const STATX_ATTR_MOUNT_ROOT: u32 = 8192;
 pub const STATX_ATTR_VERITY: u32 = 1048576;
 pub const STATX_ATTR_DAX: u32 = 2097152;
+pub const STATX_ATTR_WRITE_ATOMIC: u32 = 4194304;
 pub const IGNBRK: u32 = 1;
 pub const BRKINT: u32 = 2;
 pub const IGNPAR: u32 = 4;
@@ -2646,6 +2716,7 @@ pub const __NR_listmount: u32 = 458;
 pub const __NR_lsm_get_self_attr: u32 = 459;
 pub const __NR_lsm_set_self_attr: u32 = 460;
 pub const __NR_lsm_list_modules: u32 = 461;
+pub const __NR_mseal: u32 = 462;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
 pub const WSTOPPED: u32 = 2;
@@ -2833,6 +2904,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/x86/if_arp.rs
+++ b/src/x86/if_arp.rs
@@ -612,6 +612,7 @@ pub ar_hln: crate::ctypes::c_uchar,
 pub ar_pln: crate::ctypes::c_uchar,
 pub ar_op: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1381,6 +1382,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
@@ -1414,6 +1417,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1515,6 +1519,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
@@ -2281,7 +2286,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2319,7 +2326,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2495,7 +2503,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/x86/if_ether.rs
+++ b/src/x86/if_ether.rs
@@ -55,6 +55,7 @@ pub h_dest: [crate::ctypes::c_uchar; 6usize],
 pub h_source: [crate::ctypes::c_uchar; 6usize],
 pub h_proto: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const ETH_ALEN: u32 = 6;
 pub const ETH_TLEN: u32 = 2;
 pub const ETH_HLEN: u32 = 14;

--- a/src/x86/if_packet.rs
+++ b/src/x86/if_packet.rs
@@ -205,6 +205,7 @@ pub type_flags: __u16,
 pub max_num_members: __u32,
 }
 pub const __LITTLE_ENDIAN: u32 = 1234;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PACKET_HOST: u32 = 0;
 pub const PACKET_BROADCAST: u32 = 1;
 pub const PACKET_MULTICAST: u32 = 2;

--- a/src/x86/io_uring.rs
+++ b/src/x86/io_uring.rs
@@ -138,7 +138,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -156,7 +156,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -166,6 +167,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -181,6 +183,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -247,6 +261,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -494,6 +527,14 @@ pub resv: [__u32; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_napi {
+pub busy_poll_to: __u32,
+pub prefer_busy_poll: __u8,
+pub pad: [__u8; 3usize],
+pub resv: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -559,6 +600,7 @@ pub const IOC_OUT: u32 = 2147483648;
 pub const IOC_INOUT: u32 = 3221225472;
 pub const IOCSIZE_MASK: u32 = 1073676288;
 pub const IOCSIZE_SHIFT: u32 = 16;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const FSCRYPT_POLICY_FLAGS_PAD_4: u32 = 0;
 pub const FSCRYPT_POLICY_FLAGS_PAD_8: u32 = 1;
 pub const FSCRYPT_POLICY_FLAGS_PAD_16: u32 = 2;
@@ -673,13 +715,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -751,6 +797,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -806,15 +853,20 @@ pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
 pub const IORING_SEND_ZC_REPORT_USAGE: u32 = 8;
+pub const IORING_RECVSEND_BUNDLE: u32 = 16;
 pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
+pub const IORING_ACCEPT_DONTWAIT: u32 = 2;
+pub const IORING_ACCEPT_POLL_FIRST: u32 = 4;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
 pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
+pub const IORING_NOP_INJECT_RESULT: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
 pub const IORING_CQE_F_NOTIF: u32 = 8;
+pub const IORING_CQE_BUFFER_SHIFT: u32 = 16;
 pub const IORING_OFF_SQ_RING: u32 = 0;
 pub const IORING_OFF_CQ_RING: u32 = 134217728;
 pub const IORING_OFF_SQES: u32 = 268435456;
@@ -844,60 +896,10 @@ pub const IORING_FEAT_RSRC_TAGS: u32 = 1024;
 pub const IORING_FEAT_CQE_SKIP: u32 = 2048;
 pub const IORING_FEAT_LINKED_FILE: u32 = 4096;
 pub const IORING_FEAT_REG_REG_RING: u32 = 8192;
+pub const IORING_FEAT_RECVSEND_BUNDLE: u32 = 16384;
 pub const IORING_RSRC_REGISTER_SPARSE: u32 = 1;
 pub const IORING_REGISTER_FILES_SKIP: i32 = -2;
 pub const IO_URING_OP_SUPPORTED: u32 = 1;
-pub const IOSQE_FIXED_FILE_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_FIXED_FILE_BIT;
-pub const IOSQE_IO_DRAIN_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_DRAIN_BIT;
-pub const IOSQE_IO_LINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_LINK_BIT;
-pub const IOSQE_IO_HARDLINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_HARDLINK_BIT;
-pub const IOSQE_ASYNC_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_ASYNC_BIT;
-pub const IOSQE_BUFFER_SELECT_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_BUFFER_SELECT_BIT;
-pub const IOSQE_CQE_SKIP_SUCCESS_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_CQE_SKIP_SUCCESS_BIT;
-pub const IORING_MSG_DATA: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_DATA;
-pub const IORING_MSG_SEND_FD: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_SEND_FD;
-pub const IORING_CQE_BUFFER_SHIFT: _bindgen_ty_3 = _bindgen_ty_3::IORING_CQE_BUFFER_SHIFT;
-pub const IORING_REGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS;
-pub const IORING_UNREGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_BUFFERS;
-pub const IORING_REGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES;
-pub const IORING_UNREGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_FILES;
-pub const IORING_REGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD;
-pub const IORING_UNREGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_EVENTFD;
-pub const IORING_REGISTER_FILES_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE;
-pub const IORING_REGISTER_EVENTFD_ASYNC: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD_ASYNC;
-pub const IORING_REGISTER_PROBE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PROBE;
-pub const IORING_REGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PERSONALITY;
-pub const IORING_UNREGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PERSONALITY;
-pub const IORING_REGISTER_RESTRICTIONS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RESTRICTIONS;
-pub const IORING_REGISTER_ENABLE_RINGS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_ENABLE_RINGS;
-pub const IORING_REGISTER_FILES2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES2;
-pub const IORING_REGISTER_FILES_UPDATE2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE2;
-pub const IORING_REGISTER_BUFFERS2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS2;
-pub const IORING_REGISTER_BUFFERS_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS_UPDATE;
-pub const IORING_REGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_AFF;
-pub const IORING_UNREGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_IOWQ_AFF;
-pub const IORING_REGISTER_IOWQ_MAX_WORKERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_MAX_WORKERS;
-pub const IORING_REGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RING_FDS;
-pub const IORING_UNREGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_RING_FDS;
-pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_RING;
-pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
-pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
-pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
-pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
-pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
-pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
-pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
-pub const IO_WQ_UNBOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_UNBOUND;
-pub const IOU_PBUF_RING_MMAP: _bindgen_ty_6 = _bindgen_ty_6::IOU_PBUF_RING_MMAP;
-pub const IORING_RESTRICTION_REGISTER_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_REGISTER_OP;
-pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_OP;
-pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
-pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
-pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
-pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
-pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
-pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
-pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -915,7 +917,18 @@ FSCONFIG_CMD_CREATE_EXCL = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_1 {
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum io_uring_sqe_flags_bit {
 IOSQE_FIXED_FILE_BIT = 0,
 IOSQE_IO_DRAIN_BIT = 1,
 IOSQE_IO_LINK_BIT = 2,
@@ -983,25 +996,22 @@ IORING_OP_FUTEX_WAIT = 51,
 IORING_OP_FUTEX_WAKE = 52,
 IORING_OP_FUTEX_WAITV = 53,
 IORING_OP_FIXED_FD_INSTALL = 54,
-IORING_OP_LAST = 55,
+IORING_OP_FTRUNCATE = 55,
+IORING_OP_BIND = 56,
+IORING_OP_LISTEN = 57,
+IORING_OP_LAST = 58,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_2 {
+pub enum io_uring_msg_ring_flags {
 IORING_MSG_DATA = 0,
 IORING_MSG_SEND_FD = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_3 {
-IORING_CQE_BUFFER_SHIFT = 16,
-}
-#[repr(u32)]
-#[non_exhaustive]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_4 {
+pub enum io_uring_register_op {
 IORING_REGISTER_BUFFERS = 0,
 IORING_UNREGISTER_BUFFERS = 1,
 IORING_REGISTER_FILES = 2,
@@ -1029,26 +1039,28 @@ IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
 IORING_REGISTER_PBUF_STATUS = 26,
-IORING_REGISTER_LAST = 27,
+IORING_REGISTER_NAPI = 27,
+IORING_UNREGISTER_NAPI = 28,
+IORING_REGISTER_LAST = 29,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_5 {
+pub enum io_wq_type {
 IO_WQ_BOUND = 0,
 IO_WQ_UNBOUND = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_6 {
+pub enum io_uring_register_pbuf_ring_flags {
 IOU_PBUF_RING_MMAP = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_7 {
+pub enum io_uring_register_restriction_op {
 IORING_RESTRICTION_REGISTER_OP = 0,
 IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
@@ -1058,7 +1070,7 @@ IORING_RESTRICTION_LAST = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_8 {
+pub enum io_uring_socket_op {
 SOCKET_URING_OP_SIOCINQ = 0,
 SOCKET_URING_OP_SIOCOUTQ = 1,
 SOCKET_URING_OP_GETSOCKOPT = 2,
@@ -1117,6 +1129,7 @@ pub uring_cmd_flags: __u32,
 pub waitid_flags: __u32,
 pub futex_flags: __u32,
 pub install_fd_flags: __u32,
+pub nop_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]

--- a/src/x86/loop_device.rs
+++ b/src/x86/loop_device.rs
@@ -91,6 +91,7 @@ pub __reserved: [__u64; 8usize],
 }
 pub const LO_NAME_SIZE: u32 = 64;
 pub const LO_KEY_SIZE: u32 = 32;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const LO_CRYPT_NONE: u32 = 0;
 pub const LO_CRYPT_XOR: u32 = 1;
 pub const LO_CRYPT_DES: u32 = 2;

--- a/src/x86/mempolicy.rs
+++ b/src/x86/mempolicy.rs
@@ -158,6 +158,7 @@ pub const MPOL_BIND: _bindgen_ty_1 = _bindgen_ty_1::MPOL_BIND;
 pub const MPOL_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_INTERLEAVE;
 pub const MPOL_LOCAL: _bindgen_ty_1 = _bindgen_ty_1::MPOL_LOCAL;
 pub const MPOL_PREFERRED_MANY: _bindgen_ty_1 = _bindgen_ty_1::MPOL_PREFERRED_MANY;
+pub const MPOL_WEIGHTED_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_WEIGHTED_INTERLEAVE;
 pub const MPOL_MAX: _bindgen_ty_1 = _bindgen_ty_1::MPOL_MAX;
 #[repr(u32)]
 #[non_exhaustive]
@@ -169,5 +170,6 @@ MPOL_BIND = 2,
 MPOL_INTERLEAVE = 3,
 MPOL_LOCAL = 4,
 MPOL_PREFERRED_MANY = 5,
-MPOL_MAX = 6,
+MPOL_WEIGHTED_INTERLEAVE = 6,
+MPOL_MAX = 7,
 }

--- a/src/x86/net.rs
+++ b/src/x86/net.rs
@@ -856,6 +856,7 @@ pub _address: u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1261,6 +1262,7 @@ pub const TCP_AO_DEL_KEY: u32 = 39;
 pub const TCP_AO_INFO: u32 = 40;
 pub const TCP_AO_GET_KEYS: u32 = 41;
 pub const TCP_AO_REPAIR: u32 = 42;
+pub const TCP_IS_MPTCP: u32 = 43;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1547,6 +1549,7 @@ pub const IPPROTO_UDPLITE: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_UDPLITE;
 pub const IPPROTO_MPLS: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPLS;
 pub const IPPROTO_ETHERNET: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ETHERNET;
 pub const IPPROTO_RAW: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_RAW;
+pub const IPPROTO_SMC: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_SMC;
 pub const IPPROTO_MPTCP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPTCP;
 pub const IPPROTO_MAX: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MAX;
 pub const IPV4_DEVCONF_FORWARDING: _bindgen_ty_2 = _bindgen_ty_2::IPV4_DEVCONF_FORWARDING;
@@ -1735,6 +1738,7 @@ IPPROTO_UDPLITE = 136,
 IPPROTO_MPLS = 137,
 IPPROTO_ETHERNET = 143,
 IPPROTO_RAW = 255,
+IPPROTO_SMC = 256,
 IPPROTO_MPTCP = 262,
 IPPROTO_MAX = 263,
 }

--- a/src/x86/netlink.rs
+++ b/src/x86/netlink.rs
@@ -547,6 +547,7 @@ pub const SOCK_BUF_LOCK_MASK: u32 = 3;
 pub const SOCK_TXREHASH_DEFAULT: u32 = 255;
 pub const SOCK_TXREHASH_DISABLED: u32 = 0;
 pub const SOCK_TXREHASH_ENABLED: u32 = 1;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const NETLINK_ROUTE: u32 = 0;
 pub const NETLINK_UNUSED: u32 = 1;
 pub const NETLINK_USERSOCK: u32 = 2;
@@ -1094,6 +1095,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
@@ -1127,6 +1130,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1228,6 +1232,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
@@ -2142,7 +2147,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2180,7 +2187,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2356,7 +2364,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/x86/prctl.rs
+++ b/src/x86/prctl.rs
@@ -66,6 +66,7 @@ pub auxv: *mut __u64,
 pub auxv_size: __u32,
 pub exe_fd: __u32,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PR_SET_PDEATHSIG: u32 = 1;
 pub const PR_GET_PDEATHSIG: u32 = 2;
 pub const PR_GET_DUMPABLE: u32 = 3;
@@ -232,3 +233,20 @@ pub const PR_RISCV_V_VSTATE_CTRL_INHERIT: u32 = 16;
 pub const PR_RISCV_V_VSTATE_CTRL_CUR_MASK: u32 = 3;
 pub const PR_RISCV_V_VSTATE_CTRL_NEXT_MASK: u32 = 12;
 pub const PR_RISCV_V_VSTATE_CTRL_MASK: u32 = 31;
+pub const PR_RISCV_SET_ICACHE_FLUSH_CTX: u32 = 71;
+pub const PR_RISCV_CTX_SW_FENCEI_ON: u32 = 0;
+pub const PR_RISCV_CTX_SW_FENCEI_OFF: u32 = 1;
+pub const PR_RISCV_SCOPE_PER_PROCESS: u32 = 0;
+pub const PR_RISCV_SCOPE_PER_THREAD: u32 = 1;
+pub const PR_PPC_GET_DEXCR: u32 = 72;
+pub const PR_PPC_SET_DEXCR: u32 = 73;
+pub const PR_PPC_DEXCR_SBHE: u32 = 0;
+pub const PR_PPC_DEXCR_IBRTPD: u32 = 1;
+pub const PR_PPC_DEXCR_SRAPD: u32 = 2;
+pub const PR_PPC_DEXCR_NPHIE: u32 = 3;
+pub const PR_PPC_DEXCR_CTRL_EDITABLE: u32 = 1;
+pub const PR_PPC_DEXCR_CTRL_SET: u32 = 2;
+pub const PR_PPC_DEXCR_CTRL_CLEAR: u32 = 4;
+pub const PR_PPC_DEXCR_CTRL_SET_ONEXEC: u32 = 8;
+pub const PR_PPC_DEXCR_CTRL_CLEAR_ONEXEC: u32 = 16;
+pub const PR_PPC_DEXCR_CTRL_MASK: u32 = 31;

--- a/src/x86/system.rs
+++ b/src/x86/system.rs
@@ -94,6 +94,7 @@ pub version: [crate::ctypes::c_char; 65usize],
 pub machine: [crate::ctypes::c_char; 65usize],
 pub domainname: [crate::ctypes::c_char; 65usize],
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const SI_LOAD_SHIFT: u32 = 16;
 pub const __OLD_UTS_LEN: u32 = 8;
 pub const __NEW_UTS_LEN: u32 = 64;

--- a/src/x86/xdp.rs
+++ b/src/x86/xdp.rs
@@ -152,6 +152,7 @@ pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,
 pub tx_invalid_descs: __u64,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
@@ -159,6 +160,7 @@ pub const XDP_USE_NEED_WAKEUP: u32 = 8;
 pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
 pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
+pub const XDP_UMEM_TX_METADATA_LEN: u32 = 4;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;

--- a/src/x86_64/bootparam.rs
+++ b/src/x86_64/bootparam.rs
@@ -55,6 +55,64 @@ pub type apm_eventinfo_t = crate::ctypes::c_ushort;
 #[repr(C)]
 #[derive(Default)]
 pub struct __IncompleteArrayField<T>(::core::marker::PhantomData<T>, [T; 0]);
+#[repr(C)]
+#[derive(Debug)]
+pub struct setup_data {
+pub next: __u64,
+pub type_: __u32,
+pub len: __u32,
+pub data: __IncompleteArrayField<__u8>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct setup_indirect {
+pub type_: __u32,
+pub reserved: __u32,
+pub len: __u64,
+pub addr: __u64,
+}
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct boot_e820_entry {
+pub addr: __u64,
+pub size: __u64,
+pub type_: __u32,
+}
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct jailhouse_setup_data {
+pub hdr: jailhouse_setup_data__bindgen_ty_1,
+pub v1: jailhouse_setup_data__bindgen_ty_2,
+pub v2: jailhouse_setup_data__bindgen_ty_3,
+}
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct jailhouse_setup_data__bindgen_ty_1 {
+pub version: __u16,
+pub compatible_version: __u16,
+}
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct jailhouse_setup_data__bindgen_ty_2 {
+pub pm_timer_address: __u16,
+pub num_cpus: __u16,
+pub pci_mmconfig_base: __u64,
+pub tsc_khz: __u32,
+pub apic_khz: __u32,
+pub standard_ioapic: __u8,
+pub cpu_ids: [__u8; 255usize],
+}
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct jailhouse_setup_data__bindgen_ty_3 {
+pub flags: __u32,
+}
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct ima_setup_data {
+pub addr: __u64,
+pub size: __u64,
+}
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct screen_info {
@@ -271,22 +329,6 @@ pub perf_level: __u32,
 pub struct edid_info {
 pub dummy: [crate::ctypes::c_uchar; 128usize],
 }
-#[repr(C)]
-#[derive(Debug)]
-pub struct setup_data {
-pub next: __u64,
-pub type_: __u32,
-pub len: __u32,
-pub data: __IncompleteArrayField<__u8>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct setup_indirect {
-pub type_: __u32,
-pub reserved: __u32,
-pub len: __u64,
-pub addr: __u64,
-}
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct setup_header {
@@ -357,48 +399,6 @@ pub efi_systab_hi: __u32,
 pub efi_memmap_hi: __u32,
 }
 #[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct boot_e820_entry {
-pub addr: __u64,
-pub size: __u64,
-pub type_: __u32,
-}
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct jailhouse_setup_data {
-pub hdr: jailhouse_setup_data__bindgen_ty_1,
-pub v1: jailhouse_setup_data__bindgen_ty_2,
-pub v2: jailhouse_setup_data__bindgen_ty_3,
-}
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct jailhouse_setup_data__bindgen_ty_1 {
-pub version: __u16,
-pub compatible_version: __u16,
-}
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct jailhouse_setup_data__bindgen_ty_2 {
-pub pm_timer_address: __u16,
-pub num_cpus: __u16,
-pub pci_mmconfig_base: __u64,
-pub tsc_khz: __u32,
-pub apic_khz: __u32,
-pub standard_ioapic: __u8,
-pub cpu_ids: [__u8; 255usize],
-}
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct jailhouse_setup_data__bindgen_ty_3 {
-pub flags: __u32,
-}
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct ima_setup_data {
-pub addr: __u64,
-pub size: __u64,
-}
-#[repr(C, packed)]
 #[derive(Copy, Clone)]
 pub struct boot_params {
 pub screen_info: screen_info,
@@ -450,6 +450,7 @@ pub const SETUP_RNG_SEED: u32 = 9;
 pub const SETUP_ENUM_MAX: u32 = 9;
 pub const SETUP_INDIRECT: u32 = 2147483648;
 pub const SETUP_TYPE_MAX: u32 = 2147483657;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const RAMDISK_IMAGE_START_MASK: u32 = 2047;
 pub const RAMDISK_PROMPT_FLAG: u32 = 32768;
 pub const RAMDISK_LOAD_FLAG: u32 = 16384;
@@ -465,6 +466,7 @@ pub const XLF_EFI_HANDOVER_64: u32 = 8;
 pub const XLF_EFI_KEXEC: u32 = 16;
 pub const XLF_5LEVEL: u32 = 32;
 pub const XLF_5LEVEL_ENABLED: u32 = 64;
+pub const XLF_MEM_ENCRYPTION: u32 = 128;
 pub const VIDEO_TYPE_MDA: u32 = 16;
 pub const VIDEO_TYPE_CGA: u32 = 17;
 pub const VIDEO_TYPE_EGAM: u32 = 32;

--- a/src/x86_64/btrfs.rs
+++ b/src/x86_64/btrfs.rs
@@ -138,7 +138,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -156,7 +156,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -166,6 +167,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -181,6 +183,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -247,6 +261,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -857,10 +890,17 @@ pub physical: __le64,
 }
 #[repr(C, packed)]
 pub struct btrfs_stripe_extent {
-pub encoding: __u8,
-pub reserved: [__u8; 7usize],
+pub __bindgen_anon_1: btrfs_stripe_extent__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct btrfs_stripe_extent__bindgen_ty_1 {
+pub __empty_strides: btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1,
 pub strides: __IncompleteArrayField<btrfs_raid_stride>,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct btrfs_stripe_extent__bindgen_ty_1__bindgen_ty_1 {}
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct btrfs_extent_item {
@@ -1129,6 +1169,7 @@ pub encryption: __u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _IOC_NRBITS: u32 = 8;
 pub const _IOC_TYPEBITS: u32 = 8;
 pub const _IOC_SIZEBITS: u32 = 14;
@@ -1276,13 +1317,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1354,6 +1399,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1386,6 +1432,7 @@ pub const BTRFS_QGROUP_LIMIT_RSV_EXCL: u32 = 8;
 pub const BTRFS_QGROUP_LIMIT_RFER_CMPR: u32 = 16;
 pub const BTRFS_QGROUP_LIMIT_EXCL_CMPR: u32 = 32;
 pub const BTRFS_QGROUP_INHERIT_SET_LIMITS: u32 = 1;
+pub const BTRFS_QGROUP_INHERIT_FLAGS_SUPP: u32 = 1;
 pub const BTRFS_DEVICE_REMOVE_ARGS_MASK: u32 = 8;
 pub const BTRFS_SUBVOL_CREATE_ARGS_MASK: u32 = 6;
 pub const BTRFS_SUBVOL_DELETE_ARGS_MASK: u32 = 16;
@@ -1591,14 +1638,6 @@ pub const BTRFS_SYSTEM_CHUNK_ARRAY_SIZE: u32 = 2048;
 pub const BTRFS_NUM_BACKUP_ROOTS: u32 = 4;
 pub const BTRFS_FREE_SPACE_EXTENT: u32 = 1;
 pub const BTRFS_FREE_SPACE_BITMAP: u32 = 2;
-pub const BTRFS_STRIPE_RAID0: u32 = 1;
-pub const BTRFS_STRIPE_RAID1: u32 = 2;
-pub const BTRFS_STRIPE_DUP: u32 = 3;
-pub const BTRFS_STRIPE_RAID10: u32 = 4;
-pub const BTRFS_STRIPE_RAID5: u32 = 5;
-pub const BTRFS_STRIPE_RAID6: u32 = 6;
-pub const BTRFS_STRIPE_RAID1C3: u32 = 7;
-pub const BTRFS_STRIPE_RAID1C4: u32 = 8;
 pub const BTRFS_HEADER_FLAG_WRITTEN: u32 = 1;
 pub const BTRFS_HEADER_FLAG_RELOC: u32 = 2;
 pub const BTRFS_SUPER_FLAG_ERROR: u32 = 4;
@@ -1607,6 +1646,9 @@ pub const BTRFS_SUPER_FLAG_METADUMP: u64 = 8589934592;
 pub const BTRFS_SUPER_FLAG_METADUMP_V2: u64 = 17179869184;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID: u64 = 34359738368;
 pub const BTRFS_SUPER_FLAG_CHANGING_FSID_V2: u64 = 68719476736;
+pub const BTRFS_SUPER_FLAG_CHANGING_BG_TREE: u64 = 274877906944;
+pub const BTRFS_SUPER_FLAG_CHANGING_DATA_CSUM: u64 = 549755813888;
+pub const BTRFS_SUPER_FLAG_CHANGING_META_CSUM: u64 = 1099511627776;
 pub const BTRFS_EXTENT_FLAG_DATA: u32 = 1;
 pub const BTRFS_EXTENT_FLAG_TREE_BLOCK: u32 = 2;
 pub const BTRFS_BLOCK_FLAG_FULL_BACKREF: u32 = 256;
@@ -1662,6 +1704,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/x86_64/general.rs
+++ b/src/x86_64/general.rs
@@ -162,6 +162,14 @@ pub data: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct epoll_params {
+pub busy_poll_usecs: __u32,
+pub busy_poll_budget: __u16,
+pub prefer_busy_poll: __u8,
+pub __pad: __u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct fscrypt_policy_v1 {
 pub version: __u8,
 pub contents_encryption_mode: __u8,
@@ -244,7 +252,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -262,7 +270,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -272,6 +281,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -287,6 +297,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -356,6 +378,25 @@ pub return_mask: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct futex_waitv {
 pub val: __u64,
 pub uaddr: __u64,
@@ -411,6 +452,14 @@ pub struct rand_pool_info {
 pub entropy_count: crate::ctypes::c_int,
 pub buf_size: crate::ctypes::c_int,
 pub buf: __IncompleteArrayField<__u32>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vgetrandom_opaque_params {
+pub size_of_opaque_state: __u32,
+pub mmap_prot: __u32,
+pub mmap_flags: __u32,
+pub reserved: [__u32; 13usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -639,7 +688,12 @@ pub stx_dev_minor: __u32,
 pub stx_mnt_id: __u64,
 pub stx_dio_mem_align: __u32,
 pub stx_dio_offset_align: __u32,
-pub __spare3: [__u64; 12usize],
+pub stx_subvol: __u64,
+pub stx_atomic_write_unit_min: __u32,
+pub stx_atomic_write_unit_max: __u32,
+pub stx_atomic_write_segments_max: __u32,
+pub __spare1: [__u32; 1usize],
+pub __spare3: [__u64; 9usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -952,9 +1006,9 @@ pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
 pub sa_mask: kernel_sigset_t,
 }
-pub const LINUX_VERSION_CODE: u32 = 395264;
+pub const LINUX_VERSION_CODE: u32 = 396032;
 pub const LINUX_VERSION_MAJOR: u32 = 6;
-pub const LINUX_VERSION_PATCHLEVEL: u32 = 8;
+pub const LINUX_VERSION_PATCHLEVEL: u32 = 11;
 pub const LINUX_VERSION_SUBLEVEL: u32 = 0;
 pub const AT_SYSINFO_EHDR: u32 = 33;
 pub const AT_VECTOR_SIZE_ARCH: u32 = 3;
@@ -982,8 +1036,11 @@ pub const AT_RANDOM: u32 = 25;
 pub const AT_HWCAP2: u32 = 26;
 pub const AT_RSEQ_FEATURE_SIZE: u32 = 27;
 pub const AT_RSEQ_ALIGN: u32 = 28;
+pub const AT_HWCAP3: u32 = 29;
+pub const AT_HWCAP4: u32 = 30;
 pub const AT_EXECFN: u32 = 31;
 pub const AT_MINSIGSTKSZ: u32 = 51;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _LINUX_CAPABILITY_VERSION_1: u32 = 429392688;
 pub const _LINUX_CAPABILITY_U32S_1: u32 = 1;
@@ -1115,9 +1172,10 @@ pub const RESOLVE_IN_ROOT: u32 = 16;
 pub const RESOLVE_CACHED: u32 = 32;
 pub const F_SETLEASE: u32 = 1024;
 pub const F_GETLEASE: u32 = 1025;
+pub const F_NOTIFY: u32 = 1026;
+pub const F_DUPFD_QUERY: u32 = 1027;
 pub const F_CANCELLK: u32 = 1029;
 pub const F_DUPFD_CLOEXEC: u32 = 1030;
-pub const F_NOTIFY: u32 = 1026;
 pub const F_SETPIPE_SZ: u32 = 1031;
 pub const F_GETPIPE_SZ: u32 = 1032;
 pub const F_ADD_SEALS: u32 = 1033;
@@ -1163,6 +1221,7 @@ pub const EPOLL_CLOEXEC: u32 = 524288;
 pub const EPOLL_CTL_ADD: u32 = 1;
 pub const EPOLL_CTL_DEL: u32 = 2;
 pub const EPOLL_CTL_MOD: u32 = 3;
+pub const EPOLL_IOC_TYPE: u32 = 138;
 pub const POSIX_FADV_NORMAL: u32 = 0;
 pub const POSIX_FADV_RANDOM: u32 = 1;
 pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
@@ -1324,13 +1383,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -1402,6 +1465,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -1530,6 +1594,7 @@ pub const EFIVARFS_MAGIC: u32 = 3730735588;
 pub const HOSTFS_SUPER_MAGIC: u32 = 12648430;
 pub const OVERLAYFS_SUPER_MAGIC: u32 = 2035054128;
 pub const FUSE_SUPER_MAGIC: u32 = 1702057286;
+pub const BCACHEFS_SUPER_MAGIC: u32 = 3393526350;
 pub const MINIX_SUPER_MAGIC: u32 = 4991;
 pub const MINIX_SUPER_MAGIC2: u32 = 5007;
 pub const MINIX2_SUPER_MAGIC: u32 = 9320;
@@ -1579,6 +1644,7 @@ pub const UDF_SUPER_MAGIC: u32 = 352400198;
 pub const DMA_BUF_MAGIC: u32 = 1145913666;
 pub const DEVMEM_MAGIC: u32 = 1162691661;
 pub const SECRETMEM_MAGIC: u32 = 1397048141;
+pub const PID_FS_MAGIC: u32 = 1346978886;
 pub const MAP_32BIT: u32 = 64;
 pub const MAP_ABOVE4G: u32 = 128;
 pub const SHADOW_STACK_SET_TOKEN: u32 = 1;
@@ -1664,6 +1730,7 @@ pub const OVERCOMMIT_NEVER: u32 = 2;
 pub const MAP_SHARED: u32 = 1;
 pub const MAP_PRIVATE: u32 = 2;
 pub const MAP_SHARED_VALIDATE: u32 = 3;
+pub const MAP_DROPPABLE: u32 = 8;
 pub const MAP_HUGE_SHIFT: u32 = 26;
 pub const MAP_HUGE_MASK: u32 = 63;
 pub const MAP_HUGE_16KB: u32 = 939524096;
@@ -1970,6 +2037,8 @@ pub const STATX_BTIME: u32 = 2048;
 pub const STATX_MNT_ID: u32 = 4096;
 pub const STATX_DIOALIGN: u32 = 8192;
 pub const STATX_MNT_ID_UNIQUE: u32 = 16384;
+pub const STATX_SUBVOL: u32 = 32768;
+pub const STATX_WRITE_ATOMIC: u32 = 65536;
 pub const STATX__RESERVED: u32 = 2147483648;
 pub const STATX_ALL: u32 = 4095;
 pub const STATX_ATTR_COMPRESSED: u32 = 4;
@@ -1981,6 +2050,7 @@ pub const STATX_ATTR_AUTOMOUNT: u32 = 4096;
 pub const STATX_ATTR_MOUNT_ROOT: u32 = 8192;
 pub const STATX_ATTR_VERITY: u32 = 1048576;
 pub const STATX_ATTR_DAX: u32 = 2097152;
+pub const STATX_ATTR_WRITE_ATOMIC: u32 = 4194304;
 pub const IGNBRK: u32 = 1;
 pub const BRKINT: u32 = 2;
 pub const IGNPAR: u32 = 4;
@@ -2504,6 +2574,7 @@ pub const __NR_pkey_free: u32 = 331;
 pub const __NR_statx: u32 = 332;
 pub const __NR_io_pgetevents: u32 = 333;
 pub const __NR_rseq: u32 = 334;
+pub const __NR_uretprobe: u32 = 335;
 pub const __NR_pidfd_send_signal: u32 = 424;
 pub const __NR_io_uring_setup: u32 = 425;
 pub const __NR_io_uring_enter: u32 = 426;
@@ -2542,6 +2613,7 @@ pub const __NR_listmount: u32 = 458;
 pub const __NR_lsm_get_self_attr: u32 = 459;
 pub const __NR_lsm_set_self_attr: u32 = 460;
 pub const __NR_lsm_list_modules: u32 = 461;
+pub const __NR_mseal: u32 = 462;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
 pub const WSTOPPED: u32 = 2;
@@ -2728,6 +2800,17 @@ FSCONFIG_SET_FD = 5,
 FSCONFIG_CMD_CREATE = 6,
 FSCONFIG_CMD_RECONFIGURE = 7,
 FSCONFIG_CMD_CREATE_EXCL = 8,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/x86_64/if_arp.rs
+++ b/src/x86_64/if_arp.rs
@@ -612,6 +612,7 @@ pub ar_hln: crate::ctypes::c_uchar,
 pub ar_pln: crate::ctypes::c_uchar,
 pub ar_op: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1381,6 +1382,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_28 = _bindgen_ty_28::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_28 = _bindgen_ty_28::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MODE;
@@ -1414,6 +1417,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_29 = _bindgen_ty_29::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_29 = _bindgen_ty_29::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_30 = _bindgen_ty_30::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1515,6 +1519,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_44 = _bindgen_ty_44::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_44 = _bindgen_ty_44::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_45 = _bindgen_ty_45::IFLA_STATS_LINK_64;
@@ -2281,7 +2286,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2319,7 +2326,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2495,7 +2503,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/x86_64/if_ether.rs
+++ b/src/x86_64/if_ether.rs
@@ -57,6 +57,7 @@ pub h_dest: [crate::ctypes::c_uchar; 6usize],
 pub h_source: [crate::ctypes::c_uchar; 6usize],
 pub h_proto: __be16,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const ETH_ALEN: u32 = 6;
 pub const ETH_TLEN: u32 = 2;
 pub const ETH_HLEN: u32 = 14;

--- a/src/x86_64/if_packet.rs
+++ b/src/x86_64/if_packet.rs
@@ -205,6 +205,7 @@ pub type_flags: __u16,
 pub max_num_members: __u32,
 }
 pub const __LITTLE_ENDIAN: u32 = 1234;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PACKET_HOST: u32 = 0;
 pub const PACKET_BROADCAST: u32 = 1;
 pub const PACKET_MULTICAST: u32 = 2;

--- a/src/x86_64/io_uring.rs
+++ b/src/x86_64/io_uring.rs
@@ -140,7 +140,7 @@ pub userns_fd: __u64,
 #[derive(Debug)]
 pub struct statmount {
 pub size: __u32,
-pub __spare1: __u32,
+pub mnt_opts: __u32,
 pub mask: __u64,
 pub sb_dev_major: __u32,
 pub sb_dev_minor: __u32,
@@ -158,7 +158,8 @@ pub mnt_master: __u64,
 pub propagate_from: __u64,
 pub mnt_root: __u32,
 pub mnt_point: __u32,
-pub __spare2: [__u64; 50usize],
+pub mnt_ns_id: __u64,
+pub __spare2: [__u64; 49usize],
 pub str_: __IncompleteArrayField<crate::ctypes::c_char>,
 }
 #[repr(C)]
@@ -168,6 +169,7 @@ pub size: __u32,
 pub spare: __u32,
 pub mnt_id: __u64,
 pub param: __u64,
+pub mnt_ns_id: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -183,6 +185,18 @@ pub struct fstrim_range {
 pub start: __u64,
 pub len: __u64,
 pub minlen: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fsuuid2 {
+pub len: __u8,
+pub uuid: [__u8; 16usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fs_sysfs_path {
+pub len: __u8,
+pub name: [__u8; 128usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -249,6 +263,25 @@ pub category_inverted: __u64,
 pub category_mask: __u64,
 pub category_anyof_mask: __u64,
 pub return_mask: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct procmap_query {
+pub size: __u64,
+pub query_flags: __u64,
+pub query_addr: __u64,
+pub vma_start: __u64,
+pub vma_end: __u64,
+pub vma_flags: __u64,
+pub vma_page_size: __u64,
+pub vma_offset: __u64,
+pub inode: __u64,
+pub dev_major: __u32,
+pub dev_minor: __u32,
+pub vma_name_size: __u32,
+pub build_id_size: __u32,
+pub vma_name_addr: __u64,
+pub build_id_addr: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -492,6 +525,14 @@ pub resv: [__u32; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct io_uring_napi {
+pub busy_poll_to: __u32,
+pub prefer_busy_poll: __u8,
+pub pad: [__u8; 3usize],
+pub resv: __u64,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct io_uring_getevents_arg {
 pub sigmask: __u64,
 pub sigmask_sz: __u32,
@@ -557,6 +598,7 @@ pub const IOC_OUT: u32 = 2147483648;
 pub const IOC_INOUT: u32 = 3221225472;
 pub const IOCSIZE_MASK: u32 = 1073676288;
 pub const IOCSIZE_SHIFT: u32 = 16;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const FSCRYPT_POLICY_FLAGS_PAD_4: u32 = 0;
 pub const FSCRYPT_POLICY_FLAGS_PAD_8: u32 = 1;
 pub const FSCRYPT_POLICY_FLAGS_PAD_16: u32 = 2;
@@ -671,13 +713,17 @@ pub const MOUNT_ATTR_IDMAP: u32 = 1048576;
 pub const MOUNT_ATTR_NOSYMFOLLOW: u32 = 2097152;
 pub const MOUNT_ATTR_SIZE_VER0: u32 = 32;
 pub const MNT_ID_REQ_SIZE_VER0: u32 = 24;
+pub const MNT_ID_REQ_SIZE_VER1: u32 = 32;
 pub const STATMOUNT_SB_BASIC: u32 = 1;
 pub const STATMOUNT_MNT_BASIC: u32 = 2;
 pub const STATMOUNT_PROPAGATE_FROM: u32 = 4;
 pub const STATMOUNT_MNT_ROOT: u32 = 8;
 pub const STATMOUNT_MNT_POINT: u32 = 16;
 pub const STATMOUNT_FS_TYPE: u32 = 32;
+pub const STATMOUNT_MNT_NS_ID: u32 = 64;
+pub const STATMOUNT_MNT_OPTS: u32 = 128;
 pub const LSMT_ROOT: i32 = -1;
+pub const LISTMOUNT_REVERSE: u32 = 1;
 pub const INR_OPEN_CUR: u32 = 1024;
 pub const INR_OPEN_MAX: u32 = 4096;
 pub const BLOCK_SIZE_BITS: u32 = 10;
@@ -749,6 +795,7 @@ pub const SYNC_FILE_RANGE_WAIT_BEFORE: u32 = 1;
 pub const SYNC_FILE_RANGE_WRITE: u32 = 2;
 pub const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
 pub const SYNC_FILE_RANGE_WRITE_AND_WAIT: u32 = 7;
+pub const PROCFS_IOCTL_MAGIC: u8 = 102u8;
 pub const PAGE_IS_WPALLOWED: u32 = 1;
 pub const PAGE_IS_WRITTEN: u32 = 2;
 pub const PAGE_IS_FILE: u32 = 4;
@@ -804,15 +851,20 @@ pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
 pub const IORING_RECV_MULTISHOT: u32 = 2;
 pub const IORING_RECVSEND_FIXED_BUF: u32 = 4;
 pub const IORING_SEND_ZC_REPORT_USAGE: u32 = 8;
+pub const IORING_RECVSEND_BUNDLE: u32 = 16;
 pub const IORING_NOTIF_USAGE_ZC_COPIED: u32 = 2147483648;
 pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
+pub const IORING_ACCEPT_DONTWAIT: u32 = 2;
+pub const IORING_ACCEPT_POLL_FIRST: u32 = 4;
 pub const IORING_MSG_RING_CQE_SKIP: u32 = 1;
 pub const IORING_MSG_RING_FLAGS_PASS: u32 = 2;
 pub const IORING_FIXED_FD_NO_CLOEXEC: u32 = 1;
+pub const IORING_NOP_INJECT_RESULT: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
 pub const IORING_CQE_F_NOTIF: u32 = 8;
+pub const IORING_CQE_BUFFER_SHIFT: u32 = 16;
 pub const IORING_OFF_SQ_RING: u32 = 0;
 pub const IORING_OFF_CQ_RING: u32 = 134217728;
 pub const IORING_OFF_SQES: u32 = 268435456;
@@ -842,60 +894,10 @@ pub const IORING_FEAT_RSRC_TAGS: u32 = 1024;
 pub const IORING_FEAT_CQE_SKIP: u32 = 2048;
 pub const IORING_FEAT_LINKED_FILE: u32 = 4096;
 pub const IORING_FEAT_REG_REG_RING: u32 = 8192;
+pub const IORING_FEAT_RECVSEND_BUNDLE: u32 = 16384;
 pub const IORING_RSRC_REGISTER_SPARSE: u32 = 1;
 pub const IORING_REGISTER_FILES_SKIP: i32 = -2;
 pub const IO_URING_OP_SUPPORTED: u32 = 1;
-pub const IOSQE_FIXED_FILE_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_FIXED_FILE_BIT;
-pub const IOSQE_IO_DRAIN_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_DRAIN_BIT;
-pub const IOSQE_IO_LINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_LINK_BIT;
-pub const IOSQE_IO_HARDLINK_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_IO_HARDLINK_BIT;
-pub const IOSQE_ASYNC_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_ASYNC_BIT;
-pub const IOSQE_BUFFER_SELECT_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_BUFFER_SELECT_BIT;
-pub const IOSQE_CQE_SKIP_SUCCESS_BIT: _bindgen_ty_1 = _bindgen_ty_1::IOSQE_CQE_SKIP_SUCCESS_BIT;
-pub const IORING_MSG_DATA: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_DATA;
-pub const IORING_MSG_SEND_FD: _bindgen_ty_2 = _bindgen_ty_2::IORING_MSG_SEND_FD;
-pub const IORING_CQE_BUFFER_SHIFT: _bindgen_ty_3 = _bindgen_ty_3::IORING_CQE_BUFFER_SHIFT;
-pub const IORING_REGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS;
-pub const IORING_UNREGISTER_BUFFERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_BUFFERS;
-pub const IORING_REGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES;
-pub const IORING_UNREGISTER_FILES: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_FILES;
-pub const IORING_REGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD;
-pub const IORING_UNREGISTER_EVENTFD: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_EVENTFD;
-pub const IORING_REGISTER_FILES_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE;
-pub const IORING_REGISTER_EVENTFD_ASYNC: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_EVENTFD_ASYNC;
-pub const IORING_REGISTER_PROBE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PROBE;
-pub const IORING_REGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PERSONALITY;
-pub const IORING_UNREGISTER_PERSONALITY: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PERSONALITY;
-pub const IORING_REGISTER_RESTRICTIONS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RESTRICTIONS;
-pub const IORING_REGISTER_ENABLE_RINGS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_ENABLE_RINGS;
-pub const IORING_REGISTER_FILES2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES2;
-pub const IORING_REGISTER_FILES_UPDATE2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILES_UPDATE2;
-pub const IORING_REGISTER_BUFFERS2: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS2;
-pub const IORING_REGISTER_BUFFERS_UPDATE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_BUFFERS_UPDATE;
-pub const IORING_REGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_AFF;
-pub const IORING_UNREGISTER_IOWQ_AFF: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_IOWQ_AFF;
-pub const IORING_REGISTER_IOWQ_MAX_WORKERS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_IOWQ_MAX_WORKERS;
-pub const IORING_REGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_RING_FDS;
-pub const IORING_UNREGISTER_RING_FDS: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_RING_FDS;
-pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_RING;
-pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_UNREGISTER_PBUF_RING;
-pub const IORING_REGISTER_SYNC_CANCEL: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_SYNC_CANCEL;
-pub const IORING_REGISTER_FILE_ALLOC_RANGE: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_FILE_ALLOC_RANGE;
-pub const IORING_REGISTER_PBUF_STATUS: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_PBUF_STATUS;
-pub const IORING_REGISTER_LAST: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_LAST;
-pub const IORING_REGISTER_USE_REGISTERED_RING: _bindgen_ty_4 = _bindgen_ty_4::IORING_REGISTER_USE_REGISTERED_RING;
-pub const IO_WQ_BOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_BOUND;
-pub const IO_WQ_UNBOUND: _bindgen_ty_5 = _bindgen_ty_5::IO_WQ_UNBOUND;
-pub const IOU_PBUF_RING_MMAP: _bindgen_ty_6 = _bindgen_ty_6::IOU_PBUF_RING_MMAP;
-pub const IORING_RESTRICTION_REGISTER_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_REGISTER_OP;
-pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_OP;
-pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_ALLOWED;
-pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_SQE_FLAGS_REQUIRED;
-pub const IORING_RESTRICTION_LAST: _bindgen_ty_7 = _bindgen_ty_7::IORING_RESTRICTION_LAST;
-pub const SOCKET_URING_OP_SIOCINQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCINQ;
-pub const SOCKET_URING_OP_SIOCOUTQ: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SIOCOUTQ;
-pub const SOCKET_URING_OP_GETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_GETSOCKOPT;
-pub const SOCKET_URING_OP_SETSOCKOPT: _bindgen_ty_8 = _bindgen_ty_8::SOCKET_URING_OP_SETSOCKOPT;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -913,7 +915,18 @@ FSCONFIG_CMD_CREATE_EXCL = 8,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_1 {
+pub enum procmap_query_flags {
+PROCMAP_QUERY_VMA_READABLE = 1,
+PROCMAP_QUERY_VMA_WRITABLE = 2,
+PROCMAP_QUERY_VMA_EXECUTABLE = 4,
+PROCMAP_QUERY_VMA_SHARED = 8,
+PROCMAP_QUERY_COVERING_OR_NEXT_VMA = 16,
+PROCMAP_QUERY_FILE_BACKED_VMA = 32,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum io_uring_sqe_flags_bit {
 IOSQE_FIXED_FILE_BIT = 0,
 IOSQE_IO_DRAIN_BIT = 1,
 IOSQE_IO_LINK_BIT = 2,
@@ -981,25 +994,22 @@ IORING_OP_FUTEX_WAIT = 51,
 IORING_OP_FUTEX_WAKE = 52,
 IORING_OP_FUTEX_WAITV = 53,
 IORING_OP_FIXED_FD_INSTALL = 54,
-IORING_OP_LAST = 55,
+IORING_OP_FTRUNCATE = 55,
+IORING_OP_BIND = 56,
+IORING_OP_LISTEN = 57,
+IORING_OP_LAST = 58,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_2 {
+pub enum io_uring_msg_ring_flags {
 IORING_MSG_DATA = 0,
 IORING_MSG_SEND_FD = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_3 {
-IORING_CQE_BUFFER_SHIFT = 16,
-}
-#[repr(u32)]
-#[non_exhaustive]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_4 {
+pub enum io_uring_register_op {
 IORING_REGISTER_BUFFERS = 0,
 IORING_UNREGISTER_BUFFERS = 1,
 IORING_REGISTER_FILES = 2,
@@ -1027,26 +1037,28 @@ IORING_UNREGISTER_PBUF_RING = 23,
 IORING_REGISTER_SYNC_CANCEL = 24,
 IORING_REGISTER_FILE_ALLOC_RANGE = 25,
 IORING_REGISTER_PBUF_STATUS = 26,
-IORING_REGISTER_LAST = 27,
+IORING_REGISTER_NAPI = 27,
+IORING_UNREGISTER_NAPI = 28,
+IORING_REGISTER_LAST = 29,
 IORING_REGISTER_USE_REGISTERED_RING = 2147483648,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_5 {
+pub enum io_wq_type {
 IO_WQ_BOUND = 0,
 IO_WQ_UNBOUND = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_6 {
+pub enum io_uring_register_pbuf_ring_flags {
 IOU_PBUF_RING_MMAP = 1,
 }
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_7 {
+pub enum io_uring_register_restriction_op {
 IORING_RESTRICTION_REGISTER_OP = 0,
 IORING_RESTRICTION_SQE_OP = 1,
 IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
@@ -1056,7 +1068,7 @@ IORING_RESTRICTION_LAST = 4,
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum _bindgen_ty_8 {
+pub enum io_uring_socket_op {
 SOCKET_URING_OP_SIOCINQ = 0,
 SOCKET_URING_OP_SIOCOUTQ = 1,
 SOCKET_URING_OP_GETSOCKOPT = 2,
@@ -1115,6 +1127,7 @@ pub uring_cmd_flags: __u32,
 pub waitid_flags: __u32,
 pub futex_flags: __u32,
 pub install_fd_flags: __u32,
+pub nop_flags: __u32,
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]

--- a/src/x86_64/loop_device.rs
+++ b/src/x86_64/loop_device.rs
@@ -93,6 +93,7 @@ pub __reserved: [__u64; 8usize],
 }
 pub const LO_NAME_SIZE: u32 = 64;
 pub const LO_KEY_SIZE: u32 = 32;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const LO_CRYPT_NONE: u32 = 0;
 pub const LO_CRYPT_XOR: u32 = 1;
 pub const LO_CRYPT_DES: u32 = 2;

--- a/src/x86_64/mempolicy.rs
+++ b/src/x86_64/mempolicy.rs
@@ -158,6 +158,7 @@ pub const MPOL_BIND: _bindgen_ty_1 = _bindgen_ty_1::MPOL_BIND;
 pub const MPOL_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_INTERLEAVE;
 pub const MPOL_LOCAL: _bindgen_ty_1 = _bindgen_ty_1::MPOL_LOCAL;
 pub const MPOL_PREFERRED_MANY: _bindgen_ty_1 = _bindgen_ty_1::MPOL_PREFERRED_MANY;
+pub const MPOL_WEIGHTED_INTERLEAVE: _bindgen_ty_1 = _bindgen_ty_1::MPOL_WEIGHTED_INTERLEAVE;
 pub const MPOL_MAX: _bindgen_ty_1 = _bindgen_ty_1::MPOL_MAX;
 #[repr(u32)]
 #[non_exhaustive]
@@ -169,5 +170,6 @@ MPOL_BIND = 2,
 MPOL_INTERLEAVE = 3,
 MPOL_LOCAL = 4,
 MPOL_PREFERRED_MANY = 5,
-MPOL_MAX = 6,
+MPOL_WEIGHTED_INTERLEAVE = 6,
+MPOL_MAX = 7,
 }

--- a/src/x86_64/net.rs
+++ b/src/x86_64/net.rs
@@ -854,6 +854,7 @@ pub _address: u8,
 pub struct iovec {
 pub _address: u8,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const _K_SS_MAXSIZE: u32 = 128;
 pub const SOCK_SNDBUF_LOCK: u32 = 1;
 pub const SOCK_RCVBUF_LOCK: u32 = 2;
@@ -1267,6 +1268,7 @@ pub const TCP_AO_DEL_KEY: u32 = 39;
 pub const TCP_AO_INFO: u32 = 40;
 pub const TCP_AO_GET_KEYS: u32 = 41;
 pub const TCP_AO_REPAIR: u32 = 42;
+pub const TCP_IS_MPTCP: u32 = 43;
 pub const TCP_REPAIR_ON: u32 = 1;
 pub const TCP_REPAIR_OFF: u32 = 0;
 pub const TCP_REPAIR_OFF_NO_WP: i32 = -1;
@@ -1553,6 +1555,7 @@ pub const IPPROTO_UDPLITE: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_UDPLITE;
 pub const IPPROTO_MPLS: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPLS;
 pub const IPPROTO_ETHERNET: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_ETHERNET;
 pub const IPPROTO_RAW: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_RAW;
+pub const IPPROTO_SMC: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_SMC;
 pub const IPPROTO_MPTCP: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MPTCP;
 pub const IPPROTO_MAX: _bindgen_ty_1 = _bindgen_ty_1::IPPROTO_MAX;
 pub const IPV4_DEVCONF_FORWARDING: _bindgen_ty_2 = _bindgen_ty_2::IPV4_DEVCONF_FORWARDING;
@@ -1741,6 +1744,7 @@ IPPROTO_UDPLITE = 136,
 IPPROTO_MPLS = 137,
 IPPROTO_ETHERNET = 143,
 IPPROTO_RAW = 255,
+IPPROTO_SMC = 256,
 IPPROTO_MPTCP = 262,
 IPPROTO_MAX = 263,
 }

--- a/src/x86_64/netlink.rs
+++ b/src/x86_64/netlink.rs
@@ -549,6 +549,7 @@ pub const SOCK_BUF_LOCK_MASK: u32 = 3;
 pub const SOCK_TXREHASH_DEFAULT: u32 = 255;
 pub const SOCK_TXREHASH_DISABLED: u32 = 0;
 pub const SOCK_TXREHASH_ENABLED: u32 = 1;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const NETLINK_ROUTE: u32 = 0;
 pub const NETLINK_UNUSED: u32 = 1;
 pub const NETLINK_USERSOCK: u32 = 2;
@@ -1096,6 +1097,8 @@ pub const IFLA_GTP_PDP_HASHSIZE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_PDP_H
 pub const IFLA_GTP_ROLE: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_ROLE;
 pub const IFLA_GTP_CREATE_SOCKETS: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_CREATE_SOCKETS;
 pub const IFLA_GTP_RESTART_COUNT: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_RESTART_COUNT;
+pub const IFLA_GTP_LOCAL: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL;
+pub const IFLA_GTP_LOCAL6: _bindgen_ty_26 = _bindgen_ty_26::IFLA_GTP_LOCAL6;
 pub const __IFLA_GTP_MAX: _bindgen_ty_26 = _bindgen_ty_26::__IFLA_GTP_MAX;
 pub const IFLA_BOND_UNSPEC: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_UNSPEC;
 pub const IFLA_BOND_MODE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MODE;
@@ -1129,6 +1132,7 @@ pub const IFLA_BOND_PEER_NOTIF_DELAY: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND
 pub const IFLA_BOND_AD_LACP_ACTIVE: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_AD_LACP_ACTIVE;
 pub const IFLA_BOND_MISSED_MAX: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_MISSED_MAX;
 pub const IFLA_BOND_NS_IP6_TARGET: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_NS_IP6_TARGET;
+pub const IFLA_BOND_COUPLED_CONTROL: _bindgen_ty_27 = _bindgen_ty_27::IFLA_BOND_COUPLED_CONTROL;
 pub const __IFLA_BOND_MAX: _bindgen_ty_27 = _bindgen_ty_27::__IFLA_BOND_MAX;
 pub const IFLA_BOND_AD_INFO_UNSPEC: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_UNSPEC;
 pub const IFLA_BOND_AD_INFO_AGGREGATOR: _bindgen_ty_28 = _bindgen_ty_28::IFLA_BOND_AD_INFO_AGGREGATOR;
@@ -1230,6 +1234,7 @@ pub const IFLA_HSR_SUPERVISION_ADDR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_S
 pub const IFLA_HSR_SEQ_NR: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_SEQ_NR;
 pub const IFLA_HSR_VERSION: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_VERSION;
 pub const IFLA_HSR_PROTOCOL: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_PROTOCOL;
+pub const IFLA_HSR_INTERLINK: _bindgen_ty_42 = _bindgen_ty_42::IFLA_HSR_INTERLINK;
 pub const __IFLA_HSR_MAX: _bindgen_ty_42 = _bindgen_ty_42::__IFLA_HSR_MAX;
 pub const IFLA_STATS_UNSPEC: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_UNSPEC;
 pub const IFLA_STATS_LINK_64: _bindgen_ty_43 = _bindgen_ty_43::IFLA_STATS_LINK_64;
@@ -2144,7 +2149,9 @@ IFLA_GTP_PDP_HASHSIZE = 3,
 IFLA_GTP_ROLE = 4,
 IFLA_GTP_CREATE_SOCKETS = 5,
 IFLA_GTP_RESTART_COUNT = 6,
-__IFLA_GTP_MAX = 7,
+IFLA_GTP_LOCAL = 7,
+IFLA_GTP_LOCAL6 = 8,
+__IFLA_GTP_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2182,7 +2189,8 @@ IFLA_BOND_PEER_NOTIF_DELAY = 28,
 IFLA_BOND_AD_LACP_ACTIVE = 29,
 IFLA_BOND_MISSED_MAX = 30,
 IFLA_BOND_NS_IP6_TARGET = 31,
-__IFLA_BOND_MAX = 32,
+IFLA_BOND_COUPLED_CONTROL = 32,
+__IFLA_BOND_MAX = 33,
 }
 #[repr(u32)]
 #[non_exhaustive]
@@ -2358,7 +2366,8 @@ IFLA_HSR_SUPERVISION_ADDR = 4,
 IFLA_HSR_SEQ_NR = 5,
 IFLA_HSR_VERSION = 6,
 IFLA_HSR_PROTOCOL = 7,
-__IFLA_HSR_MAX = 8,
+IFLA_HSR_INTERLINK = 8,
+__IFLA_HSR_MAX = 9,
 }
 #[repr(u32)]
 #[non_exhaustive]

--- a/src/x86_64/prctl.rs
+++ b/src/x86_64/prctl.rs
@@ -68,6 +68,7 @@ pub auxv: *mut __u64,
 pub auxv_size: __u32,
 pub exe_fd: __u32,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const PR_SET_PDEATHSIG: u32 = 1;
 pub const PR_GET_PDEATHSIG: u32 = 2;
 pub const PR_GET_DUMPABLE: u32 = 3;
@@ -234,3 +235,20 @@ pub const PR_RISCV_V_VSTATE_CTRL_INHERIT: u32 = 16;
 pub const PR_RISCV_V_VSTATE_CTRL_CUR_MASK: u32 = 3;
 pub const PR_RISCV_V_VSTATE_CTRL_NEXT_MASK: u32 = 12;
 pub const PR_RISCV_V_VSTATE_CTRL_MASK: u32 = 31;
+pub const PR_RISCV_SET_ICACHE_FLUSH_CTX: u32 = 71;
+pub const PR_RISCV_CTX_SW_FENCEI_ON: u32 = 0;
+pub const PR_RISCV_CTX_SW_FENCEI_OFF: u32 = 1;
+pub const PR_RISCV_SCOPE_PER_PROCESS: u32 = 0;
+pub const PR_RISCV_SCOPE_PER_THREAD: u32 = 1;
+pub const PR_PPC_GET_DEXCR: u32 = 72;
+pub const PR_PPC_SET_DEXCR: u32 = 73;
+pub const PR_PPC_DEXCR_SBHE: u32 = 0;
+pub const PR_PPC_DEXCR_IBRTPD: u32 = 1;
+pub const PR_PPC_DEXCR_SRAPD: u32 = 2;
+pub const PR_PPC_DEXCR_NPHIE: u32 = 3;
+pub const PR_PPC_DEXCR_CTRL_EDITABLE: u32 = 1;
+pub const PR_PPC_DEXCR_CTRL_SET: u32 = 2;
+pub const PR_PPC_DEXCR_CTRL_CLEAR: u32 = 4;
+pub const PR_PPC_DEXCR_CTRL_SET_ONEXEC: u32 = 8;
+pub const PR_PPC_DEXCR_CTRL_CLEAR_ONEXEC: u32 = 16;
+pub const PR_PPC_DEXCR_CTRL_MASK: u32 = 31;

--- a/src/x86_64/system.rs
+++ b/src/x86_64/system.rs
@@ -99,6 +99,7 @@ pub version: [crate::ctypes::c_char; 65usize],
 pub machine: [crate::ctypes::c_char; 65usize],
 pub domainname: [crate::ctypes::c_char; 65usize],
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const SI_LOAD_SHIFT: u32 = 16;
 pub const __OLD_UTS_LEN: u32 = 8;
 pub const __NEW_UTS_LEN: u32 = 64;

--- a/src/x86_64/xdp.rs
+++ b/src/x86_64/xdp.rs
@@ -154,6 +154,7 @@ pub rx_dropped: __u64,
 pub rx_invalid_descs: __u64,
 pub tx_invalid_descs: __u64,
 }
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const XDP_SHARED_UMEM: u32 = 1;
 pub const XDP_COPY: u32 = 2;
 pub const XDP_ZEROCOPY: u32 = 4;
@@ -161,6 +162,7 @@ pub const XDP_USE_NEED_WAKEUP: u32 = 8;
 pub const XDP_USE_SG: u32 = 16;
 pub const XDP_UMEM_UNALIGNED_CHUNK_FLAG: u32 = 1;
 pub const XDP_UMEM_TX_SW_CSUM: u32 = 2;
+pub const XDP_UMEM_TX_METADATA_LEN: u32 = 4;
 pub const XDP_RING_NEED_WAKEUP: u32 = 1;
 pub const XDP_MMAP_OFFSETS: u32 = 1;
 pub const XDP_RX_RING: u32 = 2;


### PR DESCRIPTION
This pr updates the generated bindings to linux 6.11. As usual there is some more consts and structs.

Most notably this includes
- Addition of the new `mseal` syscall
- Updates to `statmount`
- New structs related to the `getrandom` vdso