### PR TITLE
Fix the value of `_NSIGS` on sparc.

### DIFF
--- a/gen/src/main.rs
+++ b/gen/src/main.rs
@@ -337,6 +337,7 @@ fn run_bindgen(
         .blocklist_item("__BITS_PER_LONG")
         .clang_arg(&format!("--target={}", clang_target))
         .clang_arg("-DBITS_PER_LONG=(__SIZEOF_LONG__*__CHAR_BIT__)")
+        .clang_arg("-D__WANT_POSIX1B_SIGNALS__")
         .clang_arg("-nostdinc")
         .clang_arg("-I")
         .clang_arg(linux_include)

--- a/src/sparc/general.rs
+++ b/src/sparc/general.rs
@@ -52,7 +52,7 @@ pub type __poll_t = crate::ctypes::c_uint;
 pub type cap_user_header_t = *mut __user_cap_header_struct;
 pub type cap_user_data_t = *mut __user_cap_data_struct;
 pub type __kernel_rwf_t = crate::ctypes::c_int;
-pub type sigset_t = crate::ctypes::c_ulong;
+pub type old_sigset_t = crate::ctypes::c_ulong;
 pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
 pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
@@ -552,7 +552,7 @@ pub cgroup: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __new_sigset_t {
+pub struct sigset_t {
 pub sig: [crate::ctypes::c_ulong; 2usize],
 }
 #[repr(C)]
@@ -563,17 +563,17 @@ pub cur_status: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __new_sigaction {
+pub struct sigaction {
 pub sa_handler: __sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
-pub sa_mask: __new_sigset_t,
+pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct sigaction {
+pub struct old_sigaction {
 pub sa_handler: __sighandler_t,
-pub sa_mask: sigset_t,
+pub sa_mask: old_sigset_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: ::core::option::Option<unsafe extern "C" fn()>,
 }
@@ -1051,7 +1051,7 @@ pub __bindgen_padding_0: [u8; 3usize],
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct kernel_sigset_t {
-pub sig: [crate::ctypes::c_ulong; 1usize],
+pub sig: [crate::ctypes::c_ulong; 2usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1988,8 +1988,7 @@ pub const _NSIG_BPW: u32 = 32;
 pub const _NSIG_WORDS: u32 = 2;
 pub const SIGRTMIN: u32 = 32;
 pub const SIGRTMAX: u32 = 64;
-pub const _NSIG: u32 = 32;
-pub const NSIG: u32 = 32;
+pub const _NSIG: u32 = 64;
 pub const _SV_SSTACK: u32 = 1;
 pub const _SV_INTR: u32 = 2;
 pub const _SV_RESET: u32 = 4;

--- a/src/sparc64/general.rs
+++ b/src/sparc64/general.rs
@@ -54,7 +54,7 @@ pub type __poll_t = crate::ctypes::c_uint;
 pub type cap_user_header_t = *mut __user_cap_header_struct;
 pub type cap_user_data_t = *mut __user_cap_data_struct;
 pub type __kernel_rwf_t = crate::ctypes::c_int;
-pub type sigset_t = crate::ctypes::c_ulong;
+pub type old_sigset_t = crate::ctypes::c_ulong;
 pub type __signalfn_t = ::core::option::Option<unsafe extern "C" fn(arg1: crate::ctypes::c_int)>;
 pub type __sighandler_t = __signalfn_t;
 pub type __restorefn_t = ::core::option::Option<unsafe extern "C" fn()>;
@@ -554,7 +554,7 @@ pub cgroup: __u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __new_sigset_t {
+pub struct sigset_t {
 pub sig: [crate::ctypes::c_ulong; 1usize],
 }
 #[repr(C)]
@@ -565,17 +565,17 @@ pub cur_status: crate::ctypes::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __new_sigaction {
+pub struct sigaction {
 pub sa_handler: __sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: __sigrestore_t,
-pub sa_mask: __new_sigset_t,
+pub sa_mask: sigset_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct sigaction {
+pub struct old_sigaction {
 pub sa_handler: __sighandler_t,
-pub sa_mask: sigset_t,
+pub sa_mask: old_sigset_t,
 pub sa_flags: crate::ctypes::c_ulong,
 pub sa_restorer: ::core::option::Option<unsafe extern "C" fn()>,
 }
@@ -1046,12 +1046,12 @@ pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 pub __bindgen_padding_0: [u8; 3usize],
 }
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct kernel_sigset_t {
-pub sig: __IncompleteArrayField<crate::ctypes::c_ulong>,
+pub sig: [crate::ctypes::c_ulong; 1usize],
 }
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct kernel_sigaction {
 pub sa_handler_kernel: __kernel_sighandler_t,
 pub sa_flags: crate::ctypes::c_ulong,
@@ -1982,8 +1982,7 @@ pub const _NSIG_BPW: u32 = 64;
 pub const _NSIG_WORDS: u32 = 1;
 pub const SIGRTMIN: u32 = 32;
 pub const SIGRTMAX: u32 = 64;
-pub const _NSIG: u32 = 32;
-pub const NSIG: u32 = 32;
+pub const _NSIG: u32 = 64;
 pub const _SV_SSTACK: u32 = 1;
 pub const _SV_INTR: u32 = 2;
 pub const _SV_RESET: u32 = 4;


### PR DESCRIPTION
Predefine `__WANT_POSIX1B_SIGNALS__` so that the Linux headers define the correct `_NSIGS` value on sparc targets.