### PR TITLE
feat: add types from net_tstamp.h, e.g. sock_txtime

### DIFF
--- a/gen/modules/net.h
+++ b/gen/modules/net.h
@@ -16,6 +16,10 @@
 #include <linux/netfilter_ipv6/ip6_tables.h>
 #include <linux/netfilter_ipv4.h>
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,7,0)
+#include <linux/net_tstamp.h>
+#endif
+
 // Miscellaneous definitions which don't appear to be defined in Linux's public
 // headers, but which are nonetheless part of the ABI, and necessary for
 // interoperability.

--- a/src/aarch64/net.rs
+++ b/src/aarch64/net.rs
@@ -804,6 +804,32 @@ pub entrytable: __IncompleteArrayField<ip6t_entry>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct so_timestamping {
+pub flags: crate::ctypes::c_int,
+pub bind_phc: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hwtstamp_config {
+pub flags: crate::ctypes::c_int,
+pub tx_type: crate::ctypes::c_int,
+pub rx_filter: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct scm_ts_pktinfo {
+pub if_index: __u32,
+pub pkt_length: __u32,
+pub reserved: [__u32; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sock_txtime {
+pub clockid: __kernel_clockid_t,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct linger {
 pub l_onoff: crate::ctypes::c_int,
 pub l_linger: crate::ctypes::c_int,
@@ -1719,6 +1745,26 @@ pub const NFPROTO_BRIDGE: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_BRIDGE;
 pub const NFPROTO_IPV6: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_IPV6;
 pub const NFPROTO_DECNET: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_DECNET;
 pub const NFPROTO_NUMPROTO: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_NUMPROTO;
+pub const SOF_TIMESTAMPING_TX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_HARDWARE;
+pub const SOF_TIMESTAMPING_TX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SOFTWARE;
+pub const SOF_TIMESTAMPING_RX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_HARDWARE;
+pub const SOF_TIMESTAMPING_RX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_SOFTWARE;
+pub const SOF_TIMESTAMPING_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SOFTWARE;
+pub const SOF_TIMESTAMPING_SYS_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SYS_HARDWARE;
+pub const SOF_TIMESTAMPING_RAW_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RAW_HARDWARE;
+pub const SOF_TIMESTAMPING_OPT_ID: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID;
+pub const SOF_TIMESTAMPING_TX_SCHED: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SCHED;
+pub const SOF_TIMESTAMPING_TX_ACK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_ACK;
+pub const SOF_TIMESTAMPING_OPT_CMSG: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_CMSG;
+pub const SOF_TIMESTAMPING_OPT_TSONLY: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TSONLY;
+pub const SOF_TIMESTAMPING_OPT_STATS: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_STATS;
+pub const SOF_TIMESTAMPING_OPT_PKTINFO: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_PKTINFO;
+pub const SOF_TIMESTAMPING_OPT_TX_SWHW: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TX_SWHW;
+pub const SOF_TIMESTAMPING_BIND_PHC: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_BIND_PHC;
+pub const SOF_TIMESTAMPING_OPT_ID_TCP: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID_TCP;
+pub const SOF_TIMESTAMPING_OPT_RX_FILTER: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_LAST: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_MASK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_MASK;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -2058,6 +2104,76 @@ NF_IP_PRI_NAT_SRC = 100,
 NF_IP_PRI_SELINUX_LAST = 225,
 NF_IP_PRI_CONNTRACK_HELPER = 300,
 NF_IP_PRI_CONNTRACK_CONFIRM = 2147483647,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_10 {
+SOF_TIMESTAMPING_TX_HARDWARE = 1,
+SOF_TIMESTAMPING_TX_SOFTWARE = 2,
+SOF_TIMESTAMPING_RX_HARDWARE = 4,
+SOF_TIMESTAMPING_RX_SOFTWARE = 8,
+SOF_TIMESTAMPING_SOFTWARE = 16,
+SOF_TIMESTAMPING_SYS_HARDWARE = 32,
+SOF_TIMESTAMPING_RAW_HARDWARE = 64,
+SOF_TIMESTAMPING_OPT_ID = 128,
+SOF_TIMESTAMPING_TX_SCHED = 256,
+SOF_TIMESTAMPING_TX_ACK = 512,
+SOF_TIMESTAMPING_OPT_CMSG = 1024,
+SOF_TIMESTAMPING_OPT_TSONLY = 2048,
+SOF_TIMESTAMPING_OPT_STATS = 4096,
+SOF_TIMESTAMPING_OPT_PKTINFO = 8192,
+SOF_TIMESTAMPING_OPT_TX_SWHW = 16384,
+SOF_TIMESTAMPING_BIND_PHC = 32768,
+SOF_TIMESTAMPING_OPT_ID_TCP = 65536,
+SOF_TIMESTAMPING_OPT_RX_FILTER = 131072,
+SOF_TIMESTAMPING_MASK = 262143,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_flags {
+HWTSTAMP_FLAG_BONDED_PHC_INDEX = 1,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_tx_types {
+HWTSTAMP_TX_OFF = 0,
+HWTSTAMP_TX_ON = 1,
+HWTSTAMP_TX_ONESTEP_SYNC = 2,
+HWTSTAMP_TX_ONESTEP_P2P = 3,
+__HWTSTAMP_TX_CNT = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_rx_filters {
+HWTSTAMP_FILTER_NONE = 0,
+HWTSTAMP_FILTER_ALL = 1,
+HWTSTAMP_FILTER_SOME = 2,
+HWTSTAMP_FILTER_PTP_V1_L4_EVENT = 3,
+HWTSTAMP_FILTER_PTP_V1_L4_SYNC = 4,
+HWTSTAMP_FILTER_PTP_V1_L4_DELAY_REQ = 5,
+HWTSTAMP_FILTER_PTP_V2_L4_EVENT = 6,
+HWTSTAMP_FILTER_PTP_V2_L4_SYNC = 7,
+HWTSTAMP_FILTER_PTP_V2_L4_DELAY_REQ = 8,
+HWTSTAMP_FILTER_PTP_V2_L2_EVENT = 9,
+HWTSTAMP_FILTER_PTP_V2_L2_SYNC = 10,
+HWTSTAMP_FILTER_PTP_V2_L2_DELAY_REQ = 11,
+HWTSTAMP_FILTER_PTP_V2_EVENT = 12,
+HWTSTAMP_FILTER_PTP_V2_SYNC = 13,
+HWTSTAMP_FILTER_PTP_V2_DELAY_REQ = 14,
+HWTSTAMP_FILTER_NTP_ALL = 15,
+__HWTSTAMP_FILTER_CNT = 16,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum txtime_flags {
+SOF_TXTIME_DEADLINE_MODE = 1,
+SOF_TXTIME_REPORT_ERRORS = 2,
+SOF_TXTIME_FLAGS_MASK = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3299,4 +3415,13 @@ pub const NF_INET_INGRESS: nf_inet_hooks = nf_inet_hooks::NF_INET_NUMHOOKS;
 }
 impl nf_ip_hook_priorities {
 pub const NF_IP_PRI_LAST: nf_ip_hook_priorities = nf_ip_hook_priorities::NF_IP_PRI_CONNTRACK_CONFIRM;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_LAST: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_MASK: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl txtime_flags {
+pub const SOF_TXTIME_FLAGS_LAST: txtime_flags = txtime_flags::SOF_TXTIME_REPORT_ERRORS;
 }

--- a/src/arm/net.rs
+++ b/src/arm/net.rs
@@ -804,6 +804,32 @@ pub entrytable: __IncompleteArrayField<ip6t_entry>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct so_timestamping {
+pub flags: crate::ctypes::c_int,
+pub bind_phc: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hwtstamp_config {
+pub flags: crate::ctypes::c_int,
+pub tx_type: crate::ctypes::c_int,
+pub rx_filter: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct scm_ts_pktinfo {
+pub if_index: __u32,
+pub pkt_length: __u32,
+pub reserved: [__u32; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sock_txtime {
+pub clockid: __kernel_clockid_t,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct linger {
 pub l_onoff: crate::ctypes::c_int,
 pub l_linger: crate::ctypes::c_int,
@@ -1711,6 +1737,26 @@ pub const NFPROTO_BRIDGE: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_BRIDGE;
 pub const NFPROTO_IPV6: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_IPV6;
 pub const NFPROTO_DECNET: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_DECNET;
 pub const NFPROTO_NUMPROTO: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_NUMPROTO;
+pub const SOF_TIMESTAMPING_TX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_HARDWARE;
+pub const SOF_TIMESTAMPING_TX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SOFTWARE;
+pub const SOF_TIMESTAMPING_RX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_HARDWARE;
+pub const SOF_TIMESTAMPING_RX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_SOFTWARE;
+pub const SOF_TIMESTAMPING_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SOFTWARE;
+pub const SOF_TIMESTAMPING_SYS_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SYS_HARDWARE;
+pub const SOF_TIMESTAMPING_RAW_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RAW_HARDWARE;
+pub const SOF_TIMESTAMPING_OPT_ID: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID;
+pub const SOF_TIMESTAMPING_TX_SCHED: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SCHED;
+pub const SOF_TIMESTAMPING_TX_ACK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_ACK;
+pub const SOF_TIMESTAMPING_OPT_CMSG: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_CMSG;
+pub const SOF_TIMESTAMPING_OPT_TSONLY: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TSONLY;
+pub const SOF_TIMESTAMPING_OPT_STATS: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_STATS;
+pub const SOF_TIMESTAMPING_OPT_PKTINFO: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_PKTINFO;
+pub const SOF_TIMESTAMPING_OPT_TX_SWHW: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TX_SWHW;
+pub const SOF_TIMESTAMPING_BIND_PHC: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_BIND_PHC;
+pub const SOF_TIMESTAMPING_OPT_ID_TCP: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID_TCP;
+pub const SOF_TIMESTAMPING_OPT_RX_FILTER: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_LAST: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_MASK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_MASK;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -2050,6 +2096,76 @@ NF_IP_PRI_NAT_SRC = 100,
 NF_IP_PRI_SELINUX_LAST = 225,
 NF_IP_PRI_CONNTRACK_HELPER = 300,
 NF_IP_PRI_CONNTRACK_CONFIRM = 2147483647,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_10 {
+SOF_TIMESTAMPING_TX_HARDWARE = 1,
+SOF_TIMESTAMPING_TX_SOFTWARE = 2,
+SOF_TIMESTAMPING_RX_HARDWARE = 4,
+SOF_TIMESTAMPING_RX_SOFTWARE = 8,
+SOF_TIMESTAMPING_SOFTWARE = 16,
+SOF_TIMESTAMPING_SYS_HARDWARE = 32,
+SOF_TIMESTAMPING_RAW_HARDWARE = 64,
+SOF_TIMESTAMPING_OPT_ID = 128,
+SOF_TIMESTAMPING_TX_SCHED = 256,
+SOF_TIMESTAMPING_TX_ACK = 512,
+SOF_TIMESTAMPING_OPT_CMSG = 1024,
+SOF_TIMESTAMPING_OPT_TSONLY = 2048,
+SOF_TIMESTAMPING_OPT_STATS = 4096,
+SOF_TIMESTAMPING_OPT_PKTINFO = 8192,
+SOF_TIMESTAMPING_OPT_TX_SWHW = 16384,
+SOF_TIMESTAMPING_BIND_PHC = 32768,
+SOF_TIMESTAMPING_OPT_ID_TCP = 65536,
+SOF_TIMESTAMPING_OPT_RX_FILTER = 131072,
+SOF_TIMESTAMPING_MASK = 262143,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_flags {
+HWTSTAMP_FLAG_BONDED_PHC_INDEX = 1,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_tx_types {
+HWTSTAMP_TX_OFF = 0,
+HWTSTAMP_TX_ON = 1,
+HWTSTAMP_TX_ONESTEP_SYNC = 2,
+HWTSTAMP_TX_ONESTEP_P2P = 3,
+__HWTSTAMP_TX_CNT = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_rx_filters {
+HWTSTAMP_FILTER_NONE = 0,
+HWTSTAMP_FILTER_ALL = 1,
+HWTSTAMP_FILTER_SOME = 2,
+HWTSTAMP_FILTER_PTP_V1_L4_EVENT = 3,
+HWTSTAMP_FILTER_PTP_V1_L4_SYNC = 4,
+HWTSTAMP_FILTER_PTP_V1_L4_DELAY_REQ = 5,
+HWTSTAMP_FILTER_PTP_V2_L4_EVENT = 6,
+HWTSTAMP_FILTER_PTP_V2_L4_SYNC = 7,
+HWTSTAMP_FILTER_PTP_V2_L4_DELAY_REQ = 8,
+HWTSTAMP_FILTER_PTP_V2_L2_EVENT = 9,
+HWTSTAMP_FILTER_PTP_V2_L2_SYNC = 10,
+HWTSTAMP_FILTER_PTP_V2_L2_DELAY_REQ = 11,
+HWTSTAMP_FILTER_PTP_V2_EVENT = 12,
+HWTSTAMP_FILTER_PTP_V2_SYNC = 13,
+HWTSTAMP_FILTER_PTP_V2_DELAY_REQ = 14,
+HWTSTAMP_FILTER_NTP_ALL = 15,
+__HWTSTAMP_FILTER_CNT = 16,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum txtime_flags {
+SOF_TXTIME_DEADLINE_MODE = 1,
+SOF_TXTIME_REPORT_ERRORS = 2,
+SOF_TXTIME_FLAGS_MASK = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3291,4 +3407,13 @@ pub const NF_INET_INGRESS: nf_inet_hooks = nf_inet_hooks::NF_INET_NUMHOOKS;
 }
 impl nf_ip_hook_priorities {
 pub const NF_IP_PRI_LAST: nf_ip_hook_priorities = nf_ip_hook_priorities::NF_IP_PRI_CONNTRACK_CONFIRM;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_LAST: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_MASK: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl txtime_flags {
+pub const SOF_TXTIME_FLAGS_LAST: txtime_flags = txtime_flags::SOF_TXTIME_REPORT_ERRORS;
 }

--- a/src/csky/net.rs
+++ b/src/csky/net.rs
@@ -806,6 +806,32 @@ pub entrytable: __IncompleteArrayField<ip6t_entry>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct so_timestamping {
+pub flags: crate::ctypes::c_int,
+pub bind_phc: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hwtstamp_config {
+pub flags: crate::ctypes::c_int,
+pub tx_type: crate::ctypes::c_int,
+pub rx_filter: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct scm_ts_pktinfo {
+pub if_index: __u32,
+pub pkt_length: __u32,
+pub reserved: [__u32; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sock_txtime {
+pub clockid: __kernel_clockid_t,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct linger {
 pub l_onoff: crate::ctypes::c_int,
 pub l_linger: crate::ctypes::c_int,
@@ -1713,6 +1739,26 @@ pub const NFPROTO_BRIDGE: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_BRIDGE;
 pub const NFPROTO_IPV6: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_IPV6;
 pub const NFPROTO_DECNET: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_DECNET;
 pub const NFPROTO_NUMPROTO: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_NUMPROTO;
+pub const SOF_TIMESTAMPING_TX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_HARDWARE;
+pub const SOF_TIMESTAMPING_TX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SOFTWARE;
+pub const SOF_TIMESTAMPING_RX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_HARDWARE;
+pub const SOF_TIMESTAMPING_RX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_SOFTWARE;
+pub const SOF_TIMESTAMPING_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SOFTWARE;
+pub const SOF_TIMESTAMPING_SYS_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SYS_HARDWARE;
+pub const SOF_TIMESTAMPING_RAW_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RAW_HARDWARE;
+pub const SOF_TIMESTAMPING_OPT_ID: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID;
+pub const SOF_TIMESTAMPING_TX_SCHED: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SCHED;
+pub const SOF_TIMESTAMPING_TX_ACK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_ACK;
+pub const SOF_TIMESTAMPING_OPT_CMSG: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_CMSG;
+pub const SOF_TIMESTAMPING_OPT_TSONLY: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TSONLY;
+pub const SOF_TIMESTAMPING_OPT_STATS: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_STATS;
+pub const SOF_TIMESTAMPING_OPT_PKTINFO: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_PKTINFO;
+pub const SOF_TIMESTAMPING_OPT_TX_SWHW: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TX_SWHW;
+pub const SOF_TIMESTAMPING_BIND_PHC: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_BIND_PHC;
+pub const SOF_TIMESTAMPING_OPT_ID_TCP: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID_TCP;
+pub const SOF_TIMESTAMPING_OPT_RX_FILTER: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_LAST: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_MASK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_MASK;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -2052,6 +2098,76 @@ NF_IP_PRI_NAT_SRC = 100,
 NF_IP_PRI_SELINUX_LAST = 225,
 NF_IP_PRI_CONNTRACK_HELPER = 300,
 NF_IP_PRI_CONNTRACK_CONFIRM = 2147483647,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_10 {
+SOF_TIMESTAMPING_TX_HARDWARE = 1,
+SOF_TIMESTAMPING_TX_SOFTWARE = 2,
+SOF_TIMESTAMPING_RX_HARDWARE = 4,
+SOF_TIMESTAMPING_RX_SOFTWARE = 8,
+SOF_TIMESTAMPING_SOFTWARE = 16,
+SOF_TIMESTAMPING_SYS_HARDWARE = 32,
+SOF_TIMESTAMPING_RAW_HARDWARE = 64,
+SOF_TIMESTAMPING_OPT_ID = 128,
+SOF_TIMESTAMPING_TX_SCHED = 256,
+SOF_TIMESTAMPING_TX_ACK = 512,
+SOF_TIMESTAMPING_OPT_CMSG = 1024,
+SOF_TIMESTAMPING_OPT_TSONLY = 2048,
+SOF_TIMESTAMPING_OPT_STATS = 4096,
+SOF_TIMESTAMPING_OPT_PKTINFO = 8192,
+SOF_TIMESTAMPING_OPT_TX_SWHW = 16384,
+SOF_TIMESTAMPING_BIND_PHC = 32768,
+SOF_TIMESTAMPING_OPT_ID_TCP = 65536,
+SOF_TIMESTAMPING_OPT_RX_FILTER = 131072,
+SOF_TIMESTAMPING_MASK = 262143,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_flags {
+HWTSTAMP_FLAG_BONDED_PHC_INDEX = 1,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_tx_types {
+HWTSTAMP_TX_OFF = 0,
+HWTSTAMP_TX_ON = 1,
+HWTSTAMP_TX_ONESTEP_SYNC = 2,
+HWTSTAMP_TX_ONESTEP_P2P = 3,
+__HWTSTAMP_TX_CNT = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_rx_filters {
+HWTSTAMP_FILTER_NONE = 0,
+HWTSTAMP_FILTER_ALL = 1,
+HWTSTAMP_FILTER_SOME = 2,
+HWTSTAMP_FILTER_PTP_V1_L4_EVENT = 3,
+HWTSTAMP_FILTER_PTP_V1_L4_SYNC = 4,
+HWTSTAMP_FILTER_PTP_V1_L4_DELAY_REQ = 5,
+HWTSTAMP_FILTER_PTP_V2_L4_EVENT = 6,
+HWTSTAMP_FILTER_PTP_V2_L4_SYNC = 7,
+HWTSTAMP_FILTER_PTP_V2_L4_DELAY_REQ = 8,
+HWTSTAMP_FILTER_PTP_V2_L2_EVENT = 9,
+HWTSTAMP_FILTER_PTP_V2_L2_SYNC = 10,
+HWTSTAMP_FILTER_PTP_V2_L2_DELAY_REQ = 11,
+HWTSTAMP_FILTER_PTP_V2_EVENT = 12,
+HWTSTAMP_FILTER_PTP_V2_SYNC = 13,
+HWTSTAMP_FILTER_PTP_V2_DELAY_REQ = 14,
+HWTSTAMP_FILTER_NTP_ALL = 15,
+__HWTSTAMP_FILTER_CNT = 16,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum txtime_flags {
+SOF_TXTIME_DEADLINE_MODE = 1,
+SOF_TXTIME_REPORT_ERRORS = 2,
+SOF_TXTIME_FLAGS_MASK = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3293,4 +3409,13 @@ pub const NF_INET_INGRESS: nf_inet_hooks = nf_inet_hooks::NF_INET_NUMHOOKS;
 }
 impl nf_ip_hook_priorities {
 pub const NF_IP_PRI_LAST: nf_ip_hook_priorities = nf_ip_hook_priorities::NF_IP_PRI_CONNTRACK_CONFIRM;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_LAST: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_MASK: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl txtime_flags {
+pub const SOF_TXTIME_FLAGS_LAST: txtime_flags = txtime_flags::SOF_TXTIME_REPORT_ERRORS;
 }

--- a/src/loongarch64/net.rs
+++ b/src/loongarch64/net.rs
@@ -804,6 +804,32 @@ pub entrytable: __IncompleteArrayField<ip6t_entry>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct so_timestamping {
+pub flags: crate::ctypes::c_int,
+pub bind_phc: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hwtstamp_config {
+pub flags: crate::ctypes::c_int,
+pub tx_type: crate::ctypes::c_int,
+pub rx_filter: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct scm_ts_pktinfo {
+pub if_index: __u32,
+pub pkt_length: __u32,
+pub reserved: [__u32; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sock_txtime {
+pub clockid: __kernel_clockid_t,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct linger {
 pub l_onoff: crate::ctypes::c_int,
 pub l_linger: crate::ctypes::c_int,
@@ -1719,6 +1745,26 @@ pub const NFPROTO_BRIDGE: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_BRIDGE;
 pub const NFPROTO_IPV6: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_IPV6;
 pub const NFPROTO_DECNET: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_DECNET;
 pub const NFPROTO_NUMPROTO: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_NUMPROTO;
+pub const SOF_TIMESTAMPING_TX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_HARDWARE;
+pub const SOF_TIMESTAMPING_TX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SOFTWARE;
+pub const SOF_TIMESTAMPING_RX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_HARDWARE;
+pub const SOF_TIMESTAMPING_RX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_SOFTWARE;
+pub const SOF_TIMESTAMPING_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SOFTWARE;
+pub const SOF_TIMESTAMPING_SYS_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SYS_HARDWARE;
+pub const SOF_TIMESTAMPING_RAW_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RAW_HARDWARE;
+pub const SOF_TIMESTAMPING_OPT_ID: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID;
+pub const SOF_TIMESTAMPING_TX_SCHED: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SCHED;
+pub const SOF_TIMESTAMPING_TX_ACK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_ACK;
+pub const SOF_TIMESTAMPING_OPT_CMSG: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_CMSG;
+pub const SOF_TIMESTAMPING_OPT_TSONLY: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TSONLY;
+pub const SOF_TIMESTAMPING_OPT_STATS: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_STATS;
+pub const SOF_TIMESTAMPING_OPT_PKTINFO: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_PKTINFO;
+pub const SOF_TIMESTAMPING_OPT_TX_SWHW: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TX_SWHW;
+pub const SOF_TIMESTAMPING_BIND_PHC: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_BIND_PHC;
+pub const SOF_TIMESTAMPING_OPT_ID_TCP: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID_TCP;
+pub const SOF_TIMESTAMPING_OPT_RX_FILTER: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_LAST: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_MASK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_MASK;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -2058,6 +2104,76 @@ NF_IP_PRI_NAT_SRC = 100,
 NF_IP_PRI_SELINUX_LAST = 225,
 NF_IP_PRI_CONNTRACK_HELPER = 300,
 NF_IP_PRI_CONNTRACK_CONFIRM = 2147483647,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_10 {
+SOF_TIMESTAMPING_TX_HARDWARE = 1,
+SOF_TIMESTAMPING_TX_SOFTWARE = 2,
+SOF_TIMESTAMPING_RX_HARDWARE = 4,
+SOF_TIMESTAMPING_RX_SOFTWARE = 8,
+SOF_TIMESTAMPING_SOFTWARE = 16,
+SOF_TIMESTAMPING_SYS_HARDWARE = 32,
+SOF_TIMESTAMPING_RAW_HARDWARE = 64,
+SOF_TIMESTAMPING_OPT_ID = 128,
+SOF_TIMESTAMPING_TX_SCHED = 256,
+SOF_TIMESTAMPING_TX_ACK = 512,
+SOF_TIMESTAMPING_OPT_CMSG = 1024,
+SOF_TIMESTAMPING_OPT_TSONLY = 2048,
+SOF_TIMESTAMPING_OPT_STATS = 4096,
+SOF_TIMESTAMPING_OPT_PKTINFO = 8192,
+SOF_TIMESTAMPING_OPT_TX_SWHW = 16384,
+SOF_TIMESTAMPING_BIND_PHC = 32768,
+SOF_TIMESTAMPING_OPT_ID_TCP = 65536,
+SOF_TIMESTAMPING_OPT_RX_FILTER = 131072,
+SOF_TIMESTAMPING_MASK = 262143,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_flags {
+HWTSTAMP_FLAG_BONDED_PHC_INDEX = 1,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_tx_types {
+HWTSTAMP_TX_OFF = 0,
+HWTSTAMP_TX_ON = 1,
+HWTSTAMP_TX_ONESTEP_SYNC = 2,
+HWTSTAMP_TX_ONESTEP_P2P = 3,
+__HWTSTAMP_TX_CNT = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_rx_filters {
+HWTSTAMP_FILTER_NONE = 0,
+HWTSTAMP_FILTER_ALL = 1,
+HWTSTAMP_FILTER_SOME = 2,
+HWTSTAMP_FILTER_PTP_V1_L4_EVENT = 3,
+HWTSTAMP_FILTER_PTP_V1_L4_SYNC = 4,
+HWTSTAMP_FILTER_PTP_V1_L4_DELAY_REQ = 5,
+HWTSTAMP_FILTER_PTP_V2_L4_EVENT = 6,
+HWTSTAMP_FILTER_PTP_V2_L4_SYNC = 7,
+HWTSTAMP_FILTER_PTP_V2_L4_DELAY_REQ = 8,
+HWTSTAMP_FILTER_PTP_V2_L2_EVENT = 9,
+HWTSTAMP_FILTER_PTP_V2_L2_SYNC = 10,
+HWTSTAMP_FILTER_PTP_V2_L2_DELAY_REQ = 11,
+HWTSTAMP_FILTER_PTP_V2_EVENT = 12,
+HWTSTAMP_FILTER_PTP_V2_SYNC = 13,
+HWTSTAMP_FILTER_PTP_V2_DELAY_REQ = 14,
+HWTSTAMP_FILTER_NTP_ALL = 15,
+__HWTSTAMP_FILTER_CNT = 16,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum txtime_flags {
+SOF_TXTIME_DEADLINE_MODE = 1,
+SOF_TXTIME_REPORT_ERRORS = 2,
+SOF_TXTIME_FLAGS_MASK = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3299,4 +3415,13 @@ pub const NF_INET_INGRESS: nf_inet_hooks = nf_inet_hooks::NF_INET_NUMHOOKS;
 }
 impl nf_ip_hook_priorities {
 pub const NF_IP_PRI_LAST: nf_ip_hook_priorities = nf_ip_hook_priorities::NF_IP_PRI_CONNTRACK_CONFIRM;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_LAST: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_MASK: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl txtime_flags {
+pub const SOF_TXTIME_FLAGS_LAST: txtime_flags = txtime_flags::SOF_TXTIME_REPORT_ERRORS;
 }

--- a/src/mips/net.rs
+++ b/src/mips/net.rs
@@ -804,6 +804,32 @@ pub entrytable: __IncompleteArrayField<ip6t_entry>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct so_timestamping {
+pub flags: crate::ctypes::c_int,
+pub bind_phc: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hwtstamp_config {
+pub flags: crate::ctypes::c_int,
+pub tx_type: crate::ctypes::c_int,
+pub rx_filter: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct scm_ts_pktinfo {
+pub if_index: __u32,
+pub pkt_length: __u32,
+pub reserved: [__u32; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sock_txtime {
+pub clockid: __kernel_clockid_t,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct linger {
 pub l_onoff: crate::ctypes::c_int,
 pub l_linger: crate::ctypes::c_int,
@@ -1742,6 +1768,26 @@ pub const NFPROTO_BRIDGE: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_BRIDGE;
 pub const NFPROTO_IPV6: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_IPV6;
 pub const NFPROTO_DECNET: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_DECNET;
 pub const NFPROTO_NUMPROTO: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_NUMPROTO;
+pub const SOF_TIMESTAMPING_TX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_HARDWARE;
+pub const SOF_TIMESTAMPING_TX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SOFTWARE;
+pub const SOF_TIMESTAMPING_RX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_HARDWARE;
+pub const SOF_TIMESTAMPING_RX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_SOFTWARE;
+pub const SOF_TIMESTAMPING_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SOFTWARE;
+pub const SOF_TIMESTAMPING_SYS_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SYS_HARDWARE;
+pub const SOF_TIMESTAMPING_RAW_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RAW_HARDWARE;
+pub const SOF_TIMESTAMPING_OPT_ID: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID;
+pub const SOF_TIMESTAMPING_TX_SCHED: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SCHED;
+pub const SOF_TIMESTAMPING_TX_ACK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_ACK;
+pub const SOF_TIMESTAMPING_OPT_CMSG: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_CMSG;
+pub const SOF_TIMESTAMPING_OPT_TSONLY: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TSONLY;
+pub const SOF_TIMESTAMPING_OPT_STATS: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_STATS;
+pub const SOF_TIMESTAMPING_OPT_PKTINFO: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_PKTINFO;
+pub const SOF_TIMESTAMPING_OPT_TX_SWHW: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TX_SWHW;
+pub const SOF_TIMESTAMPING_BIND_PHC: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_BIND_PHC;
+pub const SOF_TIMESTAMPING_OPT_ID_TCP: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID_TCP;
+pub const SOF_TIMESTAMPING_OPT_RX_FILTER: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_LAST: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_MASK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_MASK;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -2081,6 +2127,76 @@ NF_IP_PRI_NAT_SRC = 100,
 NF_IP_PRI_SELINUX_LAST = 225,
 NF_IP_PRI_CONNTRACK_HELPER = 300,
 NF_IP_PRI_CONNTRACK_CONFIRM = 2147483647,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_10 {
+SOF_TIMESTAMPING_TX_HARDWARE = 1,
+SOF_TIMESTAMPING_TX_SOFTWARE = 2,
+SOF_TIMESTAMPING_RX_HARDWARE = 4,
+SOF_TIMESTAMPING_RX_SOFTWARE = 8,
+SOF_TIMESTAMPING_SOFTWARE = 16,
+SOF_TIMESTAMPING_SYS_HARDWARE = 32,
+SOF_TIMESTAMPING_RAW_HARDWARE = 64,
+SOF_TIMESTAMPING_OPT_ID = 128,
+SOF_TIMESTAMPING_TX_SCHED = 256,
+SOF_TIMESTAMPING_TX_ACK = 512,
+SOF_TIMESTAMPING_OPT_CMSG = 1024,
+SOF_TIMESTAMPING_OPT_TSONLY = 2048,
+SOF_TIMESTAMPING_OPT_STATS = 4096,
+SOF_TIMESTAMPING_OPT_PKTINFO = 8192,
+SOF_TIMESTAMPING_OPT_TX_SWHW = 16384,
+SOF_TIMESTAMPING_BIND_PHC = 32768,
+SOF_TIMESTAMPING_OPT_ID_TCP = 65536,
+SOF_TIMESTAMPING_OPT_RX_FILTER = 131072,
+SOF_TIMESTAMPING_MASK = 262143,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_flags {
+HWTSTAMP_FLAG_BONDED_PHC_INDEX = 1,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_tx_types {
+HWTSTAMP_TX_OFF = 0,
+HWTSTAMP_TX_ON = 1,
+HWTSTAMP_TX_ONESTEP_SYNC = 2,
+HWTSTAMP_TX_ONESTEP_P2P = 3,
+__HWTSTAMP_TX_CNT = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_rx_filters {
+HWTSTAMP_FILTER_NONE = 0,
+HWTSTAMP_FILTER_ALL = 1,
+HWTSTAMP_FILTER_SOME = 2,
+HWTSTAMP_FILTER_PTP_V1_L4_EVENT = 3,
+HWTSTAMP_FILTER_PTP_V1_L4_SYNC = 4,
+HWTSTAMP_FILTER_PTP_V1_L4_DELAY_REQ = 5,
+HWTSTAMP_FILTER_PTP_V2_L4_EVENT = 6,
+HWTSTAMP_FILTER_PTP_V2_L4_SYNC = 7,
+HWTSTAMP_FILTER_PTP_V2_L4_DELAY_REQ = 8,
+HWTSTAMP_FILTER_PTP_V2_L2_EVENT = 9,
+HWTSTAMP_FILTER_PTP_V2_L2_SYNC = 10,
+HWTSTAMP_FILTER_PTP_V2_L2_DELAY_REQ = 11,
+HWTSTAMP_FILTER_PTP_V2_EVENT = 12,
+HWTSTAMP_FILTER_PTP_V2_SYNC = 13,
+HWTSTAMP_FILTER_PTP_V2_DELAY_REQ = 14,
+HWTSTAMP_FILTER_NTP_ALL = 15,
+__HWTSTAMP_FILTER_CNT = 16,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum txtime_flags {
+SOF_TXTIME_DEADLINE_MODE = 1,
+SOF_TXTIME_REPORT_ERRORS = 2,
+SOF_TXTIME_FLAGS_MASK = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3322,4 +3438,13 @@ pub const NF_INET_INGRESS: nf_inet_hooks = nf_inet_hooks::NF_INET_NUMHOOKS;
 }
 impl nf_ip_hook_priorities {
 pub const NF_IP_PRI_LAST: nf_ip_hook_priorities = nf_ip_hook_priorities::NF_IP_PRI_CONNTRACK_CONFIRM;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_LAST: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_MASK: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl txtime_flags {
+pub const SOF_TXTIME_FLAGS_LAST: txtime_flags = txtime_flags::SOF_TXTIME_REPORT_ERRORS;
 }

--- a/src/mips32r6/net.rs
+++ b/src/mips32r6/net.rs
@@ -804,6 +804,32 @@ pub entrytable: __IncompleteArrayField<ip6t_entry>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct so_timestamping {
+pub flags: crate::ctypes::c_int,
+pub bind_phc: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hwtstamp_config {
+pub flags: crate::ctypes::c_int,
+pub tx_type: crate::ctypes::c_int,
+pub rx_filter: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct scm_ts_pktinfo {
+pub if_index: __u32,
+pub pkt_length: __u32,
+pub reserved: [__u32; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sock_txtime {
+pub clockid: __kernel_clockid_t,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct linger {
 pub l_onoff: crate::ctypes::c_int,
 pub l_linger: crate::ctypes::c_int,
@@ -1742,6 +1768,26 @@ pub const NFPROTO_BRIDGE: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_BRIDGE;
 pub const NFPROTO_IPV6: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_IPV6;
 pub const NFPROTO_DECNET: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_DECNET;
 pub const NFPROTO_NUMPROTO: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_NUMPROTO;
+pub const SOF_TIMESTAMPING_TX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_HARDWARE;
+pub const SOF_TIMESTAMPING_TX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SOFTWARE;
+pub const SOF_TIMESTAMPING_RX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_HARDWARE;
+pub const SOF_TIMESTAMPING_RX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_SOFTWARE;
+pub const SOF_TIMESTAMPING_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SOFTWARE;
+pub const SOF_TIMESTAMPING_SYS_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SYS_HARDWARE;
+pub const SOF_TIMESTAMPING_RAW_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RAW_HARDWARE;
+pub const SOF_TIMESTAMPING_OPT_ID: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID;
+pub const SOF_TIMESTAMPING_TX_SCHED: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SCHED;
+pub const SOF_TIMESTAMPING_TX_ACK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_ACK;
+pub const SOF_TIMESTAMPING_OPT_CMSG: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_CMSG;
+pub const SOF_TIMESTAMPING_OPT_TSONLY: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TSONLY;
+pub const SOF_TIMESTAMPING_OPT_STATS: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_STATS;
+pub const SOF_TIMESTAMPING_OPT_PKTINFO: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_PKTINFO;
+pub const SOF_TIMESTAMPING_OPT_TX_SWHW: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TX_SWHW;
+pub const SOF_TIMESTAMPING_BIND_PHC: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_BIND_PHC;
+pub const SOF_TIMESTAMPING_OPT_ID_TCP: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID_TCP;
+pub const SOF_TIMESTAMPING_OPT_RX_FILTER: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_LAST: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_MASK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_MASK;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -2081,6 +2127,76 @@ NF_IP_PRI_NAT_SRC = 100,
 NF_IP_PRI_SELINUX_LAST = 225,
 NF_IP_PRI_CONNTRACK_HELPER = 300,
 NF_IP_PRI_CONNTRACK_CONFIRM = 2147483647,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_10 {
+SOF_TIMESTAMPING_TX_HARDWARE = 1,
+SOF_TIMESTAMPING_TX_SOFTWARE = 2,
+SOF_TIMESTAMPING_RX_HARDWARE = 4,
+SOF_TIMESTAMPING_RX_SOFTWARE = 8,
+SOF_TIMESTAMPING_SOFTWARE = 16,
+SOF_TIMESTAMPING_SYS_HARDWARE = 32,
+SOF_TIMESTAMPING_RAW_HARDWARE = 64,
+SOF_TIMESTAMPING_OPT_ID = 128,
+SOF_TIMESTAMPING_TX_SCHED = 256,
+SOF_TIMESTAMPING_TX_ACK = 512,
+SOF_TIMESTAMPING_OPT_CMSG = 1024,
+SOF_TIMESTAMPING_OPT_TSONLY = 2048,
+SOF_TIMESTAMPING_OPT_STATS = 4096,
+SOF_TIMESTAMPING_OPT_PKTINFO = 8192,
+SOF_TIMESTAMPING_OPT_TX_SWHW = 16384,
+SOF_TIMESTAMPING_BIND_PHC = 32768,
+SOF_TIMESTAMPING_OPT_ID_TCP = 65536,
+SOF_TIMESTAMPING_OPT_RX_FILTER = 131072,
+SOF_TIMESTAMPING_MASK = 262143,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_flags {
+HWTSTAMP_FLAG_BONDED_PHC_INDEX = 1,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_tx_types {
+HWTSTAMP_TX_OFF = 0,
+HWTSTAMP_TX_ON = 1,
+HWTSTAMP_TX_ONESTEP_SYNC = 2,
+HWTSTAMP_TX_ONESTEP_P2P = 3,
+__HWTSTAMP_TX_CNT = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_rx_filters {
+HWTSTAMP_FILTER_NONE = 0,
+HWTSTAMP_FILTER_ALL = 1,
+HWTSTAMP_FILTER_SOME = 2,
+HWTSTAMP_FILTER_PTP_V1_L4_EVENT = 3,
+HWTSTAMP_FILTER_PTP_V1_L4_SYNC = 4,
+HWTSTAMP_FILTER_PTP_V1_L4_DELAY_REQ = 5,
+HWTSTAMP_FILTER_PTP_V2_L4_EVENT = 6,
+HWTSTAMP_FILTER_PTP_V2_L4_SYNC = 7,
+HWTSTAMP_FILTER_PTP_V2_L4_DELAY_REQ = 8,
+HWTSTAMP_FILTER_PTP_V2_L2_EVENT = 9,
+HWTSTAMP_FILTER_PTP_V2_L2_SYNC = 10,
+HWTSTAMP_FILTER_PTP_V2_L2_DELAY_REQ = 11,
+HWTSTAMP_FILTER_PTP_V2_EVENT = 12,
+HWTSTAMP_FILTER_PTP_V2_SYNC = 13,
+HWTSTAMP_FILTER_PTP_V2_DELAY_REQ = 14,
+HWTSTAMP_FILTER_NTP_ALL = 15,
+__HWTSTAMP_FILTER_CNT = 16,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum txtime_flags {
+SOF_TXTIME_DEADLINE_MODE = 1,
+SOF_TXTIME_REPORT_ERRORS = 2,
+SOF_TXTIME_FLAGS_MASK = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3322,4 +3438,13 @@ pub const NF_INET_INGRESS: nf_inet_hooks = nf_inet_hooks::NF_INET_NUMHOOKS;
 }
 impl nf_ip_hook_priorities {
 pub const NF_IP_PRI_LAST: nf_ip_hook_priorities = nf_ip_hook_priorities::NF_IP_PRI_CONNTRACK_CONFIRM;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_LAST: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_MASK: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl txtime_flags {
+pub const SOF_TXTIME_FLAGS_LAST: txtime_flags = txtime_flags::SOF_TXTIME_REPORT_ERRORS;
 }

--- a/src/mips64/net.rs
+++ b/src/mips64/net.rs
@@ -804,6 +804,32 @@ pub entrytable: __IncompleteArrayField<ip6t_entry>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct so_timestamping {
+pub flags: crate::ctypes::c_int,
+pub bind_phc: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hwtstamp_config {
+pub flags: crate::ctypes::c_int,
+pub tx_type: crate::ctypes::c_int,
+pub rx_filter: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct scm_ts_pktinfo {
+pub if_index: __u32,
+pub pkt_length: __u32,
+pub reserved: [__u32; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sock_txtime {
+pub clockid: __kernel_clockid_t,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct linger {
 pub l_onoff: crate::ctypes::c_int,
 pub l_linger: crate::ctypes::c_int,
@@ -1750,6 +1776,26 @@ pub const NFPROTO_BRIDGE: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_BRIDGE;
 pub const NFPROTO_IPV6: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_IPV6;
 pub const NFPROTO_DECNET: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_DECNET;
 pub const NFPROTO_NUMPROTO: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_NUMPROTO;
+pub const SOF_TIMESTAMPING_TX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_HARDWARE;
+pub const SOF_TIMESTAMPING_TX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SOFTWARE;
+pub const SOF_TIMESTAMPING_RX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_HARDWARE;
+pub const SOF_TIMESTAMPING_RX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_SOFTWARE;
+pub const SOF_TIMESTAMPING_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SOFTWARE;
+pub const SOF_TIMESTAMPING_SYS_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SYS_HARDWARE;
+pub const SOF_TIMESTAMPING_RAW_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RAW_HARDWARE;
+pub const SOF_TIMESTAMPING_OPT_ID: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID;
+pub const SOF_TIMESTAMPING_TX_SCHED: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SCHED;
+pub const SOF_TIMESTAMPING_TX_ACK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_ACK;
+pub const SOF_TIMESTAMPING_OPT_CMSG: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_CMSG;
+pub const SOF_TIMESTAMPING_OPT_TSONLY: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TSONLY;
+pub const SOF_TIMESTAMPING_OPT_STATS: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_STATS;
+pub const SOF_TIMESTAMPING_OPT_PKTINFO: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_PKTINFO;
+pub const SOF_TIMESTAMPING_OPT_TX_SWHW: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TX_SWHW;
+pub const SOF_TIMESTAMPING_BIND_PHC: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_BIND_PHC;
+pub const SOF_TIMESTAMPING_OPT_ID_TCP: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID_TCP;
+pub const SOF_TIMESTAMPING_OPT_RX_FILTER: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_LAST: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_MASK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_MASK;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -2089,6 +2135,76 @@ NF_IP_PRI_NAT_SRC = 100,
 NF_IP_PRI_SELINUX_LAST = 225,
 NF_IP_PRI_CONNTRACK_HELPER = 300,
 NF_IP_PRI_CONNTRACK_CONFIRM = 2147483647,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_10 {
+SOF_TIMESTAMPING_TX_HARDWARE = 1,
+SOF_TIMESTAMPING_TX_SOFTWARE = 2,
+SOF_TIMESTAMPING_RX_HARDWARE = 4,
+SOF_TIMESTAMPING_RX_SOFTWARE = 8,
+SOF_TIMESTAMPING_SOFTWARE = 16,
+SOF_TIMESTAMPING_SYS_HARDWARE = 32,
+SOF_TIMESTAMPING_RAW_HARDWARE = 64,
+SOF_TIMESTAMPING_OPT_ID = 128,
+SOF_TIMESTAMPING_TX_SCHED = 256,
+SOF_TIMESTAMPING_TX_ACK = 512,
+SOF_TIMESTAMPING_OPT_CMSG = 1024,
+SOF_TIMESTAMPING_OPT_TSONLY = 2048,
+SOF_TIMESTAMPING_OPT_STATS = 4096,
+SOF_TIMESTAMPING_OPT_PKTINFO = 8192,
+SOF_TIMESTAMPING_OPT_TX_SWHW = 16384,
+SOF_TIMESTAMPING_BIND_PHC = 32768,
+SOF_TIMESTAMPING_OPT_ID_TCP = 65536,
+SOF_TIMESTAMPING_OPT_RX_FILTER = 131072,
+SOF_TIMESTAMPING_MASK = 262143,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_flags {
+HWTSTAMP_FLAG_BONDED_PHC_INDEX = 1,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_tx_types {
+HWTSTAMP_TX_OFF = 0,
+HWTSTAMP_TX_ON = 1,
+HWTSTAMP_TX_ONESTEP_SYNC = 2,
+HWTSTAMP_TX_ONESTEP_P2P = 3,
+__HWTSTAMP_TX_CNT = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_rx_filters {
+HWTSTAMP_FILTER_NONE = 0,
+HWTSTAMP_FILTER_ALL = 1,
+HWTSTAMP_FILTER_SOME = 2,
+HWTSTAMP_FILTER_PTP_V1_L4_EVENT = 3,
+HWTSTAMP_FILTER_PTP_V1_L4_SYNC = 4,
+HWTSTAMP_FILTER_PTP_V1_L4_DELAY_REQ = 5,
+HWTSTAMP_FILTER_PTP_V2_L4_EVENT = 6,
+HWTSTAMP_FILTER_PTP_V2_L4_SYNC = 7,
+HWTSTAMP_FILTER_PTP_V2_L4_DELAY_REQ = 8,
+HWTSTAMP_FILTER_PTP_V2_L2_EVENT = 9,
+HWTSTAMP_FILTER_PTP_V2_L2_SYNC = 10,
+HWTSTAMP_FILTER_PTP_V2_L2_DELAY_REQ = 11,
+HWTSTAMP_FILTER_PTP_V2_EVENT = 12,
+HWTSTAMP_FILTER_PTP_V2_SYNC = 13,
+HWTSTAMP_FILTER_PTP_V2_DELAY_REQ = 14,
+HWTSTAMP_FILTER_NTP_ALL = 15,
+__HWTSTAMP_FILTER_CNT = 16,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum txtime_flags {
+SOF_TXTIME_DEADLINE_MODE = 1,
+SOF_TXTIME_REPORT_ERRORS = 2,
+SOF_TXTIME_FLAGS_MASK = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3330,4 +3446,13 @@ pub const NF_INET_INGRESS: nf_inet_hooks = nf_inet_hooks::NF_INET_NUMHOOKS;
 }
 impl nf_ip_hook_priorities {
 pub const NF_IP_PRI_LAST: nf_ip_hook_priorities = nf_ip_hook_priorities::NF_IP_PRI_CONNTRACK_CONFIRM;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_LAST: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_MASK: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl txtime_flags {
+pub const SOF_TXTIME_FLAGS_LAST: txtime_flags = txtime_flags::SOF_TXTIME_REPORT_ERRORS;
 }

--- a/src/mips64r6/net.rs
+++ b/src/mips64r6/net.rs
@@ -804,6 +804,32 @@ pub entrytable: __IncompleteArrayField<ip6t_entry>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct so_timestamping {
+pub flags: crate::ctypes::c_int,
+pub bind_phc: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hwtstamp_config {
+pub flags: crate::ctypes::c_int,
+pub tx_type: crate::ctypes::c_int,
+pub rx_filter: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct scm_ts_pktinfo {
+pub if_index: __u32,
+pub pkt_length: __u32,
+pub reserved: [__u32; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sock_txtime {
+pub clockid: __kernel_clockid_t,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct linger {
 pub l_onoff: crate::ctypes::c_int,
 pub l_linger: crate::ctypes::c_int,
@@ -1750,6 +1776,26 @@ pub const NFPROTO_BRIDGE: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_BRIDGE;
 pub const NFPROTO_IPV6: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_IPV6;
 pub const NFPROTO_DECNET: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_DECNET;
 pub const NFPROTO_NUMPROTO: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_NUMPROTO;
+pub const SOF_TIMESTAMPING_TX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_HARDWARE;
+pub const SOF_TIMESTAMPING_TX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SOFTWARE;
+pub const SOF_TIMESTAMPING_RX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_HARDWARE;
+pub const SOF_TIMESTAMPING_RX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_SOFTWARE;
+pub const SOF_TIMESTAMPING_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SOFTWARE;
+pub const SOF_TIMESTAMPING_SYS_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SYS_HARDWARE;
+pub const SOF_TIMESTAMPING_RAW_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RAW_HARDWARE;
+pub const SOF_TIMESTAMPING_OPT_ID: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID;
+pub const SOF_TIMESTAMPING_TX_SCHED: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SCHED;
+pub const SOF_TIMESTAMPING_TX_ACK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_ACK;
+pub const SOF_TIMESTAMPING_OPT_CMSG: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_CMSG;
+pub const SOF_TIMESTAMPING_OPT_TSONLY: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TSONLY;
+pub const SOF_TIMESTAMPING_OPT_STATS: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_STATS;
+pub const SOF_TIMESTAMPING_OPT_PKTINFO: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_PKTINFO;
+pub const SOF_TIMESTAMPING_OPT_TX_SWHW: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TX_SWHW;
+pub const SOF_TIMESTAMPING_BIND_PHC: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_BIND_PHC;
+pub const SOF_TIMESTAMPING_OPT_ID_TCP: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID_TCP;
+pub const SOF_TIMESTAMPING_OPT_RX_FILTER: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_LAST: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_MASK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_MASK;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -2089,6 +2135,76 @@ NF_IP_PRI_NAT_SRC = 100,
 NF_IP_PRI_SELINUX_LAST = 225,
 NF_IP_PRI_CONNTRACK_HELPER = 300,
 NF_IP_PRI_CONNTRACK_CONFIRM = 2147483647,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_10 {
+SOF_TIMESTAMPING_TX_HARDWARE = 1,
+SOF_TIMESTAMPING_TX_SOFTWARE = 2,
+SOF_TIMESTAMPING_RX_HARDWARE = 4,
+SOF_TIMESTAMPING_RX_SOFTWARE = 8,
+SOF_TIMESTAMPING_SOFTWARE = 16,
+SOF_TIMESTAMPING_SYS_HARDWARE = 32,
+SOF_TIMESTAMPING_RAW_HARDWARE = 64,
+SOF_TIMESTAMPING_OPT_ID = 128,
+SOF_TIMESTAMPING_TX_SCHED = 256,
+SOF_TIMESTAMPING_TX_ACK = 512,
+SOF_TIMESTAMPING_OPT_CMSG = 1024,
+SOF_TIMESTAMPING_OPT_TSONLY = 2048,
+SOF_TIMESTAMPING_OPT_STATS = 4096,
+SOF_TIMESTAMPING_OPT_PKTINFO = 8192,
+SOF_TIMESTAMPING_OPT_TX_SWHW = 16384,
+SOF_TIMESTAMPING_BIND_PHC = 32768,
+SOF_TIMESTAMPING_OPT_ID_TCP = 65536,
+SOF_TIMESTAMPING_OPT_RX_FILTER = 131072,
+SOF_TIMESTAMPING_MASK = 262143,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_flags {
+HWTSTAMP_FLAG_BONDED_PHC_INDEX = 1,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_tx_types {
+HWTSTAMP_TX_OFF = 0,
+HWTSTAMP_TX_ON = 1,
+HWTSTAMP_TX_ONESTEP_SYNC = 2,
+HWTSTAMP_TX_ONESTEP_P2P = 3,
+__HWTSTAMP_TX_CNT = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_rx_filters {
+HWTSTAMP_FILTER_NONE = 0,
+HWTSTAMP_FILTER_ALL = 1,
+HWTSTAMP_FILTER_SOME = 2,
+HWTSTAMP_FILTER_PTP_V1_L4_EVENT = 3,
+HWTSTAMP_FILTER_PTP_V1_L4_SYNC = 4,
+HWTSTAMP_FILTER_PTP_V1_L4_DELAY_REQ = 5,
+HWTSTAMP_FILTER_PTP_V2_L4_EVENT = 6,
+HWTSTAMP_FILTER_PTP_V2_L4_SYNC = 7,
+HWTSTAMP_FILTER_PTP_V2_L4_DELAY_REQ = 8,
+HWTSTAMP_FILTER_PTP_V2_L2_EVENT = 9,
+HWTSTAMP_FILTER_PTP_V2_L2_SYNC = 10,
+HWTSTAMP_FILTER_PTP_V2_L2_DELAY_REQ = 11,
+HWTSTAMP_FILTER_PTP_V2_EVENT = 12,
+HWTSTAMP_FILTER_PTP_V2_SYNC = 13,
+HWTSTAMP_FILTER_PTP_V2_DELAY_REQ = 14,
+HWTSTAMP_FILTER_NTP_ALL = 15,
+__HWTSTAMP_FILTER_CNT = 16,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum txtime_flags {
+SOF_TXTIME_DEADLINE_MODE = 1,
+SOF_TXTIME_REPORT_ERRORS = 2,
+SOF_TXTIME_FLAGS_MASK = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3330,4 +3446,13 @@ pub const NF_INET_INGRESS: nf_inet_hooks = nf_inet_hooks::NF_INET_NUMHOOKS;
 }
 impl nf_ip_hook_priorities {
 pub const NF_IP_PRI_LAST: nf_ip_hook_priorities = nf_ip_hook_priorities::NF_IP_PRI_CONNTRACK_CONFIRM;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_LAST: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_MASK: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl txtime_flags {
+pub const SOF_TXTIME_FLAGS_LAST: txtime_flags = txtime_flags::SOF_TXTIME_REPORT_ERRORS;
 }

--- a/src/powerpc/net.rs
+++ b/src/powerpc/net.rs
@@ -810,6 +810,32 @@ pub entrytable: __IncompleteArrayField<ip6t_entry>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct so_timestamping {
+pub flags: crate::ctypes::c_int,
+pub bind_phc: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hwtstamp_config {
+pub flags: crate::ctypes::c_int,
+pub tx_type: crate::ctypes::c_int,
+pub rx_filter: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct scm_ts_pktinfo {
+pub if_index: __u32,
+pub pkt_length: __u32,
+pub reserved: [__u32; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sock_txtime {
+pub clockid: __kernel_clockid_t,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct linger {
 pub l_onoff: crate::ctypes::c_int,
 pub l_linger: crate::ctypes::c_int,
@@ -1717,6 +1743,26 @@ pub const NFPROTO_BRIDGE: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_BRIDGE;
 pub const NFPROTO_IPV6: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_IPV6;
 pub const NFPROTO_DECNET: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_DECNET;
 pub const NFPROTO_NUMPROTO: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_NUMPROTO;
+pub const SOF_TIMESTAMPING_TX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_HARDWARE;
+pub const SOF_TIMESTAMPING_TX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SOFTWARE;
+pub const SOF_TIMESTAMPING_RX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_HARDWARE;
+pub const SOF_TIMESTAMPING_RX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_SOFTWARE;
+pub const SOF_TIMESTAMPING_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SOFTWARE;
+pub const SOF_TIMESTAMPING_SYS_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SYS_HARDWARE;
+pub const SOF_TIMESTAMPING_RAW_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RAW_HARDWARE;
+pub const SOF_TIMESTAMPING_OPT_ID: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID;
+pub const SOF_TIMESTAMPING_TX_SCHED: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SCHED;
+pub const SOF_TIMESTAMPING_TX_ACK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_ACK;
+pub const SOF_TIMESTAMPING_OPT_CMSG: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_CMSG;
+pub const SOF_TIMESTAMPING_OPT_TSONLY: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TSONLY;
+pub const SOF_TIMESTAMPING_OPT_STATS: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_STATS;
+pub const SOF_TIMESTAMPING_OPT_PKTINFO: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_PKTINFO;
+pub const SOF_TIMESTAMPING_OPT_TX_SWHW: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TX_SWHW;
+pub const SOF_TIMESTAMPING_BIND_PHC: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_BIND_PHC;
+pub const SOF_TIMESTAMPING_OPT_ID_TCP: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID_TCP;
+pub const SOF_TIMESTAMPING_OPT_RX_FILTER: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_LAST: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_MASK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_MASK;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -2056,6 +2102,76 @@ NF_IP_PRI_NAT_SRC = 100,
 NF_IP_PRI_SELINUX_LAST = 225,
 NF_IP_PRI_CONNTRACK_HELPER = 300,
 NF_IP_PRI_CONNTRACK_CONFIRM = 2147483647,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_10 {
+SOF_TIMESTAMPING_TX_HARDWARE = 1,
+SOF_TIMESTAMPING_TX_SOFTWARE = 2,
+SOF_TIMESTAMPING_RX_HARDWARE = 4,
+SOF_TIMESTAMPING_RX_SOFTWARE = 8,
+SOF_TIMESTAMPING_SOFTWARE = 16,
+SOF_TIMESTAMPING_SYS_HARDWARE = 32,
+SOF_TIMESTAMPING_RAW_HARDWARE = 64,
+SOF_TIMESTAMPING_OPT_ID = 128,
+SOF_TIMESTAMPING_TX_SCHED = 256,
+SOF_TIMESTAMPING_TX_ACK = 512,
+SOF_TIMESTAMPING_OPT_CMSG = 1024,
+SOF_TIMESTAMPING_OPT_TSONLY = 2048,
+SOF_TIMESTAMPING_OPT_STATS = 4096,
+SOF_TIMESTAMPING_OPT_PKTINFO = 8192,
+SOF_TIMESTAMPING_OPT_TX_SWHW = 16384,
+SOF_TIMESTAMPING_BIND_PHC = 32768,
+SOF_TIMESTAMPING_OPT_ID_TCP = 65536,
+SOF_TIMESTAMPING_OPT_RX_FILTER = 131072,
+SOF_TIMESTAMPING_MASK = 262143,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_flags {
+HWTSTAMP_FLAG_BONDED_PHC_INDEX = 1,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_tx_types {
+HWTSTAMP_TX_OFF = 0,
+HWTSTAMP_TX_ON = 1,
+HWTSTAMP_TX_ONESTEP_SYNC = 2,
+HWTSTAMP_TX_ONESTEP_P2P = 3,
+__HWTSTAMP_TX_CNT = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_rx_filters {
+HWTSTAMP_FILTER_NONE = 0,
+HWTSTAMP_FILTER_ALL = 1,
+HWTSTAMP_FILTER_SOME = 2,
+HWTSTAMP_FILTER_PTP_V1_L4_EVENT = 3,
+HWTSTAMP_FILTER_PTP_V1_L4_SYNC = 4,
+HWTSTAMP_FILTER_PTP_V1_L4_DELAY_REQ = 5,
+HWTSTAMP_FILTER_PTP_V2_L4_EVENT = 6,
+HWTSTAMP_FILTER_PTP_V2_L4_SYNC = 7,
+HWTSTAMP_FILTER_PTP_V2_L4_DELAY_REQ = 8,
+HWTSTAMP_FILTER_PTP_V2_L2_EVENT = 9,
+HWTSTAMP_FILTER_PTP_V2_L2_SYNC = 10,
+HWTSTAMP_FILTER_PTP_V2_L2_DELAY_REQ = 11,
+HWTSTAMP_FILTER_PTP_V2_EVENT = 12,
+HWTSTAMP_FILTER_PTP_V2_SYNC = 13,
+HWTSTAMP_FILTER_PTP_V2_DELAY_REQ = 14,
+HWTSTAMP_FILTER_NTP_ALL = 15,
+__HWTSTAMP_FILTER_CNT = 16,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum txtime_flags {
+SOF_TXTIME_DEADLINE_MODE = 1,
+SOF_TXTIME_REPORT_ERRORS = 2,
+SOF_TXTIME_FLAGS_MASK = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3297,4 +3413,13 @@ pub const NF_INET_INGRESS: nf_inet_hooks = nf_inet_hooks::NF_INET_NUMHOOKS;
 }
 impl nf_ip_hook_priorities {
 pub const NF_IP_PRI_LAST: nf_ip_hook_priorities = nf_ip_hook_priorities::NF_IP_PRI_CONNTRACK_CONFIRM;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_LAST: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_MASK: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl txtime_flags {
+pub const SOF_TXTIME_FLAGS_LAST: txtime_flags = txtime_flags::SOF_TXTIME_REPORT_ERRORS;
 }

--- a/src/powerpc64/net.rs
+++ b/src/powerpc64/net.rs
@@ -810,6 +810,32 @@ pub entrytable: __IncompleteArrayField<ip6t_entry>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct so_timestamping {
+pub flags: crate::ctypes::c_int,
+pub bind_phc: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hwtstamp_config {
+pub flags: crate::ctypes::c_int,
+pub tx_type: crate::ctypes::c_int,
+pub rx_filter: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct scm_ts_pktinfo {
+pub if_index: __u32,
+pub pkt_length: __u32,
+pub reserved: [__u32; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sock_txtime {
+pub clockid: __kernel_clockid_t,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct linger {
 pub l_onoff: crate::ctypes::c_int,
 pub l_linger: crate::ctypes::c_int,
@@ -1725,6 +1751,26 @@ pub const NFPROTO_BRIDGE: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_BRIDGE;
 pub const NFPROTO_IPV6: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_IPV6;
 pub const NFPROTO_DECNET: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_DECNET;
 pub const NFPROTO_NUMPROTO: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_NUMPROTO;
+pub const SOF_TIMESTAMPING_TX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_HARDWARE;
+pub const SOF_TIMESTAMPING_TX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SOFTWARE;
+pub const SOF_TIMESTAMPING_RX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_HARDWARE;
+pub const SOF_TIMESTAMPING_RX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_SOFTWARE;
+pub const SOF_TIMESTAMPING_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SOFTWARE;
+pub const SOF_TIMESTAMPING_SYS_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SYS_HARDWARE;
+pub const SOF_TIMESTAMPING_RAW_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RAW_HARDWARE;
+pub const SOF_TIMESTAMPING_OPT_ID: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID;
+pub const SOF_TIMESTAMPING_TX_SCHED: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SCHED;
+pub const SOF_TIMESTAMPING_TX_ACK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_ACK;
+pub const SOF_TIMESTAMPING_OPT_CMSG: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_CMSG;
+pub const SOF_TIMESTAMPING_OPT_TSONLY: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TSONLY;
+pub const SOF_TIMESTAMPING_OPT_STATS: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_STATS;
+pub const SOF_TIMESTAMPING_OPT_PKTINFO: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_PKTINFO;
+pub const SOF_TIMESTAMPING_OPT_TX_SWHW: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TX_SWHW;
+pub const SOF_TIMESTAMPING_BIND_PHC: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_BIND_PHC;
+pub const SOF_TIMESTAMPING_OPT_ID_TCP: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID_TCP;
+pub const SOF_TIMESTAMPING_OPT_RX_FILTER: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_LAST: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_MASK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_MASK;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -2064,6 +2110,76 @@ NF_IP_PRI_NAT_SRC = 100,
 NF_IP_PRI_SELINUX_LAST = 225,
 NF_IP_PRI_CONNTRACK_HELPER = 300,
 NF_IP_PRI_CONNTRACK_CONFIRM = 2147483647,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_10 {
+SOF_TIMESTAMPING_TX_HARDWARE = 1,
+SOF_TIMESTAMPING_TX_SOFTWARE = 2,
+SOF_TIMESTAMPING_RX_HARDWARE = 4,
+SOF_TIMESTAMPING_RX_SOFTWARE = 8,
+SOF_TIMESTAMPING_SOFTWARE = 16,
+SOF_TIMESTAMPING_SYS_HARDWARE = 32,
+SOF_TIMESTAMPING_RAW_HARDWARE = 64,
+SOF_TIMESTAMPING_OPT_ID = 128,
+SOF_TIMESTAMPING_TX_SCHED = 256,
+SOF_TIMESTAMPING_TX_ACK = 512,
+SOF_TIMESTAMPING_OPT_CMSG = 1024,
+SOF_TIMESTAMPING_OPT_TSONLY = 2048,
+SOF_TIMESTAMPING_OPT_STATS = 4096,
+SOF_TIMESTAMPING_OPT_PKTINFO = 8192,
+SOF_TIMESTAMPING_OPT_TX_SWHW = 16384,
+SOF_TIMESTAMPING_BIND_PHC = 32768,
+SOF_TIMESTAMPING_OPT_ID_TCP = 65536,
+SOF_TIMESTAMPING_OPT_RX_FILTER = 131072,
+SOF_TIMESTAMPING_MASK = 262143,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_flags {
+HWTSTAMP_FLAG_BONDED_PHC_INDEX = 1,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_tx_types {
+HWTSTAMP_TX_OFF = 0,
+HWTSTAMP_TX_ON = 1,
+HWTSTAMP_TX_ONESTEP_SYNC = 2,
+HWTSTAMP_TX_ONESTEP_P2P = 3,
+__HWTSTAMP_TX_CNT = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_rx_filters {
+HWTSTAMP_FILTER_NONE = 0,
+HWTSTAMP_FILTER_ALL = 1,
+HWTSTAMP_FILTER_SOME = 2,
+HWTSTAMP_FILTER_PTP_V1_L4_EVENT = 3,
+HWTSTAMP_FILTER_PTP_V1_L4_SYNC = 4,
+HWTSTAMP_FILTER_PTP_V1_L4_DELAY_REQ = 5,
+HWTSTAMP_FILTER_PTP_V2_L4_EVENT = 6,
+HWTSTAMP_FILTER_PTP_V2_L4_SYNC = 7,
+HWTSTAMP_FILTER_PTP_V2_L4_DELAY_REQ = 8,
+HWTSTAMP_FILTER_PTP_V2_L2_EVENT = 9,
+HWTSTAMP_FILTER_PTP_V2_L2_SYNC = 10,
+HWTSTAMP_FILTER_PTP_V2_L2_DELAY_REQ = 11,
+HWTSTAMP_FILTER_PTP_V2_EVENT = 12,
+HWTSTAMP_FILTER_PTP_V2_SYNC = 13,
+HWTSTAMP_FILTER_PTP_V2_DELAY_REQ = 14,
+HWTSTAMP_FILTER_NTP_ALL = 15,
+__HWTSTAMP_FILTER_CNT = 16,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum txtime_flags {
+SOF_TXTIME_DEADLINE_MODE = 1,
+SOF_TXTIME_REPORT_ERRORS = 2,
+SOF_TXTIME_FLAGS_MASK = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3305,4 +3421,13 @@ pub const NF_INET_INGRESS: nf_inet_hooks = nf_inet_hooks::NF_INET_NUMHOOKS;
 }
 impl nf_ip_hook_priorities {
 pub const NF_IP_PRI_LAST: nf_ip_hook_priorities = nf_ip_hook_priorities::NF_IP_PRI_CONNTRACK_CONFIRM;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_LAST: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_MASK: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl txtime_flags {
+pub const SOF_TXTIME_FLAGS_LAST: txtime_flags = txtime_flags::SOF_TXTIME_REPORT_ERRORS;
 }

--- a/src/riscv32/net.rs
+++ b/src/riscv32/net.rs
@@ -804,6 +804,32 @@ pub entrytable: __IncompleteArrayField<ip6t_entry>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct so_timestamping {
+pub flags: crate::ctypes::c_int,
+pub bind_phc: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hwtstamp_config {
+pub flags: crate::ctypes::c_int,
+pub tx_type: crate::ctypes::c_int,
+pub rx_filter: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct scm_ts_pktinfo {
+pub if_index: __u32,
+pub pkt_length: __u32,
+pub reserved: [__u32; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sock_txtime {
+pub clockid: __kernel_clockid_t,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct linger {
 pub l_onoff: crate::ctypes::c_int,
 pub l_linger: crate::ctypes::c_int,
@@ -1711,6 +1737,26 @@ pub const NFPROTO_BRIDGE: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_BRIDGE;
 pub const NFPROTO_IPV6: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_IPV6;
 pub const NFPROTO_DECNET: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_DECNET;
 pub const NFPROTO_NUMPROTO: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_NUMPROTO;
+pub const SOF_TIMESTAMPING_TX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_HARDWARE;
+pub const SOF_TIMESTAMPING_TX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SOFTWARE;
+pub const SOF_TIMESTAMPING_RX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_HARDWARE;
+pub const SOF_TIMESTAMPING_RX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_SOFTWARE;
+pub const SOF_TIMESTAMPING_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SOFTWARE;
+pub const SOF_TIMESTAMPING_SYS_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SYS_HARDWARE;
+pub const SOF_TIMESTAMPING_RAW_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RAW_HARDWARE;
+pub const SOF_TIMESTAMPING_OPT_ID: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID;
+pub const SOF_TIMESTAMPING_TX_SCHED: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SCHED;
+pub const SOF_TIMESTAMPING_TX_ACK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_ACK;
+pub const SOF_TIMESTAMPING_OPT_CMSG: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_CMSG;
+pub const SOF_TIMESTAMPING_OPT_TSONLY: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TSONLY;
+pub const SOF_TIMESTAMPING_OPT_STATS: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_STATS;
+pub const SOF_TIMESTAMPING_OPT_PKTINFO: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_PKTINFO;
+pub const SOF_TIMESTAMPING_OPT_TX_SWHW: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TX_SWHW;
+pub const SOF_TIMESTAMPING_BIND_PHC: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_BIND_PHC;
+pub const SOF_TIMESTAMPING_OPT_ID_TCP: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID_TCP;
+pub const SOF_TIMESTAMPING_OPT_RX_FILTER: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_LAST: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_MASK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_MASK;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -2050,6 +2096,76 @@ NF_IP_PRI_NAT_SRC = 100,
 NF_IP_PRI_SELINUX_LAST = 225,
 NF_IP_PRI_CONNTRACK_HELPER = 300,
 NF_IP_PRI_CONNTRACK_CONFIRM = 2147483647,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_10 {
+SOF_TIMESTAMPING_TX_HARDWARE = 1,
+SOF_TIMESTAMPING_TX_SOFTWARE = 2,
+SOF_TIMESTAMPING_RX_HARDWARE = 4,
+SOF_TIMESTAMPING_RX_SOFTWARE = 8,
+SOF_TIMESTAMPING_SOFTWARE = 16,
+SOF_TIMESTAMPING_SYS_HARDWARE = 32,
+SOF_TIMESTAMPING_RAW_HARDWARE = 64,
+SOF_TIMESTAMPING_OPT_ID = 128,
+SOF_TIMESTAMPING_TX_SCHED = 256,
+SOF_TIMESTAMPING_TX_ACK = 512,
+SOF_TIMESTAMPING_OPT_CMSG = 1024,
+SOF_TIMESTAMPING_OPT_TSONLY = 2048,
+SOF_TIMESTAMPING_OPT_STATS = 4096,
+SOF_TIMESTAMPING_OPT_PKTINFO = 8192,
+SOF_TIMESTAMPING_OPT_TX_SWHW = 16384,
+SOF_TIMESTAMPING_BIND_PHC = 32768,
+SOF_TIMESTAMPING_OPT_ID_TCP = 65536,
+SOF_TIMESTAMPING_OPT_RX_FILTER = 131072,
+SOF_TIMESTAMPING_MASK = 262143,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_flags {
+HWTSTAMP_FLAG_BONDED_PHC_INDEX = 1,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_tx_types {
+HWTSTAMP_TX_OFF = 0,
+HWTSTAMP_TX_ON = 1,
+HWTSTAMP_TX_ONESTEP_SYNC = 2,
+HWTSTAMP_TX_ONESTEP_P2P = 3,
+__HWTSTAMP_TX_CNT = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_rx_filters {
+HWTSTAMP_FILTER_NONE = 0,
+HWTSTAMP_FILTER_ALL = 1,
+HWTSTAMP_FILTER_SOME = 2,
+HWTSTAMP_FILTER_PTP_V1_L4_EVENT = 3,
+HWTSTAMP_FILTER_PTP_V1_L4_SYNC = 4,
+HWTSTAMP_FILTER_PTP_V1_L4_DELAY_REQ = 5,
+HWTSTAMP_FILTER_PTP_V2_L4_EVENT = 6,
+HWTSTAMP_FILTER_PTP_V2_L4_SYNC = 7,
+HWTSTAMP_FILTER_PTP_V2_L4_DELAY_REQ = 8,
+HWTSTAMP_FILTER_PTP_V2_L2_EVENT = 9,
+HWTSTAMP_FILTER_PTP_V2_L2_SYNC = 10,
+HWTSTAMP_FILTER_PTP_V2_L2_DELAY_REQ = 11,
+HWTSTAMP_FILTER_PTP_V2_EVENT = 12,
+HWTSTAMP_FILTER_PTP_V2_SYNC = 13,
+HWTSTAMP_FILTER_PTP_V2_DELAY_REQ = 14,
+HWTSTAMP_FILTER_NTP_ALL = 15,
+__HWTSTAMP_FILTER_CNT = 16,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum txtime_flags {
+SOF_TXTIME_DEADLINE_MODE = 1,
+SOF_TXTIME_REPORT_ERRORS = 2,
+SOF_TXTIME_FLAGS_MASK = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3291,4 +3407,13 @@ pub const NF_INET_INGRESS: nf_inet_hooks = nf_inet_hooks::NF_INET_NUMHOOKS;
 }
 impl nf_ip_hook_priorities {
 pub const NF_IP_PRI_LAST: nf_ip_hook_priorities = nf_ip_hook_priorities::NF_IP_PRI_CONNTRACK_CONFIRM;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_LAST: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_MASK: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl txtime_flags {
+pub const SOF_TXTIME_FLAGS_LAST: txtime_flags = txtime_flags::SOF_TXTIME_REPORT_ERRORS;
 }

--- a/src/riscv64/net.rs
+++ b/src/riscv64/net.rs
@@ -804,6 +804,32 @@ pub entrytable: __IncompleteArrayField<ip6t_entry>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct so_timestamping {
+pub flags: crate::ctypes::c_int,
+pub bind_phc: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hwtstamp_config {
+pub flags: crate::ctypes::c_int,
+pub tx_type: crate::ctypes::c_int,
+pub rx_filter: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct scm_ts_pktinfo {
+pub if_index: __u32,
+pub pkt_length: __u32,
+pub reserved: [__u32; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sock_txtime {
+pub clockid: __kernel_clockid_t,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct linger {
 pub l_onoff: crate::ctypes::c_int,
 pub l_linger: crate::ctypes::c_int,
@@ -1719,6 +1745,26 @@ pub const NFPROTO_BRIDGE: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_BRIDGE;
 pub const NFPROTO_IPV6: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_IPV6;
 pub const NFPROTO_DECNET: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_DECNET;
 pub const NFPROTO_NUMPROTO: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_NUMPROTO;
+pub const SOF_TIMESTAMPING_TX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_HARDWARE;
+pub const SOF_TIMESTAMPING_TX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SOFTWARE;
+pub const SOF_TIMESTAMPING_RX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_HARDWARE;
+pub const SOF_TIMESTAMPING_RX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_SOFTWARE;
+pub const SOF_TIMESTAMPING_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SOFTWARE;
+pub const SOF_TIMESTAMPING_SYS_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SYS_HARDWARE;
+pub const SOF_TIMESTAMPING_RAW_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RAW_HARDWARE;
+pub const SOF_TIMESTAMPING_OPT_ID: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID;
+pub const SOF_TIMESTAMPING_TX_SCHED: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SCHED;
+pub const SOF_TIMESTAMPING_TX_ACK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_ACK;
+pub const SOF_TIMESTAMPING_OPT_CMSG: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_CMSG;
+pub const SOF_TIMESTAMPING_OPT_TSONLY: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TSONLY;
+pub const SOF_TIMESTAMPING_OPT_STATS: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_STATS;
+pub const SOF_TIMESTAMPING_OPT_PKTINFO: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_PKTINFO;
+pub const SOF_TIMESTAMPING_OPT_TX_SWHW: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TX_SWHW;
+pub const SOF_TIMESTAMPING_BIND_PHC: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_BIND_PHC;
+pub const SOF_TIMESTAMPING_OPT_ID_TCP: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID_TCP;
+pub const SOF_TIMESTAMPING_OPT_RX_FILTER: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_LAST: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_MASK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_MASK;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -2058,6 +2104,76 @@ NF_IP_PRI_NAT_SRC = 100,
 NF_IP_PRI_SELINUX_LAST = 225,
 NF_IP_PRI_CONNTRACK_HELPER = 300,
 NF_IP_PRI_CONNTRACK_CONFIRM = 2147483647,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_10 {
+SOF_TIMESTAMPING_TX_HARDWARE = 1,
+SOF_TIMESTAMPING_TX_SOFTWARE = 2,
+SOF_TIMESTAMPING_RX_HARDWARE = 4,
+SOF_TIMESTAMPING_RX_SOFTWARE = 8,
+SOF_TIMESTAMPING_SOFTWARE = 16,
+SOF_TIMESTAMPING_SYS_HARDWARE = 32,
+SOF_TIMESTAMPING_RAW_HARDWARE = 64,
+SOF_TIMESTAMPING_OPT_ID = 128,
+SOF_TIMESTAMPING_TX_SCHED = 256,
+SOF_TIMESTAMPING_TX_ACK = 512,
+SOF_TIMESTAMPING_OPT_CMSG = 1024,
+SOF_TIMESTAMPING_OPT_TSONLY = 2048,
+SOF_TIMESTAMPING_OPT_STATS = 4096,
+SOF_TIMESTAMPING_OPT_PKTINFO = 8192,
+SOF_TIMESTAMPING_OPT_TX_SWHW = 16384,
+SOF_TIMESTAMPING_BIND_PHC = 32768,
+SOF_TIMESTAMPING_OPT_ID_TCP = 65536,
+SOF_TIMESTAMPING_OPT_RX_FILTER = 131072,
+SOF_TIMESTAMPING_MASK = 262143,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_flags {
+HWTSTAMP_FLAG_BONDED_PHC_INDEX = 1,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_tx_types {
+HWTSTAMP_TX_OFF = 0,
+HWTSTAMP_TX_ON = 1,
+HWTSTAMP_TX_ONESTEP_SYNC = 2,
+HWTSTAMP_TX_ONESTEP_P2P = 3,
+__HWTSTAMP_TX_CNT = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_rx_filters {
+HWTSTAMP_FILTER_NONE = 0,
+HWTSTAMP_FILTER_ALL = 1,
+HWTSTAMP_FILTER_SOME = 2,
+HWTSTAMP_FILTER_PTP_V1_L4_EVENT = 3,
+HWTSTAMP_FILTER_PTP_V1_L4_SYNC = 4,
+HWTSTAMP_FILTER_PTP_V1_L4_DELAY_REQ = 5,
+HWTSTAMP_FILTER_PTP_V2_L4_EVENT = 6,
+HWTSTAMP_FILTER_PTP_V2_L4_SYNC = 7,
+HWTSTAMP_FILTER_PTP_V2_L4_DELAY_REQ = 8,
+HWTSTAMP_FILTER_PTP_V2_L2_EVENT = 9,
+HWTSTAMP_FILTER_PTP_V2_L2_SYNC = 10,
+HWTSTAMP_FILTER_PTP_V2_L2_DELAY_REQ = 11,
+HWTSTAMP_FILTER_PTP_V2_EVENT = 12,
+HWTSTAMP_FILTER_PTP_V2_SYNC = 13,
+HWTSTAMP_FILTER_PTP_V2_DELAY_REQ = 14,
+HWTSTAMP_FILTER_NTP_ALL = 15,
+__HWTSTAMP_FILTER_CNT = 16,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum txtime_flags {
+SOF_TXTIME_DEADLINE_MODE = 1,
+SOF_TXTIME_REPORT_ERRORS = 2,
+SOF_TXTIME_FLAGS_MASK = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3299,4 +3415,13 @@ pub const NF_INET_INGRESS: nf_inet_hooks = nf_inet_hooks::NF_INET_NUMHOOKS;
 }
 impl nf_ip_hook_priorities {
 pub const NF_IP_PRI_LAST: nf_ip_hook_priorities = nf_ip_hook_priorities::NF_IP_PRI_CONNTRACK_CONFIRM;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_LAST: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_MASK: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl txtime_flags {
+pub const SOF_TXTIME_FLAGS_LAST: txtime_flags = txtime_flags::SOF_TXTIME_REPORT_ERRORS;
 }

--- a/src/s390x/net.rs
+++ b/src/s390x/net.rs
@@ -818,6 +818,32 @@ pub entrytable: __IncompleteArrayField<ip6t_entry>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct so_timestamping {
+pub flags: crate::ctypes::c_int,
+pub bind_phc: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hwtstamp_config {
+pub flags: crate::ctypes::c_int,
+pub tx_type: crate::ctypes::c_int,
+pub rx_filter: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct scm_ts_pktinfo {
+pub if_index: __u32,
+pub pkt_length: __u32,
+pub reserved: [__u32; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sock_txtime {
+pub clockid: __kernel_clockid_t,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct linger {
 pub l_onoff: crate::ctypes::c_int,
 pub l_linger: crate::ctypes::c_int,
@@ -1733,6 +1759,26 @@ pub const NFPROTO_BRIDGE: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_BRIDGE;
 pub const NFPROTO_IPV6: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_IPV6;
 pub const NFPROTO_DECNET: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_DECNET;
 pub const NFPROTO_NUMPROTO: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_NUMPROTO;
+pub const SOF_TIMESTAMPING_TX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_HARDWARE;
+pub const SOF_TIMESTAMPING_TX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SOFTWARE;
+pub const SOF_TIMESTAMPING_RX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_HARDWARE;
+pub const SOF_TIMESTAMPING_RX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_SOFTWARE;
+pub const SOF_TIMESTAMPING_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SOFTWARE;
+pub const SOF_TIMESTAMPING_SYS_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SYS_HARDWARE;
+pub const SOF_TIMESTAMPING_RAW_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RAW_HARDWARE;
+pub const SOF_TIMESTAMPING_OPT_ID: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID;
+pub const SOF_TIMESTAMPING_TX_SCHED: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SCHED;
+pub const SOF_TIMESTAMPING_TX_ACK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_ACK;
+pub const SOF_TIMESTAMPING_OPT_CMSG: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_CMSG;
+pub const SOF_TIMESTAMPING_OPT_TSONLY: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TSONLY;
+pub const SOF_TIMESTAMPING_OPT_STATS: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_STATS;
+pub const SOF_TIMESTAMPING_OPT_PKTINFO: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_PKTINFO;
+pub const SOF_TIMESTAMPING_OPT_TX_SWHW: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TX_SWHW;
+pub const SOF_TIMESTAMPING_BIND_PHC: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_BIND_PHC;
+pub const SOF_TIMESTAMPING_OPT_ID_TCP: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID_TCP;
+pub const SOF_TIMESTAMPING_OPT_RX_FILTER: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_LAST: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_MASK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_MASK;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -2072,6 +2118,76 @@ NF_IP_PRI_NAT_SRC = 100,
 NF_IP_PRI_SELINUX_LAST = 225,
 NF_IP_PRI_CONNTRACK_HELPER = 300,
 NF_IP_PRI_CONNTRACK_CONFIRM = 2147483647,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_10 {
+SOF_TIMESTAMPING_TX_HARDWARE = 1,
+SOF_TIMESTAMPING_TX_SOFTWARE = 2,
+SOF_TIMESTAMPING_RX_HARDWARE = 4,
+SOF_TIMESTAMPING_RX_SOFTWARE = 8,
+SOF_TIMESTAMPING_SOFTWARE = 16,
+SOF_TIMESTAMPING_SYS_HARDWARE = 32,
+SOF_TIMESTAMPING_RAW_HARDWARE = 64,
+SOF_TIMESTAMPING_OPT_ID = 128,
+SOF_TIMESTAMPING_TX_SCHED = 256,
+SOF_TIMESTAMPING_TX_ACK = 512,
+SOF_TIMESTAMPING_OPT_CMSG = 1024,
+SOF_TIMESTAMPING_OPT_TSONLY = 2048,
+SOF_TIMESTAMPING_OPT_STATS = 4096,
+SOF_TIMESTAMPING_OPT_PKTINFO = 8192,
+SOF_TIMESTAMPING_OPT_TX_SWHW = 16384,
+SOF_TIMESTAMPING_BIND_PHC = 32768,
+SOF_TIMESTAMPING_OPT_ID_TCP = 65536,
+SOF_TIMESTAMPING_OPT_RX_FILTER = 131072,
+SOF_TIMESTAMPING_MASK = 262143,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_flags {
+HWTSTAMP_FLAG_BONDED_PHC_INDEX = 1,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_tx_types {
+HWTSTAMP_TX_OFF = 0,
+HWTSTAMP_TX_ON = 1,
+HWTSTAMP_TX_ONESTEP_SYNC = 2,
+HWTSTAMP_TX_ONESTEP_P2P = 3,
+__HWTSTAMP_TX_CNT = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_rx_filters {
+HWTSTAMP_FILTER_NONE = 0,
+HWTSTAMP_FILTER_ALL = 1,
+HWTSTAMP_FILTER_SOME = 2,
+HWTSTAMP_FILTER_PTP_V1_L4_EVENT = 3,
+HWTSTAMP_FILTER_PTP_V1_L4_SYNC = 4,
+HWTSTAMP_FILTER_PTP_V1_L4_DELAY_REQ = 5,
+HWTSTAMP_FILTER_PTP_V2_L4_EVENT = 6,
+HWTSTAMP_FILTER_PTP_V2_L4_SYNC = 7,
+HWTSTAMP_FILTER_PTP_V2_L4_DELAY_REQ = 8,
+HWTSTAMP_FILTER_PTP_V2_L2_EVENT = 9,
+HWTSTAMP_FILTER_PTP_V2_L2_SYNC = 10,
+HWTSTAMP_FILTER_PTP_V2_L2_DELAY_REQ = 11,
+HWTSTAMP_FILTER_PTP_V2_EVENT = 12,
+HWTSTAMP_FILTER_PTP_V2_SYNC = 13,
+HWTSTAMP_FILTER_PTP_V2_DELAY_REQ = 14,
+HWTSTAMP_FILTER_NTP_ALL = 15,
+__HWTSTAMP_FILTER_CNT = 16,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum txtime_flags {
+SOF_TXTIME_DEADLINE_MODE = 1,
+SOF_TXTIME_REPORT_ERRORS = 2,
+SOF_TXTIME_FLAGS_MASK = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3319,4 +3435,13 @@ pub const NF_INET_INGRESS: nf_inet_hooks = nf_inet_hooks::NF_INET_NUMHOOKS;
 }
 impl nf_ip_hook_priorities {
 pub const NF_IP_PRI_LAST: nf_ip_hook_priorities = nf_ip_hook_priorities::NF_IP_PRI_CONNTRACK_CONFIRM;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_LAST: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_MASK: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl txtime_flags {
+pub const SOF_TXTIME_FLAGS_LAST: txtime_flags = txtime_flags::SOF_TXTIME_REPORT_ERRORS;
 }

--- a/src/sparc/net.rs
+++ b/src/sparc/net.rs
@@ -804,6 +804,32 @@ pub entrytable: __IncompleteArrayField<ip6t_entry>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct so_timestamping {
+pub flags: crate::ctypes::c_int,
+pub bind_phc: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hwtstamp_config {
+pub flags: crate::ctypes::c_int,
+pub tx_type: crate::ctypes::c_int,
+pub rx_filter: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct scm_ts_pktinfo {
+pub if_index: __u32,
+pub pkt_length: __u32,
+pub reserved: [__u32; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sock_txtime {
+pub clockid: __kernel_clockid_t,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct linger {
 pub l_onoff: crate::ctypes::c_int,
 pub l_linger: crate::ctypes::c_int,
@@ -1927,6 +1953,26 @@ pub const NFPROTO_BRIDGE: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_BRIDGE;
 pub const NFPROTO_IPV6: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_IPV6;
 pub const NFPROTO_DECNET: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_DECNET;
 pub const NFPROTO_NUMPROTO: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_NUMPROTO;
+pub const SOF_TIMESTAMPING_TX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_HARDWARE;
+pub const SOF_TIMESTAMPING_TX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SOFTWARE;
+pub const SOF_TIMESTAMPING_RX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_HARDWARE;
+pub const SOF_TIMESTAMPING_RX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_SOFTWARE;
+pub const SOF_TIMESTAMPING_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SOFTWARE;
+pub const SOF_TIMESTAMPING_SYS_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SYS_HARDWARE;
+pub const SOF_TIMESTAMPING_RAW_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RAW_HARDWARE;
+pub const SOF_TIMESTAMPING_OPT_ID: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID;
+pub const SOF_TIMESTAMPING_TX_SCHED: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SCHED;
+pub const SOF_TIMESTAMPING_TX_ACK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_ACK;
+pub const SOF_TIMESTAMPING_OPT_CMSG: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_CMSG;
+pub const SOF_TIMESTAMPING_OPT_TSONLY: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TSONLY;
+pub const SOF_TIMESTAMPING_OPT_STATS: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_STATS;
+pub const SOF_TIMESTAMPING_OPT_PKTINFO: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_PKTINFO;
+pub const SOF_TIMESTAMPING_OPT_TX_SWHW: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TX_SWHW;
+pub const SOF_TIMESTAMPING_BIND_PHC: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_BIND_PHC;
+pub const SOF_TIMESTAMPING_OPT_ID_TCP: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID_TCP;
+pub const SOF_TIMESTAMPING_OPT_RX_FILTER: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_LAST: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_MASK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_MASK;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -2266,6 +2312,76 @@ NF_IP_PRI_NAT_SRC = 100,
 NF_IP_PRI_SELINUX_LAST = 225,
 NF_IP_PRI_CONNTRACK_HELPER = 300,
 NF_IP_PRI_CONNTRACK_CONFIRM = 2147483647,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_10 {
+SOF_TIMESTAMPING_TX_HARDWARE = 1,
+SOF_TIMESTAMPING_TX_SOFTWARE = 2,
+SOF_TIMESTAMPING_RX_HARDWARE = 4,
+SOF_TIMESTAMPING_RX_SOFTWARE = 8,
+SOF_TIMESTAMPING_SOFTWARE = 16,
+SOF_TIMESTAMPING_SYS_HARDWARE = 32,
+SOF_TIMESTAMPING_RAW_HARDWARE = 64,
+SOF_TIMESTAMPING_OPT_ID = 128,
+SOF_TIMESTAMPING_TX_SCHED = 256,
+SOF_TIMESTAMPING_TX_ACK = 512,
+SOF_TIMESTAMPING_OPT_CMSG = 1024,
+SOF_TIMESTAMPING_OPT_TSONLY = 2048,
+SOF_TIMESTAMPING_OPT_STATS = 4096,
+SOF_TIMESTAMPING_OPT_PKTINFO = 8192,
+SOF_TIMESTAMPING_OPT_TX_SWHW = 16384,
+SOF_TIMESTAMPING_BIND_PHC = 32768,
+SOF_TIMESTAMPING_OPT_ID_TCP = 65536,
+SOF_TIMESTAMPING_OPT_RX_FILTER = 131072,
+SOF_TIMESTAMPING_MASK = 262143,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_flags {
+HWTSTAMP_FLAG_BONDED_PHC_INDEX = 1,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_tx_types {
+HWTSTAMP_TX_OFF = 0,
+HWTSTAMP_TX_ON = 1,
+HWTSTAMP_TX_ONESTEP_SYNC = 2,
+HWTSTAMP_TX_ONESTEP_P2P = 3,
+__HWTSTAMP_TX_CNT = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_rx_filters {
+HWTSTAMP_FILTER_NONE = 0,
+HWTSTAMP_FILTER_ALL = 1,
+HWTSTAMP_FILTER_SOME = 2,
+HWTSTAMP_FILTER_PTP_V1_L4_EVENT = 3,
+HWTSTAMP_FILTER_PTP_V1_L4_SYNC = 4,
+HWTSTAMP_FILTER_PTP_V1_L4_DELAY_REQ = 5,
+HWTSTAMP_FILTER_PTP_V2_L4_EVENT = 6,
+HWTSTAMP_FILTER_PTP_V2_L4_SYNC = 7,
+HWTSTAMP_FILTER_PTP_V2_L4_DELAY_REQ = 8,
+HWTSTAMP_FILTER_PTP_V2_L2_EVENT = 9,
+HWTSTAMP_FILTER_PTP_V2_L2_SYNC = 10,
+HWTSTAMP_FILTER_PTP_V2_L2_DELAY_REQ = 11,
+HWTSTAMP_FILTER_PTP_V2_EVENT = 12,
+HWTSTAMP_FILTER_PTP_V2_SYNC = 13,
+HWTSTAMP_FILTER_PTP_V2_DELAY_REQ = 14,
+HWTSTAMP_FILTER_NTP_ALL = 15,
+__HWTSTAMP_FILTER_CNT = 16,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum txtime_flags {
+SOF_TXTIME_DEADLINE_MODE = 1,
+SOF_TXTIME_REPORT_ERRORS = 2,
+SOF_TXTIME_FLAGS_MASK = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3507,4 +3623,13 @@ pub const NF_INET_INGRESS: nf_inet_hooks = nf_inet_hooks::NF_INET_NUMHOOKS;
 }
 impl nf_ip_hook_priorities {
 pub const NF_IP_PRI_LAST: nf_ip_hook_priorities = nf_ip_hook_priorities::NF_IP_PRI_CONNTRACK_CONFIRM;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_LAST: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_MASK: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl txtime_flags {
+pub const SOF_TXTIME_FLAGS_LAST: txtime_flags = txtime_flags::SOF_TXTIME_REPORT_ERRORS;
 }

--- a/src/sparc64/net.rs
+++ b/src/sparc64/net.rs
@@ -810,6 +810,32 @@ pub entrytable: __IncompleteArrayField<ip6t_entry>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct so_timestamping {
+pub flags: crate::ctypes::c_int,
+pub bind_phc: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hwtstamp_config {
+pub flags: crate::ctypes::c_int,
+pub tx_type: crate::ctypes::c_int,
+pub rx_filter: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct scm_ts_pktinfo {
+pub if_index: __u32,
+pub pkt_length: __u32,
+pub reserved: [__u32; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sock_txtime {
+pub clockid: __kernel_clockid_t,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct linger {
 pub l_onoff: crate::ctypes::c_int,
 pub l_linger: crate::ctypes::c_int,
@@ -1941,6 +1967,26 @@ pub const NFPROTO_BRIDGE: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_BRIDGE;
 pub const NFPROTO_IPV6: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_IPV6;
 pub const NFPROTO_DECNET: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_DECNET;
 pub const NFPROTO_NUMPROTO: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_NUMPROTO;
+pub const SOF_TIMESTAMPING_TX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_HARDWARE;
+pub const SOF_TIMESTAMPING_TX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SOFTWARE;
+pub const SOF_TIMESTAMPING_RX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_HARDWARE;
+pub const SOF_TIMESTAMPING_RX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_SOFTWARE;
+pub const SOF_TIMESTAMPING_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SOFTWARE;
+pub const SOF_TIMESTAMPING_SYS_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SYS_HARDWARE;
+pub const SOF_TIMESTAMPING_RAW_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RAW_HARDWARE;
+pub const SOF_TIMESTAMPING_OPT_ID: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID;
+pub const SOF_TIMESTAMPING_TX_SCHED: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SCHED;
+pub const SOF_TIMESTAMPING_TX_ACK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_ACK;
+pub const SOF_TIMESTAMPING_OPT_CMSG: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_CMSG;
+pub const SOF_TIMESTAMPING_OPT_TSONLY: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TSONLY;
+pub const SOF_TIMESTAMPING_OPT_STATS: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_STATS;
+pub const SOF_TIMESTAMPING_OPT_PKTINFO: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_PKTINFO;
+pub const SOF_TIMESTAMPING_OPT_TX_SWHW: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TX_SWHW;
+pub const SOF_TIMESTAMPING_BIND_PHC: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_BIND_PHC;
+pub const SOF_TIMESTAMPING_OPT_ID_TCP: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID_TCP;
+pub const SOF_TIMESTAMPING_OPT_RX_FILTER: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_LAST: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_MASK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_MASK;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -2280,6 +2326,76 @@ NF_IP_PRI_NAT_SRC = 100,
 NF_IP_PRI_SELINUX_LAST = 225,
 NF_IP_PRI_CONNTRACK_HELPER = 300,
 NF_IP_PRI_CONNTRACK_CONFIRM = 2147483647,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_10 {
+SOF_TIMESTAMPING_TX_HARDWARE = 1,
+SOF_TIMESTAMPING_TX_SOFTWARE = 2,
+SOF_TIMESTAMPING_RX_HARDWARE = 4,
+SOF_TIMESTAMPING_RX_SOFTWARE = 8,
+SOF_TIMESTAMPING_SOFTWARE = 16,
+SOF_TIMESTAMPING_SYS_HARDWARE = 32,
+SOF_TIMESTAMPING_RAW_HARDWARE = 64,
+SOF_TIMESTAMPING_OPT_ID = 128,
+SOF_TIMESTAMPING_TX_SCHED = 256,
+SOF_TIMESTAMPING_TX_ACK = 512,
+SOF_TIMESTAMPING_OPT_CMSG = 1024,
+SOF_TIMESTAMPING_OPT_TSONLY = 2048,
+SOF_TIMESTAMPING_OPT_STATS = 4096,
+SOF_TIMESTAMPING_OPT_PKTINFO = 8192,
+SOF_TIMESTAMPING_OPT_TX_SWHW = 16384,
+SOF_TIMESTAMPING_BIND_PHC = 32768,
+SOF_TIMESTAMPING_OPT_ID_TCP = 65536,
+SOF_TIMESTAMPING_OPT_RX_FILTER = 131072,
+SOF_TIMESTAMPING_MASK = 262143,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_flags {
+HWTSTAMP_FLAG_BONDED_PHC_INDEX = 1,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_tx_types {
+HWTSTAMP_TX_OFF = 0,
+HWTSTAMP_TX_ON = 1,
+HWTSTAMP_TX_ONESTEP_SYNC = 2,
+HWTSTAMP_TX_ONESTEP_P2P = 3,
+__HWTSTAMP_TX_CNT = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_rx_filters {
+HWTSTAMP_FILTER_NONE = 0,
+HWTSTAMP_FILTER_ALL = 1,
+HWTSTAMP_FILTER_SOME = 2,
+HWTSTAMP_FILTER_PTP_V1_L4_EVENT = 3,
+HWTSTAMP_FILTER_PTP_V1_L4_SYNC = 4,
+HWTSTAMP_FILTER_PTP_V1_L4_DELAY_REQ = 5,
+HWTSTAMP_FILTER_PTP_V2_L4_EVENT = 6,
+HWTSTAMP_FILTER_PTP_V2_L4_SYNC = 7,
+HWTSTAMP_FILTER_PTP_V2_L4_DELAY_REQ = 8,
+HWTSTAMP_FILTER_PTP_V2_L2_EVENT = 9,
+HWTSTAMP_FILTER_PTP_V2_L2_SYNC = 10,
+HWTSTAMP_FILTER_PTP_V2_L2_DELAY_REQ = 11,
+HWTSTAMP_FILTER_PTP_V2_EVENT = 12,
+HWTSTAMP_FILTER_PTP_V2_SYNC = 13,
+HWTSTAMP_FILTER_PTP_V2_DELAY_REQ = 14,
+HWTSTAMP_FILTER_NTP_ALL = 15,
+__HWTSTAMP_FILTER_CNT = 16,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum txtime_flags {
+SOF_TXTIME_DEADLINE_MODE = 1,
+SOF_TXTIME_REPORT_ERRORS = 2,
+SOF_TXTIME_FLAGS_MASK = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3521,4 +3637,13 @@ pub const NF_INET_INGRESS: nf_inet_hooks = nf_inet_hooks::NF_INET_NUMHOOKS;
 }
 impl nf_ip_hook_priorities {
 pub const NF_IP_PRI_LAST: nf_ip_hook_priorities = nf_ip_hook_priorities::NF_IP_PRI_CONNTRACK_CONFIRM;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_LAST: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_MASK: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl txtime_flags {
+pub const SOF_TXTIME_FLAGS_LAST: txtime_flags = txtime_flags::SOF_TXTIME_REPORT_ERRORS;
 }

--- a/src/x32/net.rs
+++ b/src/x32/net.rs
@@ -806,6 +806,32 @@ pub entrytable: __IncompleteArrayField<ip6t_entry>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct so_timestamping {
+pub flags: crate::ctypes::c_int,
+pub bind_phc: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hwtstamp_config {
+pub flags: crate::ctypes::c_int,
+pub tx_type: crate::ctypes::c_int,
+pub rx_filter: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct scm_ts_pktinfo {
+pub if_index: __u32,
+pub pkt_length: __u32,
+pub reserved: [__u32; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sock_txtime {
+pub clockid: __kernel_clockid_t,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct linger {
 pub l_onoff: crate::ctypes::c_int,
 pub l_linger: crate::ctypes::c_int,
@@ -1721,6 +1747,26 @@ pub const NFPROTO_BRIDGE: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_BRIDGE;
 pub const NFPROTO_IPV6: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_IPV6;
 pub const NFPROTO_DECNET: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_DECNET;
 pub const NFPROTO_NUMPROTO: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_NUMPROTO;
+pub const SOF_TIMESTAMPING_TX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_HARDWARE;
+pub const SOF_TIMESTAMPING_TX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SOFTWARE;
+pub const SOF_TIMESTAMPING_RX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_HARDWARE;
+pub const SOF_TIMESTAMPING_RX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_SOFTWARE;
+pub const SOF_TIMESTAMPING_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SOFTWARE;
+pub const SOF_TIMESTAMPING_SYS_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SYS_HARDWARE;
+pub const SOF_TIMESTAMPING_RAW_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RAW_HARDWARE;
+pub const SOF_TIMESTAMPING_OPT_ID: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID;
+pub const SOF_TIMESTAMPING_TX_SCHED: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SCHED;
+pub const SOF_TIMESTAMPING_TX_ACK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_ACK;
+pub const SOF_TIMESTAMPING_OPT_CMSG: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_CMSG;
+pub const SOF_TIMESTAMPING_OPT_TSONLY: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TSONLY;
+pub const SOF_TIMESTAMPING_OPT_STATS: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_STATS;
+pub const SOF_TIMESTAMPING_OPT_PKTINFO: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_PKTINFO;
+pub const SOF_TIMESTAMPING_OPT_TX_SWHW: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TX_SWHW;
+pub const SOF_TIMESTAMPING_BIND_PHC: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_BIND_PHC;
+pub const SOF_TIMESTAMPING_OPT_ID_TCP: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID_TCP;
+pub const SOF_TIMESTAMPING_OPT_RX_FILTER: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_LAST: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_MASK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_MASK;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -2060,6 +2106,76 @@ NF_IP_PRI_NAT_SRC = 100,
 NF_IP_PRI_SELINUX_LAST = 225,
 NF_IP_PRI_CONNTRACK_HELPER = 300,
 NF_IP_PRI_CONNTRACK_CONFIRM = 2147483647,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_10 {
+SOF_TIMESTAMPING_TX_HARDWARE = 1,
+SOF_TIMESTAMPING_TX_SOFTWARE = 2,
+SOF_TIMESTAMPING_RX_HARDWARE = 4,
+SOF_TIMESTAMPING_RX_SOFTWARE = 8,
+SOF_TIMESTAMPING_SOFTWARE = 16,
+SOF_TIMESTAMPING_SYS_HARDWARE = 32,
+SOF_TIMESTAMPING_RAW_HARDWARE = 64,
+SOF_TIMESTAMPING_OPT_ID = 128,
+SOF_TIMESTAMPING_TX_SCHED = 256,
+SOF_TIMESTAMPING_TX_ACK = 512,
+SOF_TIMESTAMPING_OPT_CMSG = 1024,
+SOF_TIMESTAMPING_OPT_TSONLY = 2048,
+SOF_TIMESTAMPING_OPT_STATS = 4096,
+SOF_TIMESTAMPING_OPT_PKTINFO = 8192,
+SOF_TIMESTAMPING_OPT_TX_SWHW = 16384,
+SOF_TIMESTAMPING_BIND_PHC = 32768,
+SOF_TIMESTAMPING_OPT_ID_TCP = 65536,
+SOF_TIMESTAMPING_OPT_RX_FILTER = 131072,
+SOF_TIMESTAMPING_MASK = 262143,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_flags {
+HWTSTAMP_FLAG_BONDED_PHC_INDEX = 1,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_tx_types {
+HWTSTAMP_TX_OFF = 0,
+HWTSTAMP_TX_ON = 1,
+HWTSTAMP_TX_ONESTEP_SYNC = 2,
+HWTSTAMP_TX_ONESTEP_P2P = 3,
+__HWTSTAMP_TX_CNT = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_rx_filters {
+HWTSTAMP_FILTER_NONE = 0,
+HWTSTAMP_FILTER_ALL = 1,
+HWTSTAMP_FILTER_SOME = 2,
+HWTSTAMP_FILTER_PTP_V1_L4_EVENT = 3,
+HWTSTAMP_FILTER_PTP_V1_L4_SYNC = 4,
+HWTSTAMP_FILTER_PTP_V1_L4_DELAY_REQ = 5,
+HWTSTAMP_FILTER_PTP_V2_L4_EVENT = 6,
+HWTSTAMP_FILTER_PTP_V2_L4_SYNC = 7,
+HWTSTAMP_FILTER_PTP_V2_L4_DELAY_REQ = 8,
+HWTSTAMP_FILTER_PTP_V2_L2_EVENT = 9,
+HWTSTAMP_FILTER_PTP_V2_L2_SYNC = 10,
+HWTSTAMP_FILTER_PTP_V2_L2_DELAY_REQ = 11,
+HWTSTAMP_FILTER_PTP_V2_EVENT = 12,
+HWTSTAMP_FILTER_PTP_V2_SYNC = 13,
+HWTSTAMP_FILTER_PTP_V2_DELAY_REQ = 14,
+HWTSTAMP_FILTER_NTP_ALL = 15,
+__HWTSTAMP_FILTER_CNT = 16,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum txtime_flags {
+SOF_TXTIME_DEADLINE_MODE = 1,
+SOF_TXTIME_REPORT_ERRORS = 2,
+SOF_TXTIME_FLAGS_MASK = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3301,4 +3417,13 @@ pub const NF_INET_INGRESS: nf_inet_hooks = nf_inet_hooks::NF_INET_NUMHOOKS;
 }
 impl nf_ip_hook_priorities {
 pub const NF_IP_PRI_LAST: nf_ip_hook_priorities = nf_ip_hook_priorities::NF_IP_PRI_CONNTRACK_CONFIRM;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_LAST: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_MASK: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl txtime_flags {
+pub const SOF_TXTIME_FLAGS_LAST: txtime_flags = txtime_flags::SOF_TXTIME_REPORT_ERRORS;
 }

--- a/src/x86/net.rs
+++ b/src/x86/net.rs
@@ -806,6 +806,32 @@ pub entrytable: __IncompleteArrayField<ip6t_entry>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct so_timestamping {
+pub flags: crate::ctypes::c_int,
+pub bind_phc: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hwtstamp_config {
+pub flags: crate::ctypes::c_int,
+pub tx_type: crate::ctypes::c_int,
+pub rx_filter: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct scm_ts_pktinfo {
+pub if_index: __u32,
+pub pkt_length: __u32,
+pub reserved: [__u32; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sock_txtime {
+pub clockid: __kernel_clockid_t,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct linger {
 pub l_onoff: crate::ctypes::c_int,
 pub l_linger: crate::ctypes::c_int,
@@ -1713,6 +1739,26 @@ pub const NFPROTO_BRIDGE: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_BRIDGE;
 pub const NFPROTO_IPV6: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_IPV6;
 pub const NFPROTO_DECNET: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_DECNET;
 pub const NFPROTO_NUMPROTO: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_NUMPROTO;
+pub const SOF_TIMESTAMPING_TX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_HARDWARE;
+pub const SOF_TIMESTAMPING_TX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SOFTWARE;
+pub const SOF_TIMESTAMPING_RX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_HARDWARE;
+pub const SOF_TIMESTAMPING_RX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_SOFTWARE;
+pub const SOF_TIMESTAMPING_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SOFTWARE;
+pub const SOF_TIMESTAMPING_SYS_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SYS_HARDWARE;
+pub const SOF_TIMESTAMPING_RAW_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RAW_HARDWARE;
+pub const SOF_TIMESTAMPING_OPT_ID: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID;
+pub const SOF_TIMESTAMPING_TX_SCHED: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SCHED;
+pub const SOF_TIMESTAMPING_TX_ACK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_ACK;
+pub const SOF_TIMESTAMPING_OPT_CMSG: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_CMSG;
+pub const SOF_TIMESTAMPING_OPT_TSONLY: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TSONLY;
+pub const SOF_TIMESTAMPING_OPT_STATS: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_STATS;
+pub const SOF_TIMESTAMPING_OPT_PKTINFO: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_PKTINFO;
+pub const SOF_TIMESTAMPING_OPT_TX_SWHW: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TX_SWHW;
+pub const SOF_TIMESTAMPING_BIND_PHC: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_BIND_PHC;
+pub const SOF_TIMESTAMPING_OPT_ID_TCP: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID_TCP;
+pub const SOF_TIMESTAMPING_OPT_RX_FILTER: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_LAST: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_MASK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_MASK;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -2052,6 +2098,76 @@ NF_IP_PRI_NAT_SRC = 100,
 NF_IP_PRI_SELINUX_LAST = 225,
 NF_IP_PRI_CONNTRACK_HELPER = 300,
 NF_IP_PRI_CONNTRACK_CONFIRM = 2147483647,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_10 {
+SOF_TIMESTAMPING_TX_HARDWARE = 1,
+SOF_TIMESTAMPING_TX_SOFTWARE = 2,
+SOF_TIMESTAMPING_RX_HARDWARE = 4,
+SOF_TIMESTAMPING_RX_SOFTWARE = 8,
+SOF_TIMESTAMPING_SOFTWARE = 16,
+SOF_TIMESTAMPING_SYS_HARDWARE = 32,
+SOF_TIMESTAMPING_RAW_HARDWARE = 64,
+SOF_TIMESTAMPING_OPT_ID = 128,
+SOF_TIMESTAMPING_TX_SCHED = 256,
+SOF_TIMESTAMPING_TX_ACK = 512,
+SOF_TIMESTAMPING_OPT_CMSG = 1024,
+SOF_TIMESTAMPING_OPT_TSONLY = 2048,
+SOF_TIMESTAMPING_OPT_STATS = 4096,
+SOF_TIMESTAMPING_OPT_PKTINFO = 8192,
+SOF_TIMESTAMPING_OPT_TX_SWHW = 16384,
+SOF_TIMESTAMPING_BIND_PHC = 32768,
+SOF_TIMESTAMPING_OPT_ID_TCP = 65536,
+SOF_TIMESTAMPING_OPT_RX_FILTER = 131072,
+SOF_TIMESTAMPING_MASK = 262143,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_flags {
+HWTSTAMP_FLAG_BONDED_PHC_INDEX = 1,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_tx_types {
+HWTSTAMP_TX_OFF = 0,
+HWTSTAMP_TX_ON = 1,
+HWTSTAMP_TX_ONESTEP_SYNC = 2,
+HWTSTAMP_TX_ONESTEP_P2P = 3,
+__HWTSTAMP_TX_CNT = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_rx_filters {
+HWTSTAMP_FILTER_NONE = 0,
+HWTSTAMP_FILTER_ALL = 1,
+HWTSTAMP_FILTER_SOME = 2,
+HWTSTAMP_FILTER_PTP_V1_L4_EVENT = 3,
+HWTSTAMP_FILTER_PTP_V1_L4_SYNC = 4,
+HWTSTAMP_FILTER_PTP_V1_L4_DELAY_REQ = 5,
+HWTSTAMP_FILTER_PTP_V2_L4_EVENT = 6,
+HWTSTAMP_FILTER_PTP_V2_L4_SYNC = 7,
+HWTSTAMP_FILTER_PTP_V2_L4_DELAY_REQ = 8,
+HWTSTAMP_FILTER_PTP_V2_L2_EVENT = 9,
+HWTSTAMP_FILTER_PTP_V2_L2_SYNC = 10,
+HWTSTAMP_FILTER_PTP_V2_L2_DELAY_REQ = 11,
+HWTSTAMP_FILTER_PTP_V2_EVENT = 12,
+HWTSTAMP_FILTER_PTP_V2_SYNC = 13,
+HWTSTAMP_FILTER_PTP_V2_DELAY_REQ = 14,
+HWTSTAMP_FILTER_NTP_ALL = 15,
+__HWTSTAMP_FILTER_CNT = 16,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum txtime_flags {
+SOF_TXTIME_DEADLINE_MODE = 1,
+SOF_TXTIME_REPORT_ERRORS = 2,
+SOF_TXTIME_FLAGS_MASK = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3293,4 +3409,13 @@ pub const NF_INET_INGRESS: nf_inet_hooks = nf_inet_hooks::NF_INET_NUMHOOKS;
 }
 impl nf_ip_hook_priorities {
 pub const NF_IP_PRI_LAST: nf_ip_hook_priorities = nf_ip_hook_priorities::NF_IP_PRI_CONNTRACK_CONFIRM;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_LAST: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_MASK: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl txtime_flags {
+pub const SOF_TXTIME_FLAGS_LAST: txtime_flags = txtime_flags::SOF_TXTIME_REPORT_ERRORS;
 }

--- a/src/x86_64/net.rs
+++ b/src/x86_64/net.rs
@@ -804,6 +804,32 @@ pub entrytable: __IncompleteArrayField<ip6t_entry>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct so_timestamping {
+pub flags: crate::ctypes::c_int,
+pub bind_phc: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hwtstamp_config {
+pub flags: crate::ctypes::c_int,
+pub tx_type: crate::ctypes::c_int,
+pub rx_filter: crate::ctypes::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct scm_ts_pktinfo {
+pub if_index: __u32,
+pub pkt_length: __u32,
+pub reserved: [__u32; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sock_txtime {
+pub clockid: __kernel_clockid_t,
+pub flags: __u32,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct linger {
 pub l_onoff: crate::ctypes::c_int,
 pub l_linger: crate::ctypes::c_int,
@@ -1719,6 +1745,26 @@ pub const NFPROTO_BRIDGE: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_BRIDGE;
 pub const NFPROTO_IPV6: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_IPV6;
 pub const NFPROTO_DECNET: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_DECNET;
 pub const NFPROTO_NUMPROTO: _bindgen_ty_9 = _bindgen_ty_9::NFPROTO_NUMPROTO;
+pub const SOF_TIMESTAMPING_TX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_HARDWARE;
+pub const SOF_TIMESTAMPING_TX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SOFTWARE;
+pub const SOF_TIMESTAMPING_RX_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_HARDWARE;
+pub const SOF_TIMESTAMPING_RX_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RX_SOFTWARE;
+pub const SOF_TIMESTAMPING_SOFTWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SOFTWARE;
+pub const SOF_TIMESTAMPING_SYS_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_SYS_HARDWARE;
+pub const SOF_TIMESTAMPING_RAW_HARDWARE: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_RAW_HARDWARE;
+pub const SOF_TIMESTAMPING_OPT_ID: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID;
+pub const SOF_TIMESTAMPING_TX_SCHED: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_SCHED;
+pub const SOF_TIMESTAMPING_TX_ACK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_TX_ACK;
+pub const SOF_TIMESTAMPING_OPT_CMSG: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_CMSG;
+pub const SOF_TIMESTAMPING_OPT_TSONLY: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TSONLY;
+pub const SOF_TIMESTAMPING_OPT_STATS: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_STATS;
+pub const SOF_TIMESTAMPING_OPT_PKTINFO: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_PKTINFO;
+pub const SOF_TIMESTAMPING_OPT_TX_SWHW: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_TX_SWHW;
+pub const SOF_TIMESTAMPING_BIND_PHC: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_BIND_PHC;
+pub const SOF_TIMESTAMPING_OPT_ID_TCP: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_ID_TCP;
+pub const SOF_TIMESTAMPING_OPT_RX_FILTER: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_LAST: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_OPT_RX_FILTER;
+pub const SOF_TIMESTAMPING_MASK: _bindgen_ty_10 = _bindgen_ty_10::SOF_TIMESTAMPING_MASK;
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -2058,6 +2104,76 @@ NF_IP_PRI_NAT_SRC = 100,
 NF_IP_PRI_SELINUX_LAST = 225,
 NF_IP_PRI_CONNTRACK_HELPER = 300,
 NF_IP_PRI_CONNTRACK_CONFIRM = 2147483647,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum _bindgen_ty_10 {
+SOF_TIMESTAMPING_TX_HARDWARE = 1,
+SOF_TIMESTAMPING_TX_SOFTWARE = 2,
+SOF_TIMESTAMPING_RX_HARDWARE = 4,
+SOF_TIMESTAMPING_RX_SOFTWARE = 8,
+SOF_TIMESTAMPING_SOFTWARE = 16,
+SOF_TIMESTAMPING_SYS_HARDWARE = 32,
+SOF_TIMESTAMPING_RAW_HARDWARE = 64,
+SOF_TIMESTAMPING_OPT_ID = 128,
+SOF_TIMESTAMPING_TX_SCHED = 256,
+SOF_TIMESTAMPING_TX_ACK = 512,
+SOF_TIMESTAMPING_OPT_CMSG = 1024,
+SOF_TIMESTAMPING_OPT_TSONLY = 2048,
+SOF_TIMESTAMPING_OPT_STATS = 4096,
+SOF_TIMESTAMPING_OPT_PKTINFO = 8192,
+SOF_TIMESTAMPING_OPT_TX_SWHW = 16384,
+SOF_TIMESTAMPING_BIND_PHC = 32768,
+SOF_TIMESTAMPING_OPT_ID_TCP = 65536,
+SOF_TIMESTAMPING_OPT_RX_FILTER = 131072,
+SOF_TIMESTAMPING_MASK = 262143,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_flags {
+HWTSTAMP_FLAG_BONDED_PHC_INDEX = 1,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_tx_types {
+HWTSTAMP_TX_OFF = 0,
+HWTSTAMP_TX_ON = 1,
+HWTSTAMP_TX_ONESTEP_SYNC = 2,
+HWTSTAMP_TX_ONESTEP_P2P = 3,
+__HWTSTAMP_TX_CNT = 4,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum hwtstamp_rx_filters {
+HWTSTAMP_FILTER_NONE = 0,
+HWTSTAMP_FILTER_ALL = 1,
+HWTSTAMP_FILTER_SOME = 2,
+HWTSTAMP_FILTER_PTP_V1_L4_EVENT = 3,
+HWTSTAMP_FILTER_PTP_V1_L4_SYNC = 4,
+HWTSTAMP_FILTER_PTP_V1_L4_DELAY_REQ = 5,
+HWTSTAMP_FILTER_PTP_V2_L4_EVENT = 6,
+HWTSTAMP_FILTER_PTP_V2_L4_SYNC = 7,
+HWTSTAMP_FILTER_PTP_V2_L4_DELAY_REQ = 8,
+HWTSTAMP_FILTER_PTP_V2_L2_EVENT = 9,
+HWTSTAMP_FILTER_PTP_V2_L2_SYNC = 10,
+HWTSTAMP_FILTER_PTP_V2_L2_DELAY_REQ = 11,
+HWTSTAMP_FILTER_PTP_V2_EVENT = 12,
+HWTSTAMP_FILTER_PTP_V2_SYNC = 13,
+HWTSTAMP_FILTER_PTP_V2_DELAY_REQ = 14,
+HWTSTAMP_FILTER_NTP_ALL = 15,
+__HWTSTAMP_FILTER_CNT = 16,
+}
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum txtime_flags {
+SOF_TXTIME_DEADLINE_MODE = 1,
+SOF_TXTIME_REPORT_ERRORS = 2,
+SOF_TXTIME_FLAGS_MASK = 3,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3299,4 +3415,13 @@ pub const NF_INET_INGRESS: nf_inet_hooks = nf_inet_hooks::NF_INET_NUMHOOKS;
 }
 impl nf_ip_hook_priorities {
 pub const NF_IP_PRI_LAST: nf_ip_hook_priorities = nf_ip_hook_priorities::NF_IP_PRI_CONNTRACK_CONFIRM;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_LAST: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl hwtstamp_flags {
+pub const HWTSTAMP_FLAG_MASK: hwtstamp_flags = hwtstamp_flags::HWTSTAMP_FLAG_BONDED_PHC_INDEX;
+}
+impl txtime_flags {
+pub const SOF_TXTIME_FLAGS_LAST: txtime_flags = txtime_flags::SOF_TXTIME_REPORT_ERRORS;
 }


### PR DESCRIPTION
Once this lands I can add `sockopt::set_txtime` to rustix.