### PR TITLE
Add c_char definition for MIPS R6

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@ pub mod ctypes {
         target_arch = "loongarch64",
         target_arch = "mips",
         target_arch = "mips64",
+        target_arch = "mips32r6",
+        target_arch = "mips64r6",
         target_arch = "sparc",
         target_arch = "sparc64",
         target_arch = "x86",


### PR DESCRIPTION
This patch sets c_char to signed, same as the legacy MIPS targets. It also matches the fallback definition in the rust core library at `core/src/ffi/primitives.rs`.