### PR TITLE
Add hexagon to the unsigned c_char group

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod ctypes {
     #[cfg(any(
         target_arch = "aarch64",
         target_arch = "arm",
+        target_arch = "hexagon",
         target_arch = "msp430",
         target_arch = "powerpc",
         target_arch = "powerpc64",


### PR DESCRIPTION
Hexagon's `c_char` is unsigned, matching aarch64, arm, powerpc, riscv, and s390x. Without this, the `no_std` ctypes module fails to compile for `hexagon-unknown-linux-musl` because `c_char` is not defined.